### PR TITLE
Add Favre Filter tool

### DIFF
--- a/Docs/source/analysis/favreFilterPlt.rst
+++ b/Docs/source/analysis/favreFilterPlt.rst
@@ -1,0 +1,71 @@
+.. highlight:: bash
+
+Apply Favre-filtering to a Plot file
+************************************
+
+The tools are executed in the following order:
+
+1. FavrePreMultiplyPlt - multiple all the existing fields with density
+2. filterPlt - apply a filter to a Plot file
+3. FavrePostDividePlt - divide all the field by filtered density
+
+The present set of tools utilizes the PelePhysics PltFileManager with the preprocessor, FavrePreMultiplyPlt
+and postprocessor, FavrePostDividePlt to produce favre filtered fields in plot files
+To compile, it is necessary to define the AMREX_HOME and PELE_PHYSICS_HOME
+variables in the GNUmakefile. For multilevel plot files, filtering can either
+be done with a constant absolute filter width, or a constant filter to grid
+ratio across levels. The filter to grid ratio on the base level must always be
+even. Consult `PelePhysics <https://amrex-combustion.github.io/PelePhysics/Utility.html#filter>`_
+to see different filter types offered.
+
+Usage: ::
+
+   ./FavrePreMultiplyPlt.gnu.MPI.ex infile=plt00000 outfile=plt00000_DensityWt [options]
+   ./filterPlt3d.gnu.MPI.ex infile=plt00000_DensityWt outfile=plt00000_DensityWt_Filtered [options]
+   ./FavrePostDividePlt.gnu.MPI.ex infile=plt00000_Filtered outfile=plt00000_Favre_Filtered [options]
+
+Help: ::
+
+   ./FavrePreMultiplyPlt.gnu.MPI.ex help=true
+   ./filterPlt3d.gnu.MPI.ex help=true
+   ./FavrePostDividePlt.gnu.MPI.ex help=true
+
+Example: ::
+   
+   ./FavrePreMultiplyPlt.gnu.MPI.ex ./InputSamples/FavrePreMultiply.inp
+   ./filterPlt3d.gnu.MPI.ex ./InputSamples/filterPlt.inp
+   ./FavrePostDividePlt.gnu.MPI.ex ./InputSamples/FavrePostDivide.inp
+
+Example Input File ``FavrePreMultiply.inp``::
+
+        #------------------- IO CONTROL -----------------------------------------------------------
+        infiles = plt00000                        # Input pltfile
+        outfile = plt00000_DensityWt              # Name of output file
+    
+        #------------------- Operation control ----------------------------------------------------
+        variables = density temp HeatRelease      # DEF: all possible, list of variable names (density is required)
+
+Example Input File ``filterPlt.inp``::
+
+        #------------------- IO CONTROL -----------------------------------------------------------
+        infiles = plt00000_DensityWt              # pltfiles to average
+        outfile = plt00000_Filtered		  # DEF: plt_averaged, Name of output file
+        
+        #------------------- Operation control ----------------------------------------------------
+        variables = temp HeatRelease              # DEF: all possible, list of variable names to average
+        max_filter_level = 4			  # DEF: 1000, max level to consider for filtering
+        filter_type = 1				  # DEF: 1, filter type as defined in PeleC (1->box, 2->Gaussian, etc)
+        base_fgr = 2				  # DEF: 2,is the desired filter to grid ratio on the base level, must be even
+        same_fgr_all_levels = false		  # DEF: false, if true the same filter to grid ratio is kept on all levels (rather than absolute filter width)
+
+        max_grid_size = 32			  # DEF: 32, output max_grid_size. 
+        interp_type = 1				  # DEF: 1, determines the type of interpolation when FillPatching: 0 -> piecewise constant, 1 -> cell cons linear
+
+Example Input File ``FavrePostDivide.inp``::
+
+        #------------------- IO CONTROL -----------------------------------------------------------
+        infiles = plt00000_Filtered               # Input pltfile
+        outfile = plt00000_Favre_Filtered         # Name of output file
+
+        #------------------- Operation control ----------------------------------------------------
+        variables = density temp HeatRelease      # DEF: all possible, list of variable names (density is required)

