### PR TITLE
Update and improve trimMEFgen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Source code files can be automatically formatted to adhere to the appropriate fo
 
     find Src \( -name "*.cpp" -o -name "*.H" \) -exec clang-format -i {} +
 
-from within the PeleAnalysis base directory. You can also format files individually using ``clang-format -i /path/to/file``. Adherence to this format is checked for all PRs.
+from within the PeleAnalysis base directory. You can also format files individually using ``clang-format -i /path/to/file``. Adherence to this format is checked for all PRs. Currently, the CI is running with version `18.1`.
 
 Beyond that, as much as possible, `PeleAnalysis` adheres to [AMReX Coding Style](https://github.com/AMReX-Codes/amrex/blob/development/CONTRIBUTING.md#amrex-coding-style-guide)
 and we are encouraging contributors to follow those guidelines.

--- a/Docs/source/analysis/trimMEFgen.rst
+++ b/Docs/source/analysis/trimMEFgen.rst
@@ -3,7 +3,7 @@
 trimMEFgen
 **********
 
-Trim and post-process 3D isosurface meshes by removing nodes and triangular elements based on field-value thresholds or radial distance criteria. The tool reads a binary isosurface file, applies any requested trimming operations, and writes the processed surface to a new file. Surface area is reported before and after trimming.
+Trim and post-process 2D & 3D isosurface meshes by removing nodes and elements based on field-value thresholds or radial distance criteria. The tool reads a binary isosurface file, applies any requested trimming operations, and writes the processed surface to a new file. Surface area is reported before and after trimming.
 
 Usage: ::
 
@@ -27,19 +27,14 @@ Tool Options
 ::
 
    #------------------- Field-Value Trimming -------------------------------------------------
-   comps   = 3 4                              # Component indices to use for trimming
-   signs   = gt lt                            # Comparison operators for each component (lt,le,gt,ge,eq)
-   vals    = 0.5 1.0                          # Threshold values; nodes satisfying condition are removed
+   comps   = X Y(H2) RXZ                      # Component names to use for trimming. X, Y, Z are also available.
+                                              # RXY, RXZ, RYZ, RXYZ refer to the radial/spherical distance.
+   signs   = gt lt gt                         # Comparison operators for each component (lt,le,gt,ge,eq)
+   vals    = 0.5 1.0 0.1                      # Threshold values; nodes satisfying condition are removed
+   rmBound = 0                                # [0, 1], DEF: 1; If 1, elements with at least one nodes satisfying condition are removed.
+                                              # If 0, only elements with all nodes satisfying condition are removed.
 
-`comps` takes a space-separated list of zero-based component indices identifying which field variables to use for trimming. For each component, a corresponding entry must be provided in `signs` and `vals`. `signs` specifies the comparison operator applied to each component, and must be one of ``lt`` (less than), ``le`` (less than or equal), ``gt`` (greater than), ``ge`` (greater than or equal), or ``eq`` (equal). `vals` provides the corresponding threshold value. A node is removed if **any** of the specified conditions evaluates to true. Any triangular element with at least one removed node is also discarded.
-
-::
-
-   #------------------- Radial Trimming ------------------------------------------------------
-   RXY      = 0.05                            # Radial threshold: trim based on r = sqrt(x^2 + y^2)
-   sign_RXY = lt                              # Comparison operator for radial trim (lt,le,gt,ge,eq)
-
-`RXY` enables trimming based on the cylindrical radius :math:`r = \sqrt{x^2 + y^2}` of each node. This is useful for axisymmetric or cylindrical geometries where a clean inner or outer radial boundary is desired. `sign_RXY` specifies the comparison operator and accepts the same values as `signs`. For example, ``sign_RXY = lt`` with ``RXY = 0.05`` removes all nodes closer than 0.05 to the z-axis. Field-value trimming (via `comps`) and radial trimming can be applied simultaneously; both are applied independently before the surface area is recomputed.
+`comps` takes a space-separated list of component names identifying which field variables to use for trimming. For each component, a corresponding entry must be provided in `signs` and `vals`. `signs` specifies the comparison operator applied to each component, and must be one of ``lt`` (less than), ``le`` (less than or equal), ``gt`` (greater than), ``ge`` (greater than or equal), or ``eq`` (equal). `vals` provides the corresponding threshold value. `comps` can also be the coordinate comps `X`, `Y`, and `Z`. Additionally, `comps` can be `RXY`, `RXZ`, `RYZ`, and `RXYZ`, representing a condition for the radial (`RXY`, `RXZ`, `RYZ`) or spherical (`RXYZ`) coordinate. A node is flaged for removal if **any** of the specified conditions evaluates to true. If `rmBound = 1`, any triangular element with at least one node flagged for removal is also discarded. If `rmBound = 0`, only triangular elements with all corresponding nodes flagged for removal are also discarded. With this option, surfaces can be split lossless.
 
 ::
 
@@ -54,3 +49,8 @@ Tool Options
    do_area_stats = true                       # Print min/max triangle areas across the surface
 
 `do_area_stats` enables reporting of per-triangle area statistics. When set to ``true``, the tool computes the area of every triangle in the trimmed surface and prints the minimum and maximum values. This is useful for diagnosing mesh quality — a large spread between minimum and maximum triangle areas may indicate poorly resolved regions of the surface that could affect downstream calculations.
+
+.. warning::
+
+   `do_area_stats` only implemented for 3D.
+

--- a/Docs/source/analysis/trimMEFgen.rst
+++ b/Docs/source/analysis/trimMEFgen.rst
@@ -34,7 +34,39 @@ Tool Options
    rmBound = 0                                # [0, 1], DEF: 1; If 1, elements with at least one nodes satisfying condition are removed.
                                               # If 0, only elements with all nodes satisfying condition are removed.
 
-`comps` takes a space-separated list of component names identifying which field variables to use for trimming. For each component, a corresponding entry must be provided in `signs` and `vals`. `signs` specifies the comparison operator applied to each component, and must be one of ``lt`` (less than), ``le`` (less than or equal), ``gt`` (greater than), ``ge`` (greater than or equal), or ``eq`` (equal). `vals` provides the corresponding threshold value. `comps` can also be the coordinate comps `X`, `Y`, and `Z`. Additionally, `comps` can be `RXY`, `RXZ`, `RYZ`, and `RXYZ`, representing a condition for the radial (`RXY`, `RXZ`, `RYZ`) or spherical (`RXYZ`) coordinate. A node is flaged for removal if **any** of the specified conditions evaluates to true. If `rmBound = 1`, any triangular element with at least one node flagged for removal is also discarded. If `rmBound = 0`, only triangular elements with all corresponding nodes flagged for removal are also discarded. With this option, surfaces can be split lossless.
+`comps` takes a space-separated list of component names identifying which field variables to use for trimming. For each component, a corresponding entry must be provided in `signs` and `vals`. `signs` specifies the comparison operator applied to each component, and must be one of ``lt`` (less than), ``le`` (less than or equal), ``gt`` (greater than), ``ge`` (greater than or equal), or ``eq`` (equal). `vals` provides the corresponding threshold value. `comps` can also be the coordinate comps `X`, `Y`, and `Z`. Additionally, `comps` can be `RXY`, `RXZ`, `RYZ`, and `RXYZ`, representing a condition for the radial (`RXY`, `RXZ`, `RYZ`) or spherical (`RXYZ`) coordinate. A node is flaged for removal if **any** of the specified conditions evaluates to true. If `rmBound = 1`, any triangular element with at least one node flagged for removal is also discarded. If `rmBound = 0`, only triangular elements with all corresponding nodes flagged for removal are also discarded. With this option, surfaces can be split lossless. The following bash script can be used to split a surface in `nPiece`.
+
+::
+   
+   # === Parameters ===
+   nPiece=20
+   z_min=0.0000
+   z_max=0.02880
+   dim=Z
+   plt_dir=plt43000
+   exe=/home/tl277147/Software/Pele/PeleAnalysis/Src/trimMEFgen3d.gnu.MPI.ex
+
+   # === Auto-computed ===
+   z_step=$(echo "scale=10; (${z_max} - ${z_min}) / ${nPiece}" | bc)
+   base_scale=$(echo "${z_step}" | awk -F'.' '{print length($2)}')
+   scale=$(( base_scale + 2 ))
+
+   # === Loop ===
+   for (( i=1; i<=nPiece; i++ )); do
+      val_low=$(echo  "scale=${scale}; ${z_min} + ${z_step} * ($i - 1)" | bc)
+      val_high=$(echo "scale=${scale}; ${z_min} + ${z_step} * $i"       | bc)
+      rmBound=$(( (i)  % 2 ))
+
+      echo "Step ${i}/${nPiece} | Z: [${val_low}, ${val_high}] | rmBound=${rmBound}"
+
+      srun ${exe} \
+         infile=${plt_dir}_surf.mef \
+         outfile=${plt_dir}_surf_p${i}.mef \
+         comps = ${dim} ${dim} \
+         signs = le gt \
+         vals = ${val_low} ${val_high} \
+         rmBound = ${rmBound}
+   done
 
 ::
 

--- a/Src/InputsSamples/trimMEFgen.inp
+++ b/Src/InputsSamples/trimMEFgen.inp
@@ -6,13 +6,12 @@ infile  = plt00000_surf.mef                      # Input MEF isosurface file to 
 outfile = plt00000_surf_trimmed.mef              # Output file for the processed isosurface
 
 #------------------- Field-Value Trimming -------------------------------------------------
-comps   = 3 4                              # Component indices to use for trimming
-signs   = gt lt                            # Comparison operators for each component (lt,le,gt,ge,eq)
-vals    = 0.5 1.0                          # Threshold values; nodes satisfying condition are removed
-
-#------------------- Radial Trimming ------------------------------------------------------
-RXY      = 0.05                            # Radial threshold: trim based on r = sqrt(x^2 + y^2)
-sign_RXY = lt                              # Comparison operator for radial trim (lt,le,gt,ge,eq)
+comps   = X Y(H2) RXZ                      # Component names to use for trimming. X, Y, Z are also available. 
+                                           # RXY, RXZ, RYZ, RXYZ refer to the radial/spherical distance. 
+signs   = gt lt gt                         # Comparison operators for each component (lt,le,gt,ge,eq)
+vals    = 0.5 1.0 0.1                      # Threshold values; nodes satisfying condition are removed
+rmBound = 0                                # [0, 1], DEF: 1; If 1, elements with at least one nodes satisfying condition are removed.
+                                           # If 0, only elements with all nodes satisfying condition are removed.
 
 #------------------- Output Control -------------------------------------------------------
 remComps = 5 6                             # Component indices to drop from the output file

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -120,8 +120,9 @@ trim_surface(
   const Vector<Real>& vals,
   FArrayBox& nodes,
   Vector<int>& faceData,
-  int nodesPerElt,
-  std::vector<std::string> names)
+  const int nodesPerElt,
+  const std::vector<std::string> names,
+  const int rmBound)
 {
   const Box& nbox = nodes.box();
   const Real* xdat = nodes.dataPtr(0);
@@ -144,11 +145,9 @@ trim_surface(
   }
     
   int cnt = 0;
-  int cnt_new = 0;
-  std::vector<int> nodeIdx;
+  std::vector<bool> removeNode(nbox.numPts(), false);
   for (IntVect iv = nbox.smallEnd(); iv <= nbox.bigEnd();
        nbox.next(iv), cnt++) {
-    bool remove_this_node = false;
     for (int i = 0; i < nc; ++i) {
       Real data;
       if (comps[i] == "RXY") {
@@ -174,67 +173,47 @@ trim_surface(
         data = dat[i][cnt];
       }
       if (signs[i] == "lt") {
-        remove_this_node |= (data < vals[i]);
+        removeNode[cnt] = removeNode[cnt] || (data < vals[i]);
       } else if (signs[i] == "le") {
-        remove_this_node |= (data <= vals[i]);
+        removeNode[cnt] = removeNode[cnt] || (data <= vals[i]);
       } else if (signs[i] == "gt") {
-        remove_this_node |= (data > vals[i]);
+        removeNode[cnt] = removeNode[cnt] || (data > vals[i]);
       } else if (signs[i] == "ge") {
-        remove_this_node |= (data >= vals[i]);
+        removeNode[cnt] = removeNode[cnt] || (data >= vals[i]);
       } else if (signs[i] == "eq") {
-        remove_this_node |= (data == vals[i]);
+        removeNode[cnt] = removeNode[cnt] || (data == vals[i]);
       } else {
         Print() << "i,signs[i] " << i << "," << signs[i] << std::endl;
         amrex::Abort("Bad signs data. Use one of [lt,le,gt,ge,eq]");
       }
     }
-
-    nodeIdx.push_back(remove_this_node ? -1 : cnt_new++);
   }
-  int nNodesNEW = cnt_new;
 
-  // Build new nodes structure with bad points removed
-  Box newBox(IntVect::TheZeroVector(), (nNodesNEW - 1) * amrex::BASISV(0));
-  int nNodesOLD = nbox.numPts();
-  int nComp = nodes.nComp();
-  FArrayBox newNodes(newBox, nComp);
-  Vector<Real*> odp(nComp);
-  Vector<Real*> ndp(nComp);
-  for (int j = 0; j < nComp; ++j) {
-    odp[j] = nodes.dataPtr(j);
-    ndp[j] = newNodes.dataPtr(j);
-  }
-  cnt_new = 0;
-  for (int i = 0; i < nNodesOLD; ++i) {
-    int newNode = nodeIdx[i];
-    if (newNode >= 0)
-      for (int j = 0; j < nComp; ++j)
-        ndp[j][newNode] = odp[j][i];
-  }
-  nodes.resize(newBox, nComp);
-  nodes.copy(newNodes);
-  newNodes.clear(); // Make some space...not really necessary, but what the heck
-
+  // Only remove elements that have nodes that fall into the trim criterion
+  // Unsued nodes will be purged by remove_unused_nodes
   const int nElts = faceData.size() / nodesPerElt;
   AMREX_ASSERT(nElts * nodesPerElt == faceData.size()); // Idiot check
 
-  // Remove elements that refer to removed nodes
   std::vector<int> newFaceData;
-  cnt_new = 0;
+  int cnt_new = 0;
   for (int i = 0; i < nElts; ++i) {
     int offset = nodesPerElt * i;
-    bool eltGood = true;
-    for (int j = 0; j < nodesPerElt; ++j)
-      eltGood &=
-        (nodeIdx[faceData[offset + j] - 1] >=
-         0); // Remember that faceData is 1-based
-
+    bool eltGood;
+    if (rmBound == 0) {
+      // Remove element only if ALL nodes violate the criterion
+      eltGood = false;
+      for (int j = 0; j < nodesPerElt; ++j)
+        eltGood |= !removeNode[faceData[offset + j] - 1];
+    } else {
+      // Remove element if ANY node violates the criterion (default)
+      eltGood = true;
+      for (int j = 0; j < nodesPerElt; ++j)
+        eltGood &= !removeNode[faceData[offset + j] - 1];
+    }
     if (eltGood) {
       int new_offset = nodesPerElt * cnt_new;
       for (int j = 0; j < nodesPerElt; ++j)
-        newFaceData.push_back(
-          nodeIdx[faceData[offset + j] - 1] +
-          1); // Make sure new faceData is 1-based
+        newFaceData.push_back(faceData[offset + j]); // faceData is already 1-based, no remapping needed
       cnt_new++;
     }
   }
@@ -243,8 +222,6 @@ trim_surface(
   for (int i = 0; i < faceData.size(); ++i)
     faceData[i] = newFaceData[i];
 }
-
-
 
 void
 remove_unused_nodes(FArrayBox& nodes, Vector<int>& faceData, int nodesPerElt)
@@ -393,6 +370,7 @@ main(int argc, char* argv[])
   Vector<std::string> comps(nc);
   Vector<std::string> signs(nc);
   Vector<Real> vals(nc);
+  int rmBound = 1;
   if (nc > 0) {
     comps.resize(nc);
     pp.getarr("comps", comps, 0, nc);
@@ -404,11 +382,12 @@ main(int argc, char* argv[])
     int nv = pp.countval("vals");
     AMREX_ALWAYS_ASSERT(nv == nc);
     pp.getarr("vals", vals, 0, nc);
+    pp.query("rmBound", rmBound);
   } else {
     amrex::Abort("No triming tarfet in inputs");
   }
 
-  trim_surface(comps, signs, vals, nodes, faceData, nodesPerElt, names);
+  trim_surface(comps, signs, vals, nodes, faceData, nodesPerElt, names, rmBound);
   
   Print() << "Surface area after: " << surface_area(nodes, faceData, nodesPerElt)
        << '\n';

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -140,7 +140,9 @@ trim_surface(
   const int nc = comps.size();
   Vector<const Real*> dat(nc);
   for (int i = 0; i < nc; ++i) {
-    if (comps[i] == "RXY" || comps[i] == "RXZ" || comps[i] == "RYZ" || comps[i] == "RXYZ") {
+    if (
+      comps[i] == "RXY" || comps[i] == "RXZ" || comps[i] == "RYZ" ||
+      comps[i] == "RXYZ") {
       // RXY, RXZ, RYZ, and RXYZ do not have a corresponding comp.
       // Inserting a nullptr here and catching it later.
       dat[i] = nullptr;
@@ -148,7 +150,7 @@ trim_surface(
       dat[i] = nodes.dataPtr(find_comp(names, comps[i]));
     }
   }
-    
+
   int cnt = 0;
   std::vector<bool> removeNode(nbox.numPts(), false);
   for (IntVect iv = nbox.smallEnd(); iv <= nbox.bigEnd();
@@ -218,7 +220,9 @@ trim_surface(
     if (eltGood) {
       int new_offset = nodesPerElt * cnt_new;
       for (int j = 0; j < nodesPerElt; ++j)
-        newFaceData.push_back(faceData[offset + j]); // faceData is already 1-based, no remapping needed
+        newFaceData.push_back(
+          faceData[offset + j]); // faceData is already 1-based, no remapping
+                                 // needed
       cnt_new++;
     }
   }
@@ -298,7 +302,7 @@ remove_unused_nodes(FArrayBox& nodes, Vector<int>& faceData, int nodesPerElt)
 
     if (ParallelDescriptor::IOProcessor())
       Print() << "Removed " << nNodesOLD - nNodesNEW << " unusued nodes"
-                << std::endl;
+              << std::endl;
   }
 }
 
@@ -367,12 +371,12 @@ main(int argc, char* argv[])
   int nodesPerElt = faceData.size() / nElts;
   AMREX_ASSERT(nodesPerElt * nElts == faceData.size());
 
-  Print() << "Surface area before: " << surface_area(nodes, faceData, nodesPerElt)
-       << '\n';
+  Print() << "Surface area before: "
+          << surface_area(nodes, faceData, nodesPerElt) << '\n';
   Print() << "WARNING: Area is not periodicity-safe\n";
 
   int nc = pp.countval("comps");
-  
+
   Vector<std::string> comps(nc);
   Vector<std::string> signs(nc);
   Vector<Real> vals(nc);
@@ -393,10 +397,11 @@ main(int argc, char* argv[])
     amrex::Abort("No triming tarfet in inputs");
   }
 
-  trim_surface(comps, signs, vals, nodes, faceData, nodesPerElt, names, rmBound);
-  
-  Print() << "Surface area after: " << surface_area(nodes, faceData, nodesPerElt)
-       << '\n';
+  trim_surface(
+    comps, signs, vals, nodes, faceData, nodesPerElt, names, rmBound);
+
+  Print() << "Surface area after: "
+          << surface_area(nodes, faceData, nodesPerElt) << '\n';
   Print() << "WARNING: Area is not periodicity-safe\n";
 
   nElts = faceData.size() / nodesPerElt;
@@ -437,7 +442,8 @@ main(int argc, char* argv[])
   bool do_area_stats = false;
   pp.query("do_area_stats", do_area_stats);
   if (do_area_stats) {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(AMREX_SPACEDIM==3,"do_area_stats only implemented for 3D");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+      AMREX_SPACEDIM == 3, "do_area_stats only implemented for 3D");
     Vector<Real> area(nElts);
 
     int idX = 0;
@@ -458,7 +464,7 @@ main(int argc, char* argv[])
     }
 
     Print() << "  Triangle area min, max: " << area_min << " , " << area_max
-         << '\n';
+            << '\n';
   }
 
   remove_unused_nodes(nodes, faceData, nodesPerElt);

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -11,14 +11,6 @@
 
 using namespace amrex;
 
-using std::cerr;
-using std::cout;
-using std::endl;
-using std::map;
-using std::ofstream;
-using std::string;
-using std::vector;
-
 static void
 print_usage(int, char* argv[])
 {
@@ -42,16 +34,16 @@ void read_iso(
   FArrayBox& nodes,
   Vector<int>& faceData,
   int& nElts,
-  vector<string>& names,
-  string& label);
+  std::vector<std::string>& names,
+  std::string& label);
 
 void write_iso(
   const std::string& outfile,
   const FArrayBox& nodes,
   const Vector<int>& faceData,
   int nElts,
-  const vector<string>& names,
-  const string& label);
+  const std::vector<std::string>& names,
+  const std::string& label);
 
 static std::vector<std::string>
 parseVarNames(std::istream& is)