--- a/Src/FavrePostDividePlt.cpp
+++ b/Src/FavrePostDividePlt.cpp
@@ -9,17 +9,17 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n"
-            << "  " << argv[0] << " infile=IN_PLTFILE outfile=OUT_PLTFILE [OPTIONS]\n\n"
+            << "  " << argv[0]
+            << " infile=IN_PLTFILE outfile=OUT_PLTFILE [OPTIONS]\n\n"
 
             << "Required arguments:\n"
             << "  infile=IN_PLTFILE         AMReX plotfile \n"
-            << "  outfile=OUT_PLTFILE       Output plotfile with filtered fields divided by filtered density\n\n"
+            << "  outfile=OUT_PLTFILE       Output plotfile with filtered "
+               "fields divided by filtered density\n\n"
 
             << "Options:\n"
             << "  -h, --help         Show this help message\n\n"
@@ -31,30 +31,31 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
     // get infile and outfile name
-    std::string plotFileName; pp.get("infile",plotFileName);
-    std::string outFileName; pp.get("outfile",outFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
+    std::string outFileName;
+    pp.get("outfile", outFileName);
 
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
@@ -63,7 +64,7 @@ main (int   argc,
     DataServices dataServices(plotFileName, fileType);
 
     // check if the plotfile is good
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
 
@@ -71,20 +72,20 @@ main (int   argc,
 
     // getting the finest level (or whatever user sets)
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
     // setting up periodicity
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     Print() << "Periodicity assumed for this case: ";
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        Print() << is_per[idim] << " ";
+      Print() << is_per[idim] << " ";
     }
 
     Print() << "\n";
 
-    RealBox rb(&(amrData.ProbLo()[0]),&(amrData.ProbHi()[0]));
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
 
     // setting up pltfile boxes
     Vector<MultiFab> outdata(Nlev);
@@ -95,68 +96,68 @@ main (int   argc,
 
     Vector<std::string> inNames = amrData.PlotVarNames();
     Vector<std::string> outNames = amrData.PlotVarNames();
-    
+
     Vector<int> destFillComps(nComp);
 
     int ID_rho = -1;
-    
-    for (int i=0; i<nComp; ++i) {
+
+    for (int i = 0; i < nComp; ++i) {
       destFillComps[i] = i;
-      if (inNames[i] == "density") ID_rho = i;
+      if (inNames[i] == "density")
+        ID_rho = i;
     }
 
     // Validate variables exist
     if (ID_rho < 0) {
       Abort("density not found in plot file!");
     }
-    
+
     for (int lev = 0; lev < Nlev; ++lev) {
-      
+
       const BoxArray ba = amrData.boxArray(lev);
       const DistributionMapping dm(ba);
 
-      outdata[lev] = MultiFab(ba,dm,nComp,nGrow);
-      //outdata[lev].setVal(0.0);
-      MultiFab indata(ba,dm,nComp,nGrow);
+      outdata[lev] = MultiFab(ba, dm, nComp, nGrow);
+      // outdata[lev].setVal(0.0);
+      MultiFab indata(ba, dm, nComp, nGrow);
 
       int coord = 0;
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb, coord, &(is_per[0]));      
-      
+      geoms[lev] =
+        Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
+
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps);
+      amrData.FillVar(indata, lev, inNames, destFillComps);
       Print() << "Data has been read for level " << lev << std::endl;
-      
+
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-            {
-          const Box& bx = mfi.validbox();
-          auto const& out_a = outdata[lev].array(mfi);
-          auto const& in_a = indata.array(mfi);
-          amrex::ParallelFor(bx, [=]
-                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                                 {
-                                   // Do something funky
-                                   for (int n = 0; n < nComp; n++) {
-                                       if (n == ID_rho) {
-                                          out_a(i,j,k,n) = in_a(i,j,k,n);
-                                       }
-                                       else {
-                                          out_a(i,j,k,n) = in_a(i,j,k,n)/in_a(i,j,k,ID_rho);
-                                       }    
-                                   }
-                                 });
+      for (MFIter mfi(indata, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.validbox();
+        auto const& out_a = outdata[lev].array(mfi);
+        auto const& in_a = indata.array(mfi);
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            // Do something funky
+            for (int n = 0; n < nComp; n++) {
+              if (n == ID_rho) {
+                out_a(i, j, k, n) = in_a(i, j, k, n);
+              } else {
+                out_a(i, j, k, n) = in_a(i, j, k, n) / in_a(i, j, k, ID_rho);
               }
-           amrex::Gpu::synchronize();
+            }
+          });
+      }
+      amrex::Gpu::synchronize();
     }
-   
-    // write pltfile 
+
+    // write pltfile
     Print() << "Writing new data to " << outFileName << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outFileName, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps, refRatios);
-
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outFileName, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0,
+      isteps, refRatios);
   }
   Finalize();
   return 0;

--- a/Src/FavrePostDividePlt.cpp
+++ b/Src/FavrePostDividePlt.cpp
@@ -1,0 +1,163 @@
+#include <string>
+#include <iostream>
+#include <set>
+
+#include <AMReX_ParmParse.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_DataServices.H>
+#include <AMReX_PlotFileUtil.H>
+
+using namespace amrex;
+
+static
+void 
+print_usage (int,
+             char* argv[])
+{
+  std::cerr << "usage:\n"
+            << "  " << argv[0] << " infile=IN_PLTFILE outfile=OUT_PLTFILE [OPTIONS]\n\n"
+
+            << "Required arguments:\n"
+            << "  infile=IN_PLTFILE         AMReX plotfile \n"
+            << "  outfile=OUT_PLTFILE       Output plotfile with filtered fields divided by filtered density\n\n"
+
+            << "Options:\n"
+            << "  -h, --help         Show this help message\n\n"
+
+            << "Visit PeleAnalysis/Src/InputSamples for examples or refer to "
+            << "the documentation.\n";
+}
+
+std::string
+getFileRoot(const std::string& infile)
+{
+  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
+  return tokens[tokens.size()-1];
+}
+
+int
+main (int   argc,
+      char* argv[])
+{
+  Initialize(argc,argv);
+  {
+    if (argc < 2)
+      print_usage(argc,argv);
+
+    ParmParse pp;
+
+    if (pp.contains("help"))
+      print_usage(argc,argv);
+
+    if (pp.contains("verbose"))
+      AmrData::SetVerbose(true);
+
+    // get infile and outfile name
+    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string outFileName; pp.get("outfile",outFileName);
+
+    DataServices::SetBatchMode();
+    Amrvis::FileType fileType(Amrvis::NEWPLT);
+
+    // setting up reading for pltfile
+    DataServices dataServices(plotFileName, fileType);
+
+    // check if the plotfile is good
+    if( ! dataServices.AmrDataOk()) {
+      DataServices::Dispatch(DataServices::ExitRequest, NULL);
+    }
+
+    AmrData& amrData = dataServices.AmrDataRef();
+
+    // getting the finest level (or whatever user sets)
+    int finestLevel = amrData.FinestLevel();
+    pp.query("finestLevel",finestLevel);
+    int Nlev = finestLevel + 1;
+
+    // setting up periodicity
+    Vector<int> is_per(AMREX_SPACEDIM,1);
+    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    Print() << "Periodicity assumed for this case: ";
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        Print() << is_per[idim] << " ";
+    }
+
+    Print() << "\n";
+
+    RealBox rb(&(amrData.ProbLo()[0]),&(amrData.ProbHi()[0]));
+
+    // setting up pltfile boxes
+    Vector<MultiFab> outdata(Nlev);
+    Vector<Geometry> geoms(Nlev);
+
+    int nGrow = 0;
+    int nComp = amrData.NComp();
+
+    Vector<std::string> inNames = amrData.PlotVarNames();
+    Vector<std::string> outNames = amrData.PlotVarNames();
+    
+    Vector<int> destFillComps(nComp);
+
+    int ID_rho = -1;
+    
+    for (int i=0; i<nComp; ++i) {
+      destFillComps[i] = i;
+      if (inNames[i] == "density") ID_rho = i;
+    }
+
+    // Validate variables exist
+    if (ID_rho < 0) {
+      Abort("density not found in plot file!");
+    }
+    
+    for (int lev = 0; lev < Nlev; ++lev) {
+      
+      const BoxArray ba = amrData.boxArray(lev);
+      const DistributionMapping dm(ba);
+
+      outdata[lev] = MultiFab(ba,dm,nComp,nGrow);
+      //outdata[lev].setVal(0.0);
+      MultiFab indata(ba,dm,nComp,nGrow);
+
+      int coord = 0;
+      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb, coord, &(is_per[0]));      
+      
+      Print() << "Reading data for level " << lev << std::endl;
+      amrData.FillVar(indata,lev,inNames,destFillComps);
+      Print() << "Data has been read for level " << lev << std::endl;
+      
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+          const Box& bx = mfi.validbox();
+          auto const& out_a = outdata[lev].array(mfi);
+          auto const& in_a = indata.array(mfi);
+          amrex::ParallelFor(bx, [=]
+                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                                 {
+                                   // Do something funky
+                                   for (int n = 0; n < nComp; n++) {
+                                       if (n == ID_rho) {
+                                          out_a(i,j,k,n) = in_a(i,j,k,n);
+                                       }
+                                       else {
+                                          out_a(i,j,k,n) = in_a(i,j,k,n)/in_a(i,j,k,ID_rho);
+                                       }    
+                                   }
+                                 });
+              }
+           amrex::Gpu::synchronize();
+    }
+   
+    // write pltfile 
+    Print() << "Writing new data to " << outFileName << std::endl;
+    Vector<int> isteps(Nlev, 0);
+    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(outFileName, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps, refRatios);
+
+  }
+  Finalize();
+  return 0;
+}