@@ -112,7 +104,7 @@ surface_area(
 void
 trim_surface(
   const Vector<int>& comps,
-  const Vector<string>& signs,
+  const Vector<std::string>& signs,
   const Vector<Real>& vals,
   FArrayBox& nodes,
   Vector<int>& faceData,
@@ -126,7 +118,7 @@ trim_surface(
 
   int cnt = 0;
   int cnt_new = 0;
-  vector<int> nodeIdx;
+  std::vector<int> nodeIdx;
   for (IntVect iv = nbox.smallEnd(); iv <= nbox.bigEnd();
        nbox.next(iv), cnt++) {
     bool remove_this_node = false;
@@ -143,7 +135,7 @@ trim_surface(
       } else if (signs[i] == "eq") {
         remove_this_node |= (data == vals[i]);
       } else {
-        cout << "i,signs[i] " << i << "," << signs[i] << endl;
+        Print() << "i,signs[i] " << i << "," << signs[i] << std::endl;
         amrex::Abort("Bad signs data. Use one of [lt,le,gt,ge,eq]");
       }
     }
@@ -178,7 +170,7 @@ trim_surface(
   AMREX_ASSERT(nElts * nodesPerElt == faceData.size()); // Idiot check
 
   // Remove elements that refer to removed nodes
-  vector<int> newFaceData;
+  std::vector<int> newFaceData;
   cnt_new = 0;
   for (int i = 0; i < nElts; ++i) {
     int offset = nodesPerElt * i;
@@ -205,7 +197,7 @@ trim_surface(
 
 void
 trim_surface_RXY(
-  const string& sign,
+  const std::string& sign,
   Real radius,
   FArrayBox& nodes,
   Vector<int>& faceData,
@@ -217,7 +209,7 @@ trim_surface_RXY(
 
   int cnt = 0;
   int cnt_new = 0;
-  vector<int> nodeIdx;
+  std::vector<int> nodeIdx;
   for (IntVect iv = nbox.smallEnd(); iv <= nbox.bigEnd();
        nbox.next(iv), cnt++) {
     Real x = xdat[cnt];
@@ -236,7 +228,7 @@ trim_surface_RXY(
     } else if (sign == "eq") {
       remove_this_node |= (r == radius);
     } else {
-      cout << "sign_RXY: " << sign << endl;
+      Print() << "sign_RXY: " << sign << std::endl;
       amrex::Abort("Bad sign data.  Use one of [lt,le,gt,ge,eq]");
     }
 
@@ -270,7 +262,7 @@ trim_surface_RXY(
   AMREX_ASSERT(nElts * nodesPerElt == faceData.size()); // Idiot check
 
   // Remove elements that refer to removed nodes
-  vector<int> newFaceData;
+  std::vector<int> newFaceData;
   cnt_new = 0;
   for (int i = 0; i < nElts; ++i) {
     int offset = nodesPerElt * i;
@@ -341,7 +333,7 @@ remove_unused_nodes(FArrayBox& nodes, Vector<int>& faceData, int nodesPerElt)
     AMREX_ASSERT(nElts * nodesPerElt == faceData.size()); // Idiot check
 
     // Redefine elements with new numbering
-    vector<int> newFaceData;
+    std::vector<int> newFaceData;
     cnt_new = 0;
     for (int i = 0; i < nElts; ++i) {
       int offset = nodesPerElt * i;
@@ -350,7 +342,7 @@ remove_unused_nodes(FArrayBox& nodes, Vector<int>& faceData, int nodesPerElt)
         if (
           nodeIdx[faceData[offset + j] - 1] < 0 ||
           nodeIdx[faceData[offset + j] - 1] >= nNodesOLD)
-          std::cout << "messed up" << std::endl;
+          Print() << "messed up" << std::endl;
 
         newFaceData.push_back(
           nodeIdx[faceData[offset + j] - 1] +
@@ -364,7 +356,7 @@ remove_unused_nodes(FArrayBox& nodes, Vector<int>& faceData, int nodesPerElt)
       faceData[i] = newFaceData[i];
 
     if (ParallelDescriptor::IOProcessor())
-      std::cout << "Removed " << nNodesOLD - nNodesNEW << " unusued nodes"
+      Print() << "Removed " << nNodesOLD - nNodesNEW << " unusued nodes"
                 << std::endl;
   }
 }
@@ -421,20 +413,20 @@ main(int argc, char* argv[])
   ParmParse pp;
 
   int nElts;
-  string infile;
+  std::string infile;
   pp.get("infile", infile);
-  string outfile;
+  std::string outfile;
   pp.get("outfile", outfile);
 
   FArrayBox nodes;
   Vector<int> faceData;
-  vector<string> names;
-  string label;
+  std::vector<std::string> names;
+  std::string label;
   read_iso(infile, nodes, faceData, nElts, names, label);
   int nodesPerElt = faceData.size() / nElts;
   AMREX_ASSERT(nodesPerElt * nElts == faceData.size());
 
-  cout << "Surface area before: " << surface_area(nodes, faceData, nodesPerElt)
+  Print() << "Surface area before: " << surface_area(nodes, faceData, nodesPerElt)
        << '\n';
 
   Vector<int> comps;
@@ -443,7 +435,7 @@ main(int argc, char* argv[])
     comps.resize(nc);
     pp.getarr("comps", comps, 0, nc);
 
-    Vector<string> signs(nc);
+    Vector<std::string> signs(nc);
     int ns = pp.countval("signs");
     AMREX_ASSERT(ns == nc);
     pp.getarr("signs", signs, 0, nc);
@@ -459,11 +451,11 @@ main(int argc, char* argv[])
   Real RXY = -1;
   pp.query("RXY", RXY);
   if (RXY >= 0) {
-    string sign_RXY;
+    std::string sign_RXY;
     pp.get("sign_RXY", sign_RXY);
     trim_surface_RXY(sign_RXY, RXY, nodes, faceData, nodesPerElt);
   }
-  cout << "Surface area after: " << surface_area(nodes, faceData, nodesPerElt)
+  Print() << "Surface area after: " << surface_area(nodes, faceData, nodesPerElt)
        << '\n';
 
   nElts = faceData.size() / nodesPerElt;
@@ -478,7 +470,7 @@ main(int argc, char* argv[])
     int nCompsNew = names.size() - nrc;
     FArrayBox newNodes(nodes.box(), nCompsNew);
     int cnt = 0;
-    Vector<string> newNames(nCompsNew);
+    Vector<std::string> newNames(nCompsNew);
     for (int i = 0; i < names.size(); ++i) {
       bool keepThisComp = true;
       for (int j = 0; j < remComps.size(); ++j) {
@@ -523,7 +515,7 @@ main(int argc, char* argv[])
       area_max = std::max(area_max, area[i]);
     }
 
-    cout << "  Triangle area min, max: " << area_min << " , " << area_max
+    Print() << "  Triangle area min, max: " << area_min << " , " << area_max
          << '\n';
   }
 
@@ -541,8 +533,8 @@ write_iso(
   const FArrayBox& nodes,
   const Vector<int>& faceData,
   int nElts,
-  const vector<string>& names,
-  const string& label)
+  const std::vector<std::string>& names,
+  const std::string& label)
 {
   // Rotate data to vary quickest on component
   int nCompSurf = nodes.nComp();
@@ -563,7 +555,7 @@ write_iso(
 
   std::ofstream ofs;
   ofs.open(outfile.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
-  ofs << label << endl;
+  ofs << label << std::endl;
   for (int i = 0; i < nCompSurf; ++i) {
     ofs << names[i];
     if (i < nCompSurf - 1)
@@ -572,7 +564,7 @@ write_iso(
       ofs << std::endl;
   }
   int nodesPerElt = faceData.size() / nElts;
-  ofs << nElts << " " << nodesPerElt << endl;
+  ofs << nElts << " " << nodesPerElt << std::endl;
   tnodes.writeOn(ofs);
   ofs.write((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
   ofs.close();
@@ -584,8 +576,8 @@ read_iso(
   FArrayBox& nodes,
   Vector<int>& faceData,
   int& nElts,
-  vector<string>& names,
-  string& label)
+  std::vector<std::string>& names,
+  std::string& label)
 {
   std::ifstream ifs;
   ifs.open(infile.c_str(), std::ios::in | std::ios::binary);

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -301,8 +301,9 @@ remove_unused_nodes(FArrayBox& nodes, Vector<int>& faceData, int nodesPerElt)
       faceData[i] = newFaceData[i];
 
     if (ParallelDescriptor::IOProcessor())
-      Print() << "Removed " << nNodesOLD - nNodesNEW << " unusued nodes"
-              << std::endl;
+      Print() << "Input surf has " << nNodesOLD << " nodes\n" << std::endl;
+      Print() << "Output surf has " << nNodesNEW << " nodes\n" << std::endl;
+      Print() << "Removed " << nNodesOLD - nNodesNEW << " unusued nodes\n";
   }
 }
 

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -364,6 +364,7 @@ main(int argc, char* argv[])
 
   Print() << "Surface area before: " << surface_area(nodes, faceData, nodesPerElt)
        << '\n';
+  Print() << "WARNING: Area is not periodicity-safe\n";
 
   int nc = pp.countval("comps");
   
@@ -391,6 +392,7 @@ main(int argc, char* argv[])
   
   Print() << "Surface area after: " << surface_area(nodes, faceData, nodesPerElt)
        << '\n';
+  Print() << "WARNING: Area is not periodicity-safe\n";
 
   nElts = faceData.size() / nodesPerElt;
   AMREX_ASSERT(nElts * nodesPerElt == faceData.size());
@@ -430,6 +432,7 @@ main(int argc, char* argv[])
   bool do_area_stats = false;
   pp.query("do_area_stats", do_area_stats);
   if (do_area_stats) {
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(AMREX_SPACEDIM==3,"do_area_stats only implemented for 3D");
     Vector<Real> area(nElts);
 
     int idX = 0;

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -300,10 +300,11 @@ remove_unused_nodes(FArrayBox& nodes, Vector<int>& faceData, int nodesPerElt)
     for (int i = 0; i < faceData.size(); ++i)
       faceData[i] = newFaceData[i];
 
-    if (ParallelDescriptor::IOProcessor())
-      Print() << "Input surf has " << nNodesOLD << " nodes\n" << std::endl;
-      Print() << "Output surf has " << nNodesNEW << " nodes\n" << std::endl;
+    if (ParallelDescriptor::IOProcessor()) {
+      Print() << "Input surf has " << nNodesOLD << " nodes\n";
+      Print() << "Output surf has " << nNodesNEW << " nodes\n";
       Print() << "Removed " << nNodesOLD - nNodesNEW << " unusued nodes\n";
+    }
   }
 }
 

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -101,21 +101,48 @@ surface_area(
   return Area;
 }
 
+int
+find_comp(const std::vector<std::string>& names, const std::string& comp)
+{
+  for (int i = 0; i < names.size(); ++i) {
+    if (names[i] == comp)
+      return i;
+  }
+  Print() << "comp: " << comp << std::endl;
+  amrex::Abort("Component not found in names.");
+  return -1; // unreachable, but suppresses compiler warning
+}
+
 void
 trim_surface(
-  const Vector<int>& comps,
+  const Vector<std::string>& comps,
   const Vector<std::string>& signs,
   const Vector<Real>& vals,
   FArrayBox& nodes,
   Vector<int>& faceData,
-  int nodesPerElt)
+  int nodesPerElt,
+  std::vector<std::string> names)
 {
   const Box& nbox = nodes.box();
-  const int nc = comps.size();
-  Vector<Real*> dat(nc);
-  for (int i = 0; i < nc; ++i)
-    dat[i] = nodes.dataPtr(comps[i]);
+  const Real* xdat = nodes.dataPtr(0);
+  const Real* ydat = nodes.dataPtr(1);
+#if AMREX_SPACEDIM == 3
+  const Real* zdat = nodes.dataPtr(2);
+#endif
 
+  // Include the radius to the comp logic as comp = -1
+  const int nc = comps.size();
+  Vector<const Real*> dat(nc);
+  for (int i = 0; i < nc; ++i) {
+    if (comps[i] == "RXY" || comps[i] == "RXZ" || comps[i] == "RXZ") {
+      // RXY, RXZ, and RXZ do not have a corresponding comp.
+      // Inserting a nullptr here and catching it later.
+      dat[i] = nullptr;
+    } else {
+      dat[i] = nodes.dataPtr(find_comp(names, comps[i]));
+    }
+  }
+    
   int cnt = 0;
   int cnt_new = 0;
   std::vector<int> nodeIdx;
@@ -123,7 +150,24 @@ trim_surface(
        nbox.next(iv), cnt++) {
     bool remove_this_node = false;
     for (int i = 0; i < nc; ++i) {
-      const Real data = dat[i][cnt];
+      Real data;
+      if (comps[i] == "RXY") {
+        Real x = xdat[cnt];
+        Real y = ydat[cnt];
+        data = std::sqrt(x * x + y * y);
+#if AMREX_SPACEDIM == 3
+      } else if (comps[i] == "RXZ") {
+        Real x = xdat[cnt];
+        Real z = zdat[cnt];
+        data = std::sqrt(x * x + z * z);
+      } else if (comps[i] == "RYZ") {
+        Real y = ydat[cnt];
+        Real z = zdat[cnt];
+        data = std::sqrt(y * y + z * z);
+#endif
+      } else {
+        data = dat[i][cnt];
+      }
       if (signs[i] == "lt") {
         remove_this_node |= (data < vals[i]);
       } else if (signs[i] == "le") {
@@ -195,97 +239,7 @@ trim_surface(
     faceData[i] = newFaceData[i];
 }
 
-void
-trim_surface_RXY(
-  const std::string& sign,
-  Real radius,
-  FArrayBox& nodes,
-  Vector<int>& faceData,
-  int nodesPerElt)
-{
-  const Box& nbox = nodes.box();
-  const Real* xdat = nodes.dataPtr(0);
-  const Real* ydat = nodes.dataPtr(1);
 
-  int cnt = 0;
-  int cnt_new = 0;
-  std::vector<int> nodeIdx;
-  for (IntVect iv = nbox.smallEnd(); iv <= nbox.bigEnd();
-       nbox.next(iv), cnt++) {
-    Real x = xdat[cnt];
-    Real y = ydat[cnt];
-    Real r = std::sqrt(x * x + y * y);
-    bool remove_this_node = false;
-
-    if (sign == "lt") {
-      remove_this_node = (r < radius);
-    } else if (sign == "le") {
-      remove_this_node |= (r <= radius);
-    } else if (sign == "gt") {
-      remove_this_node |= (r > radius);
-    } else if (sign == "ge") {
-      remove_this_node |= (r >= radius);
-    } else if (sign == "eq") {
-      remove_this_node |= (r == radius);
-    } else {
-      Print() << "sign_RXY: " << sign << std::endl;
-      amrex::Abort("Bad sign data.  Use one of [lt,le,gt,ge,eq]");
-    }
-
-    nodeIdx.push_back(remove_this_node ? -1 : cnt_new++);
-  }
-  int nNodesNEW = cnt_new;
-
-  // Build new nodes structure with bad points removed
-  Box newBox(IntVect::TheZeroVector(), (nNodesNEW - 1) * amrex::BASISV(0));
-  int nNodesOLD = nbox.numPts();
-  int nComp = nodes.nComp();
-  FArrayBox newNodes(newBox, nComp);
-  Vector<Real*> odp(nComp);
-  Vector<Real*> ndp(nComp);
-  for (int j = 0; j < nComp; ++j) {
-    odp[j] = nodes.dataPtr(j);
-    ndp[j] = newNodes.dataPtr(j);
-  }
-  cnt_new = 0;
-  for (int i = 0; i < nNodesOLD; ++i) {
-    int newNode = nodeIdx[i];
-    if (newNode >= 0)
-      for (int j = 0; j < nComp; ++j)
-        ndp[j][newNode] = odp[j][i];
-  }
-  nodes.resize(newBox, nComp);
-  nodes.copy(newNodes);
-  newNodes.clear(); // Make some space...not really necessary, but what the heck
-
-  const int nElts = faceData.size() / nodesPerElt;
-  AMREX_ASSERT(nElts * nodesPerElt == faceData.size()); // Idiot check
-
-  // Remove elements that refer to removed nodes
-  std::vector<int> newFaceData;
-  cnt_new = 0;
-  for (int i = 0; i < nElts; ++i) {
-    int offset = nodesPerElt * i;
-    bool eltGood = true;
-    for (int j = 0; j < nodesPerElt; ++j)
-      eltGood &=
-        (nodeIdx[faceData[offset + j] - 1] >=
-         0); // Remember that faceData is 1-based
-
-    if (eltGood) {
-      int new_offset = nodesPerElt * cnt_new;
-      for (int j = 0; j < nodesPerElt; ++j)
-        newFaceData.push_back(
-          nodeIdx[faceData[offset + j] - 1] +
-          1); // Make sure new faceData is 1-based
-      cnt_new++;
-    }
-  }
-
-  faceData.resize(cnt_new * nodesPerElt);
-  for (int i = 0; i < faceData.size(); ++i)
-    faceData[i] = newFaceData[i];
-}
 
 void
 remove_unused_nodes(FArrayBox& nodes, Vector<int>& faceData, int nodesPerElt)
@@ -429,32 +383,28 @@ main(int argc, char* argv[])
   Print() << "Surface area before: " << surface_area(nodes, faceData, nodesPerElt)
        << '\n';
 
-  Vector<int> comps;
   int nc = pp.countval("comps");
+  
+  Vector<std::string> comps(nc);
+  Vector<std::string> signs(nc);
+  Vector<Real> vals(nc);
   if (nc > 0) {
     comps.resize(nc);
     pp.getarr("comps", comps, 0, nc);
 
-    Vector<std::string> signs(nc);
     int ns = pp.countval("signs");
-    AMREX_ASSERT(ns == nc);
+    AMREX_ALWAYS_ASSERT(ns == nc);
     pp.getarr("signs", signs, 0, nc);
 
-    Vector<Real> vals(nc);
     int nv = pp.countval("vals");
-    AMREX_ASSERT(nv == nc);
+    AMREX_ALWAYS_ASSERT(nv == nc);
     pp.getarr("vals", vals, 0, nc);
-
-    trim_surface(comps, signs, vals, nodes, faceData, nodesPerElt);
+  } else {
+    amrex::Abort("No triming tarfet in inputs");
   }
 
-  Real RXY = -1;
-  pp.query("RXY", RXY);
-  if (RXY >= 0) {
-    std::string sign_RXY;
-    pp.get("sign_RXY", sign_RXY);
-    trim_surface_RXY(sign_RXY, RXY, nodes, faceData, nodesPerElt);
-  }
+  trim_surface(comps, signs, vals, nodes, faceData, nodesPerElt, names);
+  
   Print() << "Surface area after: " << surface_area(nodes, faceData, nodesPerElt)
        << '\n';
 

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -300,11 +300,9 @@ remove_unused_nodes(FArrayBox& nodes, Vector<int>& faceData, int nodesPerElt)
     for (int i = 0; i < faceData.size(); ++i)
       faceData[i] = newFaceData[i];
 
-    if (ParallelDescriptor::IOProcessor()) {
-      Print() << "Input surf has " << nNodesOLD << " nodes\n";
-      Print() << "Output surf has " << nNodesNEW << " nodes\n";
-      Print() << "Removed " << nNodesOLD - nNodesNEW << " unusued nodes\n";
-    }
+    Print() << "Input surf has " << nNodesOLD << " nodes\n";
+    Print() << "Output surf has " << nNodesNEW << " nodes\n";
+    Print() << "Removed " << nNodesOLD - nNodesNEW << " unusued nodes\n";
   }
 }
 
@@ -383,21 +381,22 @@ main(int argc, char* argv[])
   Vector<std::string> signs(nc);
   Vector<Real> vals(nc);
   int rmBound = 1;
-  if (nc > 0) {
-    comps.resize(nc);
-    pp.getarr("comps", comps, 0, nc);
 
-    int ns = pp.countval("signs");
-    AMREX_ALWAYS_ASSERT(ns == nc);
-    pp.getarr("signs", signs, 0, nc);
-
-    int nv = pp.countval("vals");
-    AMREX_ALWAYS_ASSERT(nv == nc);
-    pp.getarr("vals", vals, 0, nc);
-    pp.query("rmBound", rmBound);
-  } else {
-    amrex::Abort("No triming tarfet in inputs");
+  if (nc == 0) {
+    amrex::Abort("No triming target in inputs...");
   }
+
+  comps.resize(nc);
+  pp.getarr("comps", comps, 0, nc);
+
+  int ns = pp.countval("signs");
+  AMREX_ALWAYS_ASSERT(ns == nc);
+  pp.getarr("signs", signs, 0, nc);
+
+  int nv = pp.countval("vals");
+  AMREX_ALWAYS_ASSERT(nv == nc);
+  pp.getarr("vals", vals, 0, nc);
+  pp.query("rmBound", rmBound);
 
   trim_surface(
     comps, signs, vals, nodes, faceData, nodesPerElt, names, rmBound);
@@ -408,6 +407,11 @@ main(int argc, char* argv[])
 
   nElts = faceData.size() / nodesPerElt;
   AMREX_ASSERT(nElts * nodesPerElt == faceData.size());
+
+  if (nElts <= 0) {
+    Print() << "No surface left. Stopping here...\n";
+    return 1;
+  }
 
   Vector<int> remComps;
   int nrc = pp.countval("remComps");

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -134,8 +134,8 @@ trim_surface(
   const int nc = comps.size();
   Vector<const Real*> dat(nc);
   for (int i = 0; i < nc; ++i) {
-    if (comps[i] == "RXY" || comps[i] == "RXZ" || comps[i] == "RXZ") {
-      // RXY, RXZ, and RXZ do not have a corresponding comp.
+    if (comps[i] == "RXY" || comps[i] == "RXZ" || comps[i] == "RYZ" || comps[i] == "RXYZ") {
+      // RXY, RXZ, RYZ, and RXYZ do not have a corresponding comp.
       // Inserting a nullptr here and catching it later.
       dat[i] = nullptr;
     } else {
@@ -164,6 +164,11 @@ trim_surface(
         Real y = ydat[cnt];
         Real z = zdat[cnt];
         data = std::sqrt(y * y + z * z);
+      } else if (comps[i] == "RXYZ") {
+        Real x = xdat[cnt];
+        Real y = ydat[cnt];
+        Real z = zdat[cnt];
+        data = std::sqrt(x * x + y * y + z * z);
 #endif
       } else {
         data = dat[i][cnt];

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -69,18 +69,20 @@ surface_area(
   for (int i = 0; i < dat.size(); ++i)
     dat[i] = nodes.dataPtr(i);
 
-  AMREX_ASSERT(nodesPerElt == 3); // not general enough for anything else
   int nElts = faceData.size() / nodesPerElt;
   Real Area = 0;
   Vector<Real> p0(AMREX_SPACEDIM), p1(AMREX_SPACEDIM), p2(AMREX_SPACEDIM);
   for (int k = 0; k < nElts; ++k) {
     // set points of
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
       p0[i] = dat[i][faceData[k * nodesPerElt + 0] - 1];
       p1[i] = dat[i][faceData[k * nodesPerElt + 1] - 1];
+#if AMREX_SPACEDIM == 3
       p2[i] = dat[i][faceData[k * nodesPerElt + 2] - 1];
+#endif
     }
 
+#if AMREX_SPACEDIM == 3
     Area +=
       0.5 *
       sqrt(
@@ -97,6 +99,9 @@ surface_area(
         pow(
           (p1[0] - p0[0]) * (p2[1] - p0[1]) - (p1[1] - p0[1]) * (p2[0] - p0[0]),
           2));
+#elif AMREX_SPACEDIM == 2
+    Area += sqrt(pow(p0[0] - p1[0], 2) + pow(p0[1] - p1[1], 2));
+#endif
   }
   return Area;
 }


### PR DESCRIPTION
This PR updates the `trimMEFgen` tool.

- Change comps input to names instead of indices
- consolidate the component-based and radial-based (RXY) `trim_surface` functions
- extend radial-based functionality to XY, XZ, YZ, and XYZ for completeness.
- Add option rmBound. This option makes it possible to split a surface without losing elements:
- Fix area calculation for 2D
- Update docs

**rmBound Option**

This option allows splitting a surface without losing elements. `rmBound = 1` removes every element where at least one node satisfies the trim condition (default, as previously). `rmBound = 0` only removes elements where all nodes satisfy the trim condition.

- Step 1: Trim surface, e.g. in X with `gt` and `rmBound = 1` -> part1
- Step 2: Trim surface, e.g. in X with `le` and `rmBound = 0` -> part2

Joining parts 1 and 2 results in the original surface. Without `rmBound = 0`, the unification would miss the elements on the "cutting line".


**CONTRIBUTING.md**

Added the version of clang-format accepted by the CI.