--- a/Src/FavrePreMultiplyPlt.cpp
+++ b/Src/FavrePreMultiplyPlt.cpp
@@ -9,17 +9,17 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n"
-            << "  " << argv[0] << " infile=IN_PLTFILE outfile=OUT_PLTFILE [OPTIONS]\n\n"
+            << "  " << argv[0]
+            << " infile=IN_PLTFILE outfile=OUT_PLTFILE [OPTIONS]\n\n"
 
             << "Required arguments:\n"
             << "  infile=IN_PLTFILE         AMReX plotfile\n"
-            << "  outfile=OUT_PLTFILE       Output plotfile with fields multiplied by density\n\n"
+            << "  outfile=OUT_PLTFILE       Output plotfile with fields "
+               "multiplied by density\n\n"
 
             << "Options:\n"
             << "  -h, --help         Show this help message\n\n"
@@ -33,30 +33,31 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
     // get infile and outfile name
-    std::string plotFileName; pp.get("infile",plotFileName);
-    std::string outFileName; pp.get("outfile",outFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
+    std::string outFileName;
+    pp.get("outfile", outFileName);
 
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
@@ -65,7 +66,7 @@ main (int   argc,
     DataServices dataServices(plotFileName, fileType);
 
     // check if plotfile is good
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
 
@@ -73,21 +74,21 @@ main (int   argc,
 
     // getting the finest level (or whatever user sets)
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
     // setting up periodicity
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     Print() << "Periodicity assumed for this case: ";
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        Print() << is_per[idim] << " ";
+      Print() << is_per[idim] << " ";
     }
 
     Print() << "\n";
 
-    RealBox rb(&(amrData.ProbLo()[0]),&(amrData.ProbHi()[0]));
-    
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
+
     // setting up pltfile boxes
     Vector<MultiFab> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
@@ -98,7 +99,7 @@ main (int   argc,
 
     int nvar = pp.countval("variables");
     if (nvar == 0) {
-       Abort("You must specify variables= including density");
+      Abort("You must specify variables= including density");
     }
 
     pp.getarr("variables", inNames);
@@ -106,9 +107,9 @@ main (int   argc,
     // Validate variables exist
     Vector<std::string> plotVars = amrData.PlotVarNames();
     for (const auto& v : inNames) {
-        if (std::find(plotVars.begin(), plotVars.end(), v) == plotVars.end()) {
-           Abort("Variable '" + v + "' not found in plotfile");
-        }
+      if (std::find(plotVars.begin(), plotVars.end(), v) == plotVars.end()) {
+        Abort("Variable '" + v + "' not found in plotfile");
+      }
     }
 
     Vector<std::string> outNames = inNames;
@@ -116,71 +117,69 @@ main (int   argc,
 
     Vector<int> destFillComps(nComp);
     for (int i = 0; i < nComp; ++i) {
-        destFillComps[i] = i;
-    } 
-
+      destFillComps[i] = i;
+    }
 
     int ID_rho = -1;
-    
-    for (int i=0; i<nComp; ++i) {
+
+    for (int i = 0; i < nComp; ++i) {
       destFillComps[i] = i;
-      if (inNames[i] == "density") ID_rho = i;
+      if (inNames[i] == "density")
+        ID_rho = i;
     }
 
     // Check if density is written in the infile
     if (ID_rho < 0) {
       Abort("density not found in plot file!");
     }
-    
+
     for (int lev = 0; lev < Nlev; ++lev) {
-      
+
       BoxArray ba = amrData.boxArray(lev);
-      ba.maxSize(32);   // or 64 depending on memory
+      ba.maxSize(32); // or 64 depending on memory
       const DistributionMapping dm(ba);
 
-      outdata[lev] = MultiFab(ba,dm,nComp,nGrow);
-      MultiFab indata(ba,dm,nComp,nGrow);
-      //outdata[lev].setVal(0.0);
+      outdata[lev] = MultiFab(ba, dm, nComp, nGrow);
+      MultiFab indata(ba, dm, nComp, nGrow);
+      // outdata[lev].setVal(0.0);
 
       int coord = 0;
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb, coord, &(is_per[0]));      
-      
+      geoms[lev] =
+        Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
+
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps);
+      amrData.FillVar(indata, lev, inNames, destFillComps);
       Print() << "Data has been read for level " << lev << std::endl;
-      
+
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-            {
-          const Box& bx = mfi.validbox();
-          auto const& out_a = outdata[lev].array(mfi);
-          auto const& in_a = indata.array(mfi);
-          amrex::ParallelFor(bx, [=]
-                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                                 {
-                                   // Do something funky
-                                   for (int n = 0; n < nComp; n++) {
-                                       if (n == ID_rho) {
-                                          out_a(i,j,k,n) = in_a(i,j,k,n);
-                                       }
-                                       else {
-                                          out_a(i,j,k,n) = in_a(i,j,k,ID_rho)*in_a(i,j,k,n);
-                                       }    
-                                   }
-                                 });
+      for (MFIter mfi(indata, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.validbox();
+        auto const& out_a = outdata[lev].array(mfi);
+        auto const& in_a = indata.array(mfi);
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            // Do something funky
+            for (int n = 0; n < nComp; n++) {
+              if (n == ID_rho) {
+                out_a(i, j, k, n) = in_a(i, j, k, n);
+              } else {
+                out_a(i, j, k, n) = in_a(i, j, k, ID_rho) * in_a(i, j, k, n);
+              }
             }
-          amrex::Gpu::synchronize();
-
+          });
+      }
+      amrex::Gpu::synchronize();
     }
 
-    // write pltfile 
+    // write pltfile
     Print() << "Writing new data to " << outFileName << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outFileName, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps, refRatios);
-
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outFileName, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0,
+      isteps, refRatios);
   }
   Finalize();
   return 0;

--- a/Src/FavrePreMultiplyPlt.cpp
+++ b/Src/FavrePreMultiplyPlt.cpp
@@ -1,0 +1,187 @@
+#include <string>
+#include <iostream>
+#include <set>
+
+#include <AMReX_ParmParse.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_DataServices.H>
+#include <AMReX_PlotFileUtil.H>
+
+using namespace amrex;
+
+static
+void 
+print_usage (int,
+             char* argv[])
+{
+  std::cerr << "usage:\n"
+            << "  " << argv[0] << " infile=IN_PLTFILE outfile=OUT_PLTFILE [OPTIONS]\n\n"
+
+            << "Required arguments:\n"
+            << "  infile=IN_PLTFILE         AMReX plotfile\n"
+            << "  outfile=OUT_PLTFILE       Output plotfile with fields multiplied by density\n\n"
+
+            << "Options:\n"
+            << "  -h, --help         Show this help message\n\n"
+
+            << "Visit PeleAnalysis/Src/InputSamples for examples or refer to "
+            << "the documentation.\n";
+
+  exit(1);
+}
+
+std::string
+getFileRoot(const std::string& infile)
+{
+  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
+  return tokens[tokens.size()-1];
+}
+
+int
+main (int   argc,
+      char* argv[])
+{
+  Initialize(argc,argv);
+  {
+    if (argc < 2)
+      print_usage(argc,argv);
+
+    ParmParse pp;
+
+    if (pp.contains("help"))
+      print_usage(argc,argv);
+
+    if (pp.contains("verbose"))
+      AmrData::SetVerbose(true);
+
+    // get infile and outfile name
+    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string outFileName; pp.get("outfile",outFileName);
+
+    DataServices::SetBatchMode();
+    Amrvis::FileType fileType(Amrvis::NEWPLT);
+
+    // setting up reading for pltfile
+    DataServices dataServices(plotFileName, fileType);
+
+    // check if plotfile is good
+    if( ! dataServices.AmrDataOk()) {
+      DataServices::Dispatch(DataServices::ExitRequest, NULL);
+    }
+
+    AmrData& amrData = dataServices.AmrDataRef();
+
+    // getting the finest level (or whatever user sets)
+    int finestLevel = amrData.FinestLevel();
+    pp.query("finestLevel",finestLevel);
+    int Nlev = finestLevel + 1;
+
+    // setting up periodicity
+    Vector<int> is_per(AMREX_SPACEDIM,1);
+    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    Print() << "Periodicity assumed for this case: ";
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        Print() << is_per[idim] << " ";
+    }
+
+    Print() << "\n";
+
+    RealBox rb(&(amrData.ProbLo()[0]),&(amrData.ProbHi()[0]));
+    
+    // setting up pltfile boxes
+    Vector<MultiFab> outdata(Nlev);
+    Vector<Geometry> geoms(Nlev);
+
+    int nGrow = 0;
+
+    Vector<std::string> inNames;
+
+    int nvar = pp.countval("variables");
+    if (nvar == 0) {
+       Abort("You must specify variables= including density");
+    }
+
+    pp.getarr("variables", inNames);
+
+    // Validate variables exist
+    Vector<std::string> plotVars = amrData.PlotVarNames();
+    for (const auto& v : inNames) {
+        if (std::find(plotVars.begin(), plotVars.end(), v) == plotVars.end()) {
+           Abort("Variable '" + v + "' not found in plotfile");
+        }
+    }
+
+    Vector<std::string> outNames = inNames;
+    int nComp = inNames.size();
+
+    Vector<int> destFillComps(nComp);
+    for (int i = 0; i < nComp; ++i) {
+        destFillComps[i] = i;
+    } 
+
+
+    int ID_rho = -1;
+    
+    for (int i=0; i<nComp; ++i) {
+      destFillComps[i] = i;
+      if (inNames[i] == "density") ID_rho = i;
+    }
+
+    // Check if density is written in the infile
+    if (ID_rho < 0) {
+      Abort("density not found in plot file!");
+    }
+    
+    for (int lev = 0; lev < Nlev; ++lev) {
+      
+      BoxArray ba = amrData.boxArray(lev);
+      ba.maxSize(32);   // or 64 depending on memory
+      const DistributionMapping dm(ba);
+
+      outdata[lev] = MultiFab(ba,dm,nComp,nGrow);
+      MultiFab indata(ba,dm,nComp,nGrow);
+      //outdata[lev].setVal(0.0);
+
+      int coord = 0;
+      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb, coord, &(is_per[0]));      
+      
+      Print() << "Reading data for level " << lev << std::endl;
+      amrData.FillVar(indata,lev,inNames,destFillComps);
+      Print() << "Data has been read for level " << lev << std::endl;
+      
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+          const Box& bx = mfi.validbox();
+          auto const& out_a = outdata[lev].array(mfi);
+          auto const& in_a = indata.array(mfi);
+          amrex::ParallelFor(bx, [=]
+                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                                 {
+                                   // Do something funky
+                                   for (int n = 0; n < nComp; n++) {
+                                       if (n == ID_rho) {
+                                          out_a(i,j,k,n) = in_a(i,j,k,n);
+                                       }
+                                       else {
+                                          out_a(i,j,k,n) = in_a(i,j,k,ID_rho)*in_a(i,j,k,n);
+                                       }    
+                                   }
+                                 });
+            }
+          amrex::Gpu::synchronize();
+
+    }
+
+    // write pltfile 
+    Print() << "Writing new data to " << outFileName << std::endl;
+    Vector<int> isteps(Nlev, 0);
+    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(outFileName, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps, refRatios);
+
+  }
+  Finalize();
+  return 0;
+}

--- a/Src/InputsSamples/FavrePostDivide.inp
+++ b/Src/InputsSamples/FavrePostDivide.inp
@@ -1,0 +1,6 @@
+#------------------- IO CONTROL -----------------------------------------------------------
+ infiles = plt00000_Filtered               # Input pltfile
+ outfile = plt00000_Favre_Filtered         # Name of output file
+
+#------------------- Operation control ----------------------------------------------------
+variables = density temp HeatRelease      # DEF: all possible, list of variable names (density is required)

--- a/Src/InputsSamples/FavrePreMultiply.inp
+++ b/Src/InputsSamples/FavrePreMultiply.inp
@@ -1,0 +1,6 @@
+#------------------- IO CONTROL -----------------------------------------------------------
+infiles = plt00000_Filtered               # Input pltfile
+outfile = plt00000_Favre_Filtered         # Name of output file
+
+#------------------- Operation control ----------------------------------------------------
+variables = density temp HeatRelease      # DEF: all possible, list of variable names (density is required)


### PR DESCRIPTION

The present set of tools utilizes the PelePhysics PltFileManager with the preprocessor, FavrePreMultiplyPlt
and postprocessor, FavrePostDividePlt to produce favre filtered fields in plot files

=========== Fill your description above and fill the checklist below ===========

The steps outlined in CONTRIBUTING.md were checked. This includes:

**General**
- [x] C++ and Python code formatted
- [x] Updated the documentation

**For new tools**
- [x] Added an example input file with short descriptions for all input options
- [x] Added a documentation page for the tool similar to existing pages
