### PR TITLE
Extend `generateTestPlt` — multi-level AMR, output_name, MPI robustness, cylindrical support

### DIFF
--- a/Docs/source/analysis/generateTestPlt.rst
+++ b/Docs/source/analysis/generateTestPlt.rst
@@ -2,7 +2,7 @@
 ******************************************
 generateTestPlt
 ******************************************
-Generate a synthetic single-level AMReX plot file populated with one or more analytically defined fields. Fields can be simple constants, planar step or smooth transitions, circular/spherical regions, annular rings or spherical shells, or sinusoidal patterns. This tool is primarily used to create test and validation data for other tools in the PeleAnalysis suite without requiring a full simulation.
+Generate a synthetic multilevel AMReX plot file populated with one or more analytically defined fields. Fields can be simple constants, planar step or smooth transitions, circular/spherical regions, annular rings or spherical shells, or sinusoidal patterns. Refinement regions can be specified geometrically (bounding box) or by field-value criteria. This tool is primarily used to create test and validation data for other tools in the PeleAnalysis suite without requiring a full simulation.
 
 Usage: ::
 
@@ -14,7 +14,7 @@ Example: ::
 
 .. note::
 
-   Only single-level (non-AMR) Cartesian grids are supported. Only ``geometry.coord_sys = 0`` (Cartesian) is accepted; other coordinate systems will cause an abort.
+   Only Cartesian grids are supported (``geometry.coord_sys = 0``). 
 
 Tool Options
 #############
@@ -30,17 +30,81 @@ These parameters follow the standard AMReX geometry convention and are all requi
 ::
 
    #------------------- Grid ------------------------------------------------------------
-   amr.n_cell = 64 64 64                 # Number of cells per dimension (required)
+   amr.n_cell = 64 64 64                 # Number of cells per dimension on level 0 (required)
    amr.max_grid_size = 32                # DEF: 32; Maximum box size for domain decomposition
    amr.ngrow = 0                         # DEF: 0; Number of ghost cells
 
-``amr.n_cell`` sets the resolution of the generated plot file and is required. ``max_grid_size`` controls the internal parallel decomposition and does not affect the output. ``ngrow`` sets the number of ghost cell layers; ghost cells are filled with the same field values as interior cells.
+``amr.n_cell`` sets the level-0 resolution and is required. ``max_grid_size`` controls the parallel decomposition and does not affect the output.
+::
+
+   #------------------- AMR / Refinement ------------------------------------------------
+   amr.max_level = 2                     # DEF: 0; Maximum refinement level (0 = single-level)
+   amr.ref_ratio = 2 2                   # DEF: 2; Refinement ratio, one value per level transition
+   amr.grid_eff = 0.7                    # DEF: 0.7; Clustering efficiency threshold
+   amr.blocking_factor = 8               # DEF: 8; Minimum box size during grid generation
+   amr.n_error_buf = 2 2                 # DEF: 1; Buffer cells per level around tagged regions
+
+``amr.max_level`` enables multilevel output. When greater than 0, ``amr.refinement_indicators`` must list one or more criteria that determine where finer grids are placed. ``amr.ref_ratio`` accepts one integer per level transition; if fewer values are given the last value is repeated. ``amr.n_error_buf`` expands each tagged region by that many cells (in coarse index space) before clustering into boxes.
+
+Refinement Indicators
+######################
+::
+
+   amr.refinement_indicators = NAME [NAME ...]   # Space-separated list of indicator names
+
+Each name in ``amr.refinement_indicators`` introduces a refinement criterion whose parameters are read under the ``amr.<NAME>.*`` namespace. A single plotfile run may combine multiple indicators of any type.
+
+Common option for all indicator types::
+
+   amr.<name>.max_level = N              # DEF: amr.max_level; Max refinement level for this criterion
+
+Available criterion types
+--------------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Criterion
+     - Description
+   * - ``in_box_lo`` / ``in_box_hi``
+     - Refine all cells whose centres fall within the specified physical bounding box
+   * - ``value_greater`` + ``field_name``
+     - Refine cells where the named field evaluates above the threshold
+   * - ``value_less`` + ``field_name``
+     - Refine cells where the named field evaluates below the threshold
+   * - ``adjacent_difference_greater`` + ``field_name``
+     - Refine cells where the maximum absolute difference to any immediate neighbour exceeds the threshold
+
+**Box-based criterion** ::
+
+   amr.<name>.in_box_lo = 0.2 0.2 0.2   # Physical lower corner of the refinement region
+   amr.<name>.in_box_hi = 0.8 0.8 0.8   # Physical upper corner of the refinement region
+
+**Value-greater criterion** ::
+
+   amr.<name>.value_greater = 5.0        # Refine where field > 5.0
+   amr.<name>.field_name    = circle_step
+
+**Value-less criterion** ::
+
+   amr.<name>.value_less = 0.1           # Refine where field < 0.1
+   amr.<name>.field_name = plane_step
+
+**Adjacent-difference criterion** ::
+
+   amr.<name>.adjacent_difference_greater = 0.4   # Refine at sharp interfaces
+   amr.<name>.field_name                  = plane_step
+
+.. note::
+
+   Value-based criteria evaluate the analytic field expression at cell centres. They do not depend on data stored in the plotfile and can therefore be used at any refinement level without first filling a coarser level.
 ::
 
    #------------------- Output ----------------------------------------------------------
    plotfile_name = pltTestFile            # DEF: pltTestFile; Name of the output plot file
 
-The output is a standard single-level AMReX plot file that can be read by any tool in the PeleAnalysis suite or visualised with VisIt or ParaView.
+The output is a standard AMReX multilevel plot file (one level when ``amr.max_level = 0``) readable by any tool in the PeleAnalysis suite or visualised with VisIt or ParaView.
 ::
 
    #------------------- Fields ----------------------------------------------------------
@@ -145,4 +209,3 @@ Type-specific parameters
    myField.offset    = 0.0               # DEF: 0.0; Additive offset
 
    # Result: offset + amplitude * sin(2π f_x x + φ_x) * cos(2π f_y y + φ_y) * sin(2π f_z z + φ_z)
-

--- a/Docs/source/analysis/generateTestPlt.rst
+++ b/Docs/source/analysis/generateTestPlt.rst
@@ -12,9 +12,6 @@ Example: ::
 
    ./generateTestPlt.gnu.ex ./InputSamples/generateTestPlt.inp
 
-.. note::
-
-   Only Cartesian grids are supported (``geometry.coord_sys = 0``). 
 
 Tool Options
 #############
@@ -24,9 +21,9 @@ Tool Options
    geometry.prob_lo = 0.0 0.0 0.0        # Physical lower bound of the domain (required)
    geometry.prob_hi = 1.0 1.0 1.0        # Physical upper bound of the domain (required)
    geometry.is_periodic = 1 1 1          # Periodicity flags per dimension (required)
-   geometry.coord_sys = 0                # DEF: 0; Coordinate system (only 0=Cartesian supported)
+   geometry.coord_sys = 0                # DEF: 0; Coordinate system (0=Cartesian, 1=cylindrical/RZ — 2D builds only)
 
-These parameters follow the standard AMReX geometry convention and are all required except ``coord_sys``.
+These parameters follow the standard AMReX geometry convention and are all required except ``coord_sys``. ``coord_sys = 1`` (cylindrical/RZ) requires a 2D build (``DIM=2``) and produces a Header with ``spacedim=2`` matching PeleLMeX 2D RZ output.
 ::
 
    #------------------- Grid ------------------------------------------------------------
@@ -160,12 +157,20 @@ Available field types
      - Step function in an annular ring or spherical shell
    * - ``ring_smooth`` / ``spherical_shell_smooth``
      - Smoothly blended annular ring or spherical shell
+   * - ``cylinder_step``
+     - Step function based on radial distance from an infinite axis line (3D Cartesian)
+   * - ``cylinder_smooth``
+     - Smoothly blended transition based on radial distance from an infinite axis line (3D Cartesian)
    * - ``sine``
      - Sinusoidal field: offset + amplitude * sin(2π f_x x) * cos(2π f_y y) * sin(2π f_z z)
 
 .. note::
 
    ``circle_*`` and ``sphere_*`` are identical in behaviour — both compute a radial distance from a centre point using all spatial dimensions. The same applies to ``ring_*`` and ``spherical_shell_*``.
+
+.. note::
+
+   ``cylinder_*`` measures the radial distance from an *axis line* (not a point), making it suitable for jet or pipe geometries on 3D Cartesian grids. The axis direction is set with ``axis``; the ``center`` parameter gives any point on that axis line.
 
 Smooth transitions use a *smootherstep* function (5th-order Hermite) centred on the specified position, over a width of ``smooth_width``.
 
@@ -209,6 +214,15 @@ Type-specific parameters
    myField.value_inside  = 1.0           # DEF: 1.0; Value between inner and outer radii
    myField.value_outside = 0.0           # DEF: 0.0; Value outside the shell
    myField.smooth_width  = 0.05          # DEF: 0.1; Transition width at each radius (smooth only)
+
+**cylinder_step** / **cylinder_smooth** ::
+
+   myField.axis          = 2             # DEF: 2; Cylinder axis direction (0=x, 1=y, 2=z)
+   myField.center        = 0.5 0.5 0.5  # DEF: 0.5 0.5 0.5; Any point on the axis line
+   myField.radius        = 0.25         # DEF: 0.25; Cylinder radius
+   myField.value_inside  = 1.0          # DEF: 1.0; Value inside the cylinder
+   myField.value_outside = 0.0          # DEF: 0.0; Value outside the cylinder
+   myField.smooth_width  = 0.1          # DEF: 0.1; Transition width (cylinder_smooth only)
 
 **sine** ::
 

--- a/Docs/source/analysis/generateTestPlt.rst
+++ b/Docs/source/analysis/generateTestPlt.rst
@@ -121,8 +121,17 @@ Common parameters
 ::
 
    myField.type = <type_string>           # Field type (required, see table below)
+   myField.output_name = Y(OH)            # DEF: <field_name>; Variable name written to the plotfile header
    myField.value_inside  = 1.0            # DEF: 1.0; Value inside the region
    myField.value_outside = 0.0            # DEF: 0.0; Value outside the region
+
+.. note::
+
+   ``output_name`` lets you embed characters that ParmParse treats as key separators (e.g. ``/``) in the
+   plotfile variable name without affecting the ParmParse prefix used to configure the field.  For example,
+   setting ``myField.output_name = Y(OH)`` writes the variable as ``Y(OH)`` in the plotfile header while
+   ``myField`` remains the valid ParmParse prefix.  This is the recommended way to create test fixtures for
+   tools that handle slash-containing species names such as ``jpdf``.
 
 Available field types
 ---------------------

--- a/Src/GNUmakefile
+++ b/Src/GNUmakefile
@@ -7,8 +7,8 @@ PELE_ANALYSIS_HOME = ..
 # to link PeleAnalysis to your versions of PELE_PHYSICS_HOME and AMREX_HOME used by 
 # PeleLMeX or PeleC, make the following lines to point to the respective directories.
 #
-#PELE_PHYSICS_HOME = ../../PelePhysics
-#AMREX_HOME = ../../PelePhysics/Submodules/amrex
+PELE_PHYSICS_HOME = ../../PelePhysics
+AMREX_HOME = ../../PelePhysics/Submodules/amrex
 
 
 # AMReX
@@ -38,7 +38,7 @@ USE_CUDA      = FALSE
 #EBASE   = dumpFABslice
 #EBASE   = filterPlt
 #EBASE   = flattenAMRFile
-#EBASE   = generateTestPlt
+EBASE   = generateTestPlt
 #EBASE   = grad
 #EBASE   = integral
 #EBASE   = isoMEF

--- a/Src/GNUmakefile
+++ b/Src/GNUmakefile
@@ -7,8 +7,8 @@ PELE_ANALYSIS_HOME = ..
 # to link PeleAnalysis to your versions of PELE_PHYSICS_HOME and AMREX_HOME used by 
 # PeleLMeX or PeleC, make the following lines to point to the respective directories.
 #
-PELE_PHYSICS_HOME = ../../PelePhysics
-AMREX_HOME = ../../PelePhysics/Submodules/amrex
+#PELE_PHYSICS_HOME = ../../PelePhysics
+#AMREX_HOME = ../../PelePhysics/Submodules/amrex
 
 
 # AMReX
@@ -38,7 +38,7 @@ USE_CUDA      = FALSE
 #EBASE   = dumpFABslice
 #EBASE   = filterPlt
 #EBASE   = flattenAMRFile
-EBASE   = generateTestPlt
+#EBASE   = generateTestPlt
 #EBASE   = grad
 #EBASE   = integral
 #EBASE   = isoMEF

--- a/Src/InputsSamples/generateTestPlt.inp
+++ b/Src/InputsSamples/generateTestPlt.inp
@@ -12,6 +12,35 @@ geometry.is_periodic = 0 0 0
 # Output
 plotfile_name = plt_test
 
+# --- Multilevel AMR (set amr.max_level = 0 or omit for single-level output) ---
+amr.max_level = 2
+# One refinement ratio per level transition (level 0->1, level 1->2, ...)
+amr.ref_ratio = 2 2
+# Minimum box size used during grid generation
+amr.blocking_factor = 8
+# Clustering efficiency threshold (higher = fewer but larger boxes)
+amr.grid_eff = 0.7
+# Buffer cells (in coarse index space) added around each tagged region, per level
+amr.n_error_buf = 2 2
+
+# List of refinement indicators — each entry below defines one criterion
+amr.refinement_indicators = sphere_box gthan adjd
+
+# Box region: refine the central sphere region up to level 2
+amr.sphere_box.in_box_lo = 0.2 0.2 0.2
+amr.sphere_box.in_box_hi = 0.8 0.8 0.8
+amr.sphere_box.max_level = 2
+
+# Value criterion: refine where circle_step > 5.0, up to level 2
+amr.gthan.value_greater = 5.0
+amr.gthan.field_name    = circle_step
+amr.gthan.max_level     = 2
+
+# Adjacent-difference criterion: refine the plane_step interface up to level 2
+amr.adjd.adjacent_difference_greater = 0.4
+amr.adjd.field_name                  = plane_step
+amr.adjd.max_level                   = 2
+
 # Field definitions
 field.names = const_field plane_step plane_smooth double_plane_step double_plane_smooth circle_step circle_smooth spherical_shell_step spherical_shell_smooth sine_field
 
@@ -34,11 +63,11 @@ plane_smooth.value_left = 2.0
 plane_smooth.value_right = -1.0
 plane_smooth.smooth_width = 0.2  # Transition width
 
-# Double plane step function (vertical split at x=0.5)
+# Double plane step function (slab between x=0.3 and x=0.7)
 double_plane_step.type = double_plane_step
 double_plane_step.axis = 0              # 0=x, 1=y, 2=z
-double_plane_step.position = 0.5        # Position along axis
-double_plane_step.position_second = 0.6 # Position of second plane along axis
+double_plane_step.position = 0.3        # Position along axis
+double_plane_step.position_second = 0.7 # Position of second plane along axis
 double_plane_step.value_inside = 1.0      # Value on left/below
 double_plane_step.value_outside = 0.0     # Value on right/above
 
@@ -49,7 +78,7 @@ double_plane_smooth.position = 0.5
 double_plane_smooth.position_second = 0.6
 double_plane_smooth.value_inside = 2.0
 double_plane_smooth.value_outside = -1.0
-double_plane_smooth.smooth_width = 0.2  # Transition width
+double_plane_smooth.smooth_width = 0.05
 
 # Circle/Sphere step function
 circle_step.type = sphere_step   # or circle_step for 2D
@@ -81,7 +110,7 @@ spherical_shell_smooth.radius_inner = 0.1
 spherical_shell_smooth.radius_outer = 0.3
 spherical_shell_smooth.value_inside = 10.0
 spherical_shell_smooth.value_outside = 0.0
-spherical_shell_smooth.smooth_width = 0.1
+spherical_shell_smooth.smooth_width = 0.05
 
 # Sine function
 sine_field.type = sine

--- a/Src/InputsSamples/generateTestPlt.inp
+++ b/Src/InputsSamples/generateTestPlt.inp
@@ -1,27 +1,23 @@
 # AMReX Grid Parameters
-amr.n_cell = 64 64 64
-amr.max_grid_size = 32
-amr.ngrow = 0
+amr.n_cell = 64 64 64        # Number of cells along each axis at level 0
+amr.max_grid_size = 32       # Maximum box side length (cells) per MPI rank
+amr.ngrow = 0                # Ghost-cell layers (0 = none)
 
 # Geometry
-geometry.coord_sys = 0
+geometry.coord_sys = 0       # 0 = Cartesian, 1 = cylindrical/RZ (2D only)
 geometry.prob_lo = 0.0 0.0 0.0
 geometry.prob_hi = 1.0 1.0 1.0
-geometry.is_periodic = 0 0 0
+geometry.is_periodic = 0 0 0 # Periodic boundary flags per axis
 
 # Output
-plotfile_name = plt_test
+plotfile_name = plt_test      # Directory name written by the tool
 
 # --- Multilevel AMR (set amr.max_level = 0 or omit for single-level output) ---
-amr.max_level = 2
-# One refinement ratio per level transition (level 0->1, level 1->2, ...)
-amr.ref_ratio = 2 2
-# Minimum box size used during grid generation
-amr.blocking_factor = 8
-# Clustering efficiency threshold (higher = fewer but larger boxes)
-amr.grid_eff = 0.7
-# Buffer cells (in coarse index space) added around each tagged region, per level
-amr.n_error_buf = 2 2
+amr.max_level = 2            # Number of refinement levels above the base grid
+amr.ref_ratio = 2 2          # Refinement ratio per level transition (one entry per transition)
+amr.blocking_factor = 8      # Minimum box size used during grid generation
+amr.grid_eff = 0.7           # Clustering efficiency threshold (higher = fewer but larger boxes)
+amr.n_error_buf = 2 2        # Buffer cells (coarse index space) added around tagged regions, per level
 
 # List of refinement indicators — each entry below defines one criterion
 amr.refinement_indicators = sphere_box gthan adjd
@@ -42,7 +38,7 @@ amr.adjd.field_name                  = plane_step
 amr.adjd.max_level                   = 2
 
 # Field definitions
-field.names = const_field plane_step plane_smooth double_plane_step double_plane_smooth circle_step circle_smooth spherical_shell_step spherical_shell_smooth sine_field
+field.names = const_field plane_step plane_smooth double_plane_step double_plane_smooth circle_step circle_smooth spherical_shell_step spherical_shell_smooth sine_field cylinder_step cylinder_smooth
 
 # Constant field
 const_field.type = constant
@@ -118,3 +114,20 @@ sine_field.frequency = 2.0 3.0 1.0  # Frequency in each direction
 sine_field.phase = 0.0 0.0 0.0      # Phase shift
 sine_field.amplitude = 1.0
 sine_field.offset = 0.0
+
+# Infinite cylinder step (axis along z; radial distance in x-y plane)
+cylinder_step.type = cylinder_step
+cylinder_step.axis = 2               # Cylinder axis: 0=x, 1=y, 2=z
+cylinder_step.center = 0.5 0.5 0.5  # Point on the cylinder axis
+cylinder_step.radius = 0.3
+cylinder_step.value_inside = 1.0
+cylinder_step.value_outside = 0.0
+
+# Infinite cylinder with smooth radial transition
+cylinder_smooth.type = cylinder_smooth
+cylinder_smooth.axis = 2             # Cylinder axis: 0=x, 1=y, 2=z
+cylinder_smooth.center = 0.5 0.5 0.5
+cylinder_smooth.radius = 0.3
+cylinder_smooth.value_inside = 1.0
+cylinder_smooth.value_outside = 0.0
+cylinder_smooth.smooth_width = 0.1  # Transition width around radius

--- a/Src/generateTestPlt.cpp
+++ b/Src/generateTestPlt.cpp
@@ -28,6 +28,28 @@ print_usage(int, char* argv[])
     << "                               (default: same as field name; use to embed\n"
     << "                                '/' or other ParmParse-reserved characters)\n\n"
 
+    << "Geometry options:\n"
+    << "  geometry.coord_sys=N         0 = Cartesian (default), 1 = cylindrical/RZ\n\n"
+
+    << "Field types (for <name>.type):\n"
+    << "  constant                     Uniform value everywhere\n"
+    << "  plane_step / plane_smooth    Step/smooth transition at a coordinate plane\n"
+    << "                               axis=0|1|2  position=F  [smooth_width=F]\n"
+    << "  double_plane_step/smooth     Slab between two parallel planes\n"
+    << "                               axis=0|1|2  position=F  position_second=F\n"
+    << "  sphere_step / sphere_smooth  Step/smooth sphere (3D) or circle (2D)\n"
+    << "                               center=X [Y Z]  radius=F  [smooth_width=F]\n"
+    << "  ring_step / ring_smooth      Spherical shell (annulus in 2D)\n"
+    << "                               center=X [Y Z]  radius_inner=F  radius_outer=F\n"
+    << "  cylinder_step / cylinder_smooth  Step/smooth infinite cylinder\n"
+    << "                               axis=0|1|2 (default 2)  center=X [Y Z]\n"
+    << "                               radius=F  [smooth_width=F]\n"
+    << "                               Radial distance is measured from the named\n"
+    << "                               axis line, not from a point.\n"
+    << "  sine                         Separable sin*cos*sin wave\n"
+    << "                               frequency=Fx [Fy Fz]  phase=Px [Py Pz]\n"
+    << "                               amplitude=A  offset=B\n\n"
+
     << "AMR options (multilevel):\n"
     << "  amr.max_level=N              Maximum refinement level (default 0)\n"
     << "  amr.ref_ratio=N [N ...]      Refinement ratio per level (default 2)\n"
@@ -64,6 +86,8 @@ enum class FieldType {
   CircleSmooth,
   RingStep,
   RingSmooth,
+  CylinderStep,
+  CylinderSmooth,
   Sine
 };
 
@@ -130,12 +154,14 @@ parseFieldType(const std::string& type_str)
     {"double_plane_smooth", FieldType::DoublePlaneSmooth},
     {"circle_step", FieldType::CircleStep},
     {"circle_smooth", FieldType::CircleSmooth},
-    {"sphere_step", FieldType::CircleStep}, // Same as circle in code
+    {"sphere_step", FieldType::CircleStep},
     {"sphere_smooth", FieldType::CircleSmooth},
     {"ring_step", FieldType::RingStep},
     {"ring_smooth", FieldType::RingSmooth},
-    {"spherical_shell_step", FieldType::RingStep}, // Same as ring in code
+    {"spherical_shell_step", FieldType::RingStep},
     {"spherical_shell_smooth", FieldType::RingSmooth},
+    {"cylinder_step", FieldType::CylinderStep},
+    {"cylinder_smooth", FieldType::CylinderSmooth},
     {"sine", FieldType::Sine}};
 
   auto it = type_map.find(type_str);
@@ -333,6 +359,63 @@ evaluateField(
     Real blend = blend_inner * (1.0 - blend_outer);
 
     result = config.value_inside * blend + config.value_outside * (1.0 - blend);
+    break;
+  }
+
+  case FieldType::CylinderStep: {
+    Real r;
+    if (config.plane_axis == 0) {         // cylinder axis along x; transverse = y,z
+#if AMREX_SPACEDIM == 3
+      Real dy = y - config.center[1];
+      Real dz = z - config.center[2];
+      r = std::sqrt(dy * dy + dz * dz);
+#else
+      r = std::abs(y - config.center[1]); // 2D: only one transverse direction
+#endif
+    } else if (config.plane_axis == 1) {  // cylinder axis along y; transverse = x,z
+#if AMREX_SPACEDIM == 3
+      Real dx = x - config.center[0];
+      Real dz = z - config.center[2];
+      r = std::sqrt(dx * dx + dz * dz);
+#else
+      r = std::abs(x - config.center[0]); // 2D: only one transverse direction
+#endif
+    } else {                               // cylinder axis along z; transverse = x,y
+      Real dx = x - config.center[0];
+      Real dy = y - config.center[1];
+      r = std::sqrt(dx * dx + dy * dy);
+    }
+    result = (r < config.radius) ? config.value_inside : config.value_outside;
+    break;
+  }
+
+  case FieldType::CylinderSmooth: {
+    Real r;
+    if (config.plane_axis == 0) {
+#if AMREX_SPACEDIM == 3
+      Real dy = y - config.center[1];
+      Real dz = z - config.center[2];
+      r = std::sqrt(dy * dy + dz * dz);
+#else
+      r = std::abs(y - config.center[1]);
+#endif
+    } else if (config.plane_axis == 1) {
+#if AMREX_SPACEDIM == 3
+      Real dx = x - config.center[0];
+      Real dz = z - config.center[2];
+      r = std::sqrt(dx * dx + dz * dz);
+#else
+      r = std::abs(x - config.center[0]);
+#endif
+    } else {
+      Real dx = x - config.center[0];
+      Real dy = y - config.center[1];
+      r = std::sqrt(dx * dx + dy * dy);
+    }
+    Real edge0 = config.radius - config.smooth_width / 2.0;
+    Real edge1 = config.radius + config.smooth_width / 2.0;
+    Real blend = smoothstep(edge0, edge1, r);
+    result = config.value_inside * (1.0 - blend) + config.value_outside * blend;
     break;
   }
 
@@ -559,10 +642,12 @@ main(int argc, char* argv[])
     Array<int, AMREX_SPACEDIM> is_per = {
       AMREX_D_DECL(pp_is_per[0], pp_is_per[1], pp_is_per[2])};
 
-    // Coordinate system (only Cartesian supported)
+    // Coordinate system: 0 = Cartesian, 1 = cylindrical/RZ
     int coord = 0;
     ppgeom.query("coord_sys", coord);
-    AMREX_ALWAYS_ASSERT(coord == 0);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+      coord == 0 || coord == 1,
+      "geometry.coord_sys must be 0 (Cartesian) or 1 (cylindrical/RZ)");
 
     // Level-0 geometry
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
@@ -736,6 +821,24 @@ main(int argc, char* argv[])
           ppf.query("value_inside", config.value_inside);
           ppf.query("value_outside", config.value_outside);
           if (config.type == FieldType::RingSmooth) {
+            ppf.query("smooth_width", config.smooth_width);
+          }
+          break;
+        }
+
+        case FieldType::CylinderStep:
+        case FieldType::CylinderSmooth: {
+          config.plane_axis = 2; // default: cylinder axis along z
+          ppf.query("axis", config.plane_axis);
+          Vector<Real> pp_center(AMREX_SPACEDIM, 0.5);
+          ppf.queryarr("center", pp_center);
+          for (int dim = 0; dim < static_cast<int>(pp_center.size()); ++dim) {
+            config.center[dim] = pp_center[dim];
+          }
+          ppf.query("radius", config.radius);
+          ppf.query("value_inside", config.value_inside);
+          ppf.query("value_outside", config.value_outside);
+          if (config.type == FieldType::CylinderSmooth) {
             ppf.query("smooth_width", config.smooth_width);
           }
           break;

--- a/Src/generateTestPlt.cpp
+++ b/Src/generateTestPlt.cpp
@@ -480,26 +480,37 @@ buildFineBoxArray(
   // Expand tagged cells by n_error_buf cells at coarse level
   tba.buffer(IntVect(n_error_buf));
 
-  // Collect tagged cell positions
+  // Gather tagged cell positions to IO proc (collate is gather-to-root, not allgather).
+  // Pattern mirrors AMReX AmrMesh::regrid (AMReX_AmrMesh.cpp ~line 736-775).
   Gpu::PinnedVector<IntVect> pts;
   tba.collate(pts);
+  // collate uses ReduceLongSum internally: if numtags==0 it calls clear() on ALL
+  // ranks, so pts.empty() is a safe all-rank test for "nothing to refine".
   if (pts.empty()) {
     return BoxArray{};
   }
 
-  // Cluster tagged cells into coarse-level boxes
-  ClusterList clist(pts.data(), static_cast<Long>(pts.size()));
-  clist.chop(grid_eff);
-  BoxList coarse_bl = clist.boxList();
-  coarse_bl.intersect(coarse_domain);
-  coarse_bl.simplify();
-
-  // Refine coarse-level boxes to fine-level index space
+  // Cluster on IO proc only (non-IO procs have a single-element placeholder in pts).
   BoxList fine_bl;
-  for (Box b : coarse_bl) {
-    fine_bl.push_back(b.refine(ref_ratio_lev));
+  if (ParallelDescriptor::IOProcessor()) {
+    ClusterList clist(pts.data(), static_cast<Long>(pts.size()));
+    clist.chop(grid_eff);
+    BoxList coarse_bl = clist.boxList();
+    coarse_bl.intersect(coarse_domain);
+    coarse_bl.simplify();
+    for (Box b : coarse_bl) {
+      fine_bl.push_back(b.refine(ref_ratio_lev));
+    }
+    fine_bl.simplify();
   }
-  fine_bl.simplify();
+
+  // Broadcast the BoxList from IO proc to all ranks so every rank builds the
+  // same BoxArray and DistributionMapping (required for MPI collectives).
+  fine_bl.Bcast();
+
+  if (fine_bl.isEmpty()) {
+    return BoxArray{};
+  }
 
   BoxArray ba(fine_bl);
   ba.maxSize(max_grid_size);

--- a/Src/generateTestPlt.cpp
+++ b/Src/generateTestPlt.cpp
@@ -23,7 +23,10 @@ print_usage(int, char* argv[])
     << "  geometry.prob_hi=X [Y Z]     Physical upper bound of the domain\n"
     << "  geometry.is_periodic=N [N N] Periodicity flags per dimension\n"
     << "  field.names=NAME [NAME ...]  Space-separated list of field names\n"
-    << "  <name>.type=TYPE             Field type for each named field\n\n"
+    << "  <name>.type=TYPE             Field type for each named field\n"
+    << "  <name>.output_name=S         Variable name written to plotfile header\n"
+    << "                               (default: same as field name; use to embed\n"
+    << "                                '/' or other ParmParse-reserved characters)\n\n"
 
     << "AMR options (multilevel):\n"
     << "  amr.max_level=N              Maximum refinement level (default 0)\n"
@@ -837,10 +840,11 @@ main(int argc, char* argv[])
       fillLevel(lev);
     }
 
-    // Variable names for plotfile
+    // Variable names for plotfile (output_name overrides the ParmParse prefix)
     Vector<std::string> varnames(ncomp);
     for (int n = 0; n < ncomp; ++n) {
       varnames[n] = field_names[n];
+      ParmParse(field_names[n]).query("output_name", varnames[n]);
     }
 
     // Write multilevel plot file

--- a/Src/generateTestPlt.cpp
+++ b/Src/generateTestPlt.cpp
@@ -18,33 +18,44 @@ print_usage(int, char* argv[])
     << "  " << argv[0] << " [OPTIONS]\n\n"
 
     << "Required arguments:\n"
-    << "  amr.n_cell=N [N N]           Number of cells per dimension (level 0)\n"
+    << "  amr.n_cell=N [N N]           Number of cells per dimension (level "
+       "0)\n"
     << "  geometry.prob_lo=X [Y Z]     Physical lower bound of the domain\n"
     << "  geometry.prob_hi=X [Y Z]     Physical upper bound of the domain\n"
     << "  geometry.is_periodic=N [N N] Periodicity flags per dimension\n"
     << "  field.names=NAME [NAME ...]  Space-separated list of field names\n"
     << "  <name>.type=TYPE             Field type for each named field\n"
-    << "  <name>.output_name=S         Variable name written to plotfile header\n"
-    << "                               (default: same as field name; use to embed\n"
-    << "                                '/' or other ParmParse-reserved characters)\n\n"
+    << "  <name>.output_name=S         Variable name written to plotfile "
+       "header\n"
+    << "                               (default: same as field name; use to "
+       "embed\n"
+    << "                                '/' or other ParmParse-reserved "
+       "characters)\n\n"
 
     << "Geometry options:\n"
-    << "  geometry.coord_sys=N         0 = Cartesian (default), 1 = cylindrical/RZ\n\n"
+    << "  geometry.coord_sys=N         0 = Cartesian (default), 1 = "
+       "cylindrical/RZ\n\n"
 
     << "Field types (for <name>.type):\n"
     << "  constant                     Uniform value everywhere\n"
-    << "  plane_step / plane_smooth    Step/smooth transition at a coordinate plane\n"
-    << "                               axis=0|1|2  position=F  [smooth_width=F]\n"
+    << "  plane_step / plane_smooth    Step/smooth transition at a coordinate "
+       "plane\n"
+    << "                               axis=0|1|2  position=F  "
+       "[smooth_width=F]\n"
     << "  double_plane_step/smooth     Slab between two parallel planes\n"
-    << "                               axis=0|1|2  position=F  position_second=F\n"
+    << "                               axis=0|1|2  position=F  "
+       "position_second=F\n"
     << "  sphere_step / sphere_smooth  Step/smooth sphere (3D) or circle (2D)\n"
-    << "                               center=X [Y Z]  radius=F  [smooth_width=F]\n"
+    << "                               center=X [Y Z]  radius=F  "
+       "[smooth_width=F]\n"
     << "  ring_step / ring_smooth      Spherical shell (annulus in 2D)\n"
-    << "                               center=X [Y Z]  radius_inner=F  radius_outer=F\n"
+    << "                               center=X [Y Z]  radius_inner=F  "
+       "radius_outer=F\n"
     << "  cylinder_step / cylinder_smooth  Step/smooth infinite cylinder\n"
     << "                               axis=0|1|2 (default 2)  center=X [Y Z]\n"
     << "                               radius=F  [smooth_width=F]\n"
-    << "                               Radial distance is measured from the named\n"
+    << "                               Radial distance is measured from the "
+       "named\n"
     << "                               axis line, not from a point.\n"
     << "  sine                         Separable sin*cos*sin wave\n"
     << "                               frequency=Fx [Fy Fz]  phase=Px [Py Pz]\n"
@@ -53,19 +64,27 @@ print_usage(int, char* argv[])
     << "AMR options (multilevel):\n"
     << "  amr.max_level=N              Maximum refinement level (default 0)\n"
     << "  amr.ref_ratio=N [N ...]      Refinement ratio per level (default 2)\n"
-    << "  amr.grid_eff=F               Clustering efficiency threshold (default 0.7)\n"
+    << "  amr.grid_eff=F               Clustering efficiency threshold "
+       "(default 0.7)\n"
     << "  amr.blocking_factor=N        Minimum box size (default 8)\n"
-    << "  amr.n_error_buf=N [N ...]    Buffer cells around tagged region (default 1)\n"
+    << "  amr.n_error_buf=N [N ...]    Buffer cells around tagged region "
+       "(default 1)\n"
     << "  amr.max_grid_size=N          Maximum box size (default 32)\n"
     << "  amr.refinement_indicators=NAME [NAME ...]\n"
-    << "                               Space-separated list of refinement criteria\n"
-    << "  amr.<name>.in_box_lo=X [Y Z] Physical lower bound of refinement region\n"
-    << "  amr.<name>.in_box_hi=X [Y Z] Physical upper bound of refinement region\n"
+    << "                               Space-separated list of refinement "
+       "criteria\n"
+    << "  amr.<name>.in_box_lo=X [Y Z] Physical lower bound of refinement "
+       "region\n"
+    << "  amr.<name>.in_box_hi=X [Y Z] Physical upper bound of refinement "
+       "region\n"
     << "  amr.<name>.value_greater=F   Refine where field > F\n"
     << "  amr.<name>.value_less=F      Refine where field < F\n"
-    << "  amr.<name>.adjacent_difference_greater=F  Refine where max neighbor diff > F\n"
-    << "  amr.<name>.field_name=NAME   Field to evaluate (value-based criteria)\n"
-    << "  amr.<name>.max_level=N       Max level for this indicator (default: amr.max_level)\n\n"
+    << "  amr.<name>.adjacent_difference_greater=F  Refine where max neighbor "
+       "diff > F\n"
+    << "  amr.<name>.field_name=NAME   Field to evaluate (value-based "
+       "criteria)\n"
+    << "  amr.<name>.max_level=N       Max level for this indicator (default: "
+       "amr.max_level)\n\n"
 
     << "  -h, --help                   Show this help message\n\n"
 
@@ -123,7 +142,12 @@ struct FieldConfig
 };
 
 // Enum for refinement criterion types
-enum class RefinementType { InBox, ValueGreater, ValueLess, AdjacentDiffGreater };
+enum class RefinementType {
+  InBox,
+  ValueGreater,
+  ValueLess,
+  AdjacentDiffGreater
+};
 
 // Structure to hold refinement indicator configuration
 struct RefinementRegion
@@ -364,7 +388,7 @@ evaluateField(
 
   case FieldType::CylinderStep: {
     Real r;
-    if (config.plane_axis == 0) {         // cylinder axis along x; transverse = y,z
+    if (config.plane_axis == 0) { // cylinder axis along x; transverse = y,z
 #if AMREX_SPACEDIM == 3
       Real dy = y - config.center[1];
       Real dz = z - config.center[2];
@@ -372,7 +396,8 @@ evaluateField(
 #else
       r = std::abs(y - config.center[1]); // 2D: only one transverse direction
 #endif
-    } else if (config.plane_axis == 1) {  // cylinder axis along y; transverse = x,z
+    } else if (config.plane_axis == 1) { // cylinder axis along y; transverse =
+                                         // x,z
 #if AMREX_SPACEDIM == 3
       Real dx = x - config.center[0];
       Real dz = z - config.center[2];
@@ -380,7 +405,7 @@ evaluateField(
 #else
       r = std::abs(x - config.center[0]); // 2D: only one transverse direction
 #endif
-    } else {                               // cylinder axis along z; transverse = x,y
+    } else { // cylinder axis along z; transverse = x,y
       Real dx = x - config.center[0];
       Real dy = y - config.center[1];
       r = std::sqrt(dx * dx + dy * dy);
@@ -438,7 +463,8 @@ evaluateField(
 }
 
 // Build the BoxArray for refinement level `lev` (lev >= 1).
-// Tags coarse cells analytically, buffers, clusters, and refines to fine index space.
+// Tags coarse cells analytically, buffers, clusters, and refines to fine index
+// space.
 BoxArray
 buildFineBoxArray(
   int lev,
@@ -453,8 +479,8 @@ buildFineBoxArray(
   int /*blocking_factor*/,
   int max_grid_size)
 {
-  const auto coarse_dx   = coarse_geom.CellSizeArray();
-  const auto prob_lo     = coarse_geom.ProbLoArray();
+  const auto coarse_dx = coarse_geom.CellSizeArray();
+  const auto prob_lo = coarse_geom.ProbLoArray();
   const Box coarse_domain = coarse_geom.Domain();
 
   TagBoxArray tba(coarse_ba, coarse_dm, n_error_buf);
@@ -480,9 +506,9 @@ buildFineBoxArray(
 #else
           Real z = 0.0;
 #endif
-          if (AMREX_D_TERM(x >= rlo[0] && x <= rhi[0],
-                            &&y >= rlo[1] && y <= rhi[1],
-                            &&z >= rlo[2] && z <= rhi[2])) {
+          if (AMREX_D_TERM(
+                x >= rlo[0] && x <= rhi[0], &&y >= rlo[1] && y <= rhi[1],
+                &&z >= rlo[2] && z <= rhi[2])) {
             tag(i, j, k) = TagBox::SET;
           }
         });
@@ -533,21 +559,27 @@ buildFineBoxArray(
           Real val = evaluateField(cfg, x, y, z, coarse_dx, prob_lo);
           Real max_diff = 0.0;
 
-          Real vxp = evaluateField(cfg, x + coarse_dx[0], y, z, coarse_dx, prob_lo);
-          Real vxm = evaluateField(cfg, x - coarse_dx[0], y, z, coarse_dx, prob_lo);
+          Real vxp =
+            evaluateField(cfg, x + coarse_dx[0], y, z, coarse_dx, prob_lo);
+          Real vxm =
+            evaluateField(cfg, x - coarse_dx[0], y, z, coarse_dx, prob_lo);
           max_diff = std::max(max_diff, std::abs(vxp - val));
           max_diff = std::max(max_diff, std::abs(vxm - val));
 
 #if AMREX_SPACEDIM >= 2
-          Real vyp = evaluateField(cfg, x, y + coarse_dx[1], z, coarse_dx, prob_lo);
-          Real vym = evaluateField(cfg, x, y - coarse_dx[1], z, coarse_dx, prob_lo);
+          Real vyp =
+            evaluateField(cfg, x, y + coarse_dx[1], z, coarse_dx, prob_lo);
+          Real vym =
+            evaluateField(cfg, x, y - coarse_dx[1], z, coarse_dx, prob_lo);
           max_diff = std::max(max_diff, std::abs(vyp - val));
           max_diff = std::max(max_diff, std::abs(vym - val));
 #endif
 
 #if AMREX_SPACEDIM == 3
-          Real vzp = evaluateField(cfg, x, y, z + coarse_dx[2], coarse_dx, prob_lo);
-          Real vzm = evaluateField(cfg, x, y, z - coarse_dx[2], coarse_dx, prob_lo);
+          Real vzp =
+            evaluateField(cfg, x, y, z + coarse_dx[2], coarse_dx, prob_lo);
+          Real vzm =
+            evaluateField(cfg, x, y, z - coarse_dx[2], coarse_dx, prob_lo);
           max_diff = std::max(max_diff, std::abs(vzp - val));
           max_diff = std::max(max_diff, std::abs(vzm - val));
 #endif
@@ -563,17 +595,19 @@ buildFineBoxArray(
   // Expand tagged cells by n_error_buf cells at coarse level
   tba.buffer(IntVect(n_error_buf));
 
-  // Gather tagged cell positions to IO proc (collate is gather-to-root, not allgather).
-  // Pattern mirrors AMReX AmrMesh::regrid (AMReX_AmrMesh.cpp ~line 736-775).
+  // Gather tagged cell positions to IO proc (collate is gather-to-root, not
+  // allgather). Pattern mirrors AMReX AmrMesh::regrid (AMReX_AmrMesh.cpp ~line
+  // 736-775).
   Gpu::PinnedVector<IntVect> pts;
   tba.collate(pts);
-  // collate uses ReduceLongSum internally: if numtags==0 it calls clear() on ALL
-  // ranks, so pts.empty() is a safe all-rank test for "nothing to refine".
+  // collate uses ReduceLongSum internally: if numtags==0 it calls clear() on
+  // ALL ranks, so pts.empty() is a safe all-rank test for "nothing to refine".
   if (pts.empty()) {
     return BoxArray{};
   }
 
-  // Cluster on IO proc only (non-IO procs have a single-element placeholder in pts).
+  // Cluster on IO proc only (non-IO procs have a single-element placeholder in
+  // pts).
   BoxList fine_bl;
   if (ParallelDescriptor::IOProcessor()) {
     ClusterList clist(pts.data(), static_cast<Long>(pts.size()));
@@ -666,7 +700,8 @@ main(int argc, char* argv[])
       Vector<int> rr;
       ppamr.getarr("ref_ratio", rr);
       for (int lev = 0; lev < max_level; ++lev) {
-        ref_ratio[lev] = (lev < static_cast<int>(rr.size())) ? rr[lev] : rr.back();
+        ref_ratio[lev] =
+          (lev < static_cast<int>(rr.size())) ? rr[lev] : rr.back();
       }
     }
 
@@ -847,7 +882,8 @@ main(int argc, char* argv[])
         case FieldType::Sine: {
           Vector<Real> pp_frequency(AMREX_SPACEDIM, 0.0);
           ppf.queryarr("frequency", pp_frequency);
-          for (int dim = 0; dim < static_cast<int>(pp_frequency.size()); ++dim) {
+          for (int dim = 0; dim < static_cast<int>(pp_frequency.size());
+               ++dim) {
             config.frequency[dim] = pp_frequency[dim];
           }
           Vector<Real> pp_phase(AMREX_SPACEDIM, 0.0);
@@ -893,7 +929,7 @@ main(int argc, char* argv[])
 
     // Lambda to fill one level analytically
     auto fillLevel = [&](int lev) {
-      const auto lev_dx      = geoms[lev].CellSizeArray();
+      const auto lev_dx = geoms[lev].CellSizeArray();
       const auto lev_prob_lo = geoms[lev].ProbLoArray();
 
       Gpu::DeviceVector<FieldConfig> d_configs(ncomp);
@@ -971,8 +1007,8 @@ main(int argc, char* argv[])
       refRatios[lev] = IntVect(ref_ratio[lev]);
     }
     amrex::WriteMultiLevelPlotfile(
-      plotfile_name, Nlev, GetVecOfConstPtrs(mfs), varnames, geoms, 0.0,
-      isteps, refRatios);
+      plotfile_name, Nlev, GetVecOfConstPtrs(mfs), varnames, geoms, 0.0, isteps,
+      refRatios);
 
     amrex::Print() << "Plotfile created: " << plotfile_name << "\n";
   }

--- a/Src/generateTestPlt.cpp
+++ b/Src/generateTestPlt.cpp
@@ -374,7 +374,7 @@ buildFineBoxArray(
   const auto prob_lo     = coarse_geom.ProbLoArray();
   const Box coarse_domain = coarse_geom.Domain();
 
-  TagBoxArray tba(coarse_ba, coarse_dm);
+  TagBoxArray tba(coarse_ba, coarse_dm, n_error_buf);
   tba.setVal(TagBox::CLEAR);
 
   for (const auto& reg : regions) {

--- a/Src/generateTestPlt.cpp
+++ b/Src/generateTestPlt.cpp
@@ -682,6 +682,9 @@ main(int argc, char* argv[])
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
       coord == 0 || coord == 1,
       "geometry.coord_sys must be 0 (Cartesian) or 1 (cylindrical/RZ)");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+      coord == 0 || AMREX_SPACEDIM == 2,
+      "geometry.coord_sys=1 (cylindrical/RZ) requires a 2D build (DIM=2)");
 
     // Level-0 geometry
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Src/generateTestPlt.cpp
+++ b/Src/generateTestPlt.cpp
@@ -2,6 +2,9 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_TagBox.H>
+#include <AMReX_Cluster.H>
+#include <algorithm>
 #include <string>
 #include <map>
 
@@ -15,14 +18,31 @@ print_usage(int, char* argv[])
     << "  " << argv[0] << " [OPTIONS]\n\n"
 
     << "Required arguments:\n"
-    << "  amr.n_cell=N [N N]         Number of cells per dimension\n"
-    << "  geometry.prob_lo=X [Y Z]   Physical lower bound of the domain\n"
-    << "  geometry.prob_hi=X [Y Z]   Physical upper bound of the domain\n"
+    << "  amr.n_cell=N [N N]           Number of cells per dimension (level 0)\n"
+    << "  geometry.prob_lo=X [Y Z]     Physical lower bound of the domain\n"
+    << "  geometry.prob_hi=X [Y Z]     Physical upper bound of the domain\n"
     << "  geometry.is_periodic=N [N N] Periodicity flags per dimension\n"
-    << "  field.names=NAME [NAME ...] Space-separated list of field names\n"
-    << "  <name>.type=TYPE           Field type for each named field\n\n"
+    << "  field.names=NAME [NAME ...]  Space-separated list of field names\n"
+    << "  <name>.type=TYPE             Field type for each named field\n\n"
 
-    << "  -h, --help                 Show this help message\n\n"
+    << "AMR options (multilevel):\n"
+    << "  amr.max_level=N              Maximum refinement level (default 0)\n"
+    << "  amr.ref_ratio=N [N ...]      Refinement ratio per level (default 2)\n"
+    << "  amr.grid_eff=F               Clustering efficiency threshold (default 0.7)\n"
+    << "  amr.blocking_factor=N        Minimum box size (default 8)\n"
+    << "  amr.n_error_buf=N [N ...]    Buffer cells around tagged region (default 1)\n"
+    << "  amr.max_grid_size=N          Maximum box size (default 32)\n"
+    << "  amr.refinement_indicators=NAME [NAME ...]\n"
+    << "                               Space-separated list of refinement criteria\n"
+    << "  amr.<name>.in_box_lo=X [Y Z] Physical lower bound of refinement region\n"
+    << "  amr.<name>.in_box_hi=X [Y Z] Physical upper bound of refinement region\n"
+    << "  amr.<name>.value_greater=F   Refine where field > F\n"
+    << "  amr.<name>.value_less=F      Refine where field < F\n"
+    << "  amr.<name>.adjacent_difference_greater=F  Refine where max neighbor diff > F\n"
+    << "  amr.<name>.field_name=NAME   Field to evaluate (value-based criteria)\n"
+    << "  amr.<name>.max_level=N       Max level for this indicator (default: amr.max_level)\n\n"
+
+    << "  -h, --help                   Show this help message\n\n"
 
     << "Visit PeleAnalysis/Src/InputSamples for examples or refer to "
     << "the documentation.\n";
@@ -75,6 +95,26 @@ struct FieldConfig
   Real offset = 0.0;
 };
 
+// Enum for refinement criterion types
+enum class RefinementType { InBox, ValueGreater, ValueLess, AdjacentDiffGreater };
+
+// Structure to hold refinement indicator configuration
+struct RefinementRegion
+{
+  std::string name;
+  int max_level = -1; // -1 resolved to global max_level after parsing
+  RefinementType type = RefinementType::InBox;
+
+  // InBox parameters
+  GpuArray<Real, AMREX_SPACEDIM> lo = {AMREX_D_DECL(0.0, 0.0, 0.0)};
+  GpuArray<Real, AMREX_SPACEDIM> hi = {AMREX_D_DECL(1.0, 1.0, 1.0)};
+
+  // Value-based parameters
+  std::string field_name;
+  int field_comp = -1; // resolved after field name parsing
+  Real threshold = 0.0;
+};
+
 // Helper function to parse field type
 FieldType
 parseFieldType(const std::string& type_str)
@@ -105,23 +145,15 @@ parseFieldType(const std::string& type_str)
 }
 
 // Smooth step function
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE Real
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real
 smoothstep(Real edge0, Real edge1, Real x)
 {
   Real t = std::max(0.0, std::min(1.0, (x - edge0) / (edge1 - edge0)));
-
-  // smoothstep
-  // return t * t * (3.0 - 2.0 * t);
-
-  // smootherstep
   return t * t * t * (t * (6.0 * t - 15.0) + 10.0);
-
-  // tanh
-  // return 0.5 * (1 + std::tanh(6 * t - 3));
 }
 
 // Function to evaluate field value at a point
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE Real
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real
 evaluateField(
   const FieldConfig& config,
   Real x,
@@ -319,6 +351,158 @@ evaluateField(
   return result;
 }
 
+// Build the BoxArray for refinement level `lev` (lev >= 1).
+// Tags coarse cells analytically, buffers, clusters, and refines to fine index space.
+BoxArray
+buildFineBoxArray(
+  int lev,
+  const Geometry& coarse_geom,
+  const BoxArray& coarse_ba,
+  const DistributionMapping& coarse_dm,
+  const Vector<RefinementRegion>& regions,
+  const FieldConfig* h_configs, // host pointer to field configs
+  int ref_ratio_lev,
+  int n_error_buf,
+  Real grid_eff,
+  int /*blocking_factor*/,
+  int max_grid_size)
+{
+  const auto coarse_dx   = coarse_geom.CellSizeArray();
+  const auto prob_lo     = coarse_geom.ProbLoArray();
+  const Box coarse_domain = coarse_geom.Domain();
+
+  TagBoxArray tba(coarse_ba, coarse_dm);
+  tba.setVal(TagBox::CLEAR);
+
+  for (const auto& reg : regions) {
+    if (reg.max_level < lev) {
+      continue;
+    }
+
+    if (reg.type == RefinementType::InBox) {
+      const GpuArray<Real, AMREX_SPACEDIM> rlo = reg.lo;
+      const GpuArray<Real, AMREX_SPACEDIM> rhi = reg.hi;
+
+      for (MFIter mfi(tba); mfi.isValid(); ++mfi) {
+        const Box& box = mfi.validbox();
+        auto tag = tba[mfi].array();
+        amrex::Loop(box, [=](int i, int j, int k) noexcept {
+          Real x = prob_lo[0] + (i + 0.5) * coarse_dx[0];
+          Real y = prob_lo[1] + (j + 0.5) * coarse_dx[1];
+#if AMREX_SPACEDIM == 3
+          Real z = prob_lo[2] + (k + 0.5) * coarse_dx[2];
+#else
+          Real z = 0.0;
+#endif
+          if (AMREX_D_TERM(x >= rlo[0] && x <= rhi[0],
+                            &&y >= rlo[1] && y <= rhi[1],
+                            &&z >= rlo[2] && z <= rhi[2])) {
+            tag(i, j, k) = TagBox::SET;
+          }
+        });
+      }
+
+    } else if (
+      reg.type == RefinementType::ValueGreater ||
+      reg.type == RefinementType::ValueLess) {
+      const int comp = reg.field_comp;
+      const Real thresh = reg.threshold;
+      const bool do_greater = (reg.type == RefinementType::ValueGreater);
+      const FieldConfig cfg = h_configs[comp];
+
+      for (MFIter mfi(tba); mfi.isValid(); ++mfi) {
+        const Box& box = mfi.validbox();
+        auto tag = tba[mfi].array();
+        amrex::Loop(box, [=](int i, int j, int k) noexcept {
+          Real x = prob_lo[0] + (i + 0.5) * coarse_dx[0];
+          Real y = prob_lo[1] + (j + 0.5) * coarse_dx[1];
+#if AMREX_SPACEDIM == 3
+          Real z = prob_lo[2] + (k + 0.5) * coarse_dx[2];
+#else
+          Real z = 0.0;
+#endif
+          Real val = evaluateField(cfg, x, y, z, coarse_dx, prob_lo);
+          if ((do_greater && val > thresh) || (!do_greater && val < thresh)) {
+            tag(i, j, k) = TagBox::SET;
+          }
+        });
+      }
+
+    } else { // AdjacentDiffGreater
+      const int comp = reg.field_comp;
+      const Real thresh = reg.threshold;
+      const FieldConfig cfg = h_configs[comp];
+
+      for (MFIter mfi(tba); mfi.isValid(); ++mfi) {
+        const Box& box = mfi.validbox();
+        auto tag = tba[mfi].array();
+        amrex::Loop(box, [=](int i, int j, int k) noexcept {
+          Real x = prob_lo[0] + (i + 0.5) * coarse_dx[0];
+          Real y = prob_lo[1] + (j + 0.5) * coarse_dx[1];
+#if AMREX_SPACEDIM == 3
+          Real z = prob_lo[2] + (k + 0.5) * coarse_dx[2];
+#else
+          Real z = 0.0;
+#endif
+          Real val = evaluateField(cfg, x, y, z, coarse_dx, prob_lo);
+          Real max_diff = 0.0;
+
+          Real vxp = evaluateField(cfg, x + coarse_dx[0], y, z, coarse_dx, prob_lo);
+          Real vxm = evaluateField(cfg, x - coarse_dx[0], y, z, coarse_dx, prob_lo);
+          max_diff = std::max(max_diff, std::abs(vxp - val));
+          max_diff = std::max(max_diff, std::abs(vxm - val));
+
+#if AMREX_SPACEDIM >= 2
+          Real vyp = evaluateField(cfg, x, y + coarse_dx[1], z, coarse_dx, prob_lo);
+          Real vym = evaluateField(cfg, x, y - coarse_dx[1], z, coarse_dx, prob_lo);
+          max_diff = std::max(max_diff, std::abs(vyp - val));
+          max_diff = std::max(max_diff, std::abs(vym - val));
+#endif
+
+#if AMREX_SPACEDIM == 3
+          Real vzp = evaluateField(cfg, x, y, z + coarse_dx[2], coarse_dx, prob_lo);
+          Real vzm = evaluateField(cfg, x, y, z - coarse_dx[2], coarse_dx, prob_lo);
+          max_diff = std::max(max_diff, std::abs(vzp - val));
+          max_diff = std::max(max_diff, std::abs(vzm - val));
+#endif
+
+          if (max_diff > thresh) {
+            tag(i, j, k) = TagBox::SET;
+          }
+        });
+      }
+    }
+  }
+
+  // Expand tagged cells by n_error_buf cells at coarse level
+  tba.buffer(IntVect(n_error_buf));
+
+  // Collect tagged cell positions
+  Gpu::PinnedVector<IntVect> pts;
+  tba.collate(pts);
+  if (pts.empty()) {
+    return BoxArray{};
+  }
+
+  // Cluster tagged cells into coarse-level boxes
+  ClusterList clist(pts.data(), static_cast<Long>(pts.size()));
+  clist.chop(grid_eff);
+  BoxList coarse_bl = clist.boxList();
+  coarse_bl.intersect(coarse_domain);
+  coarse_bl.simplify();
+
+  // Refine coarse-level boxes to fine-level index space
+  BoxList fine_bl;
+  for (Box b : coarse_bl) {
+    fine_bl.push_back(b.refine(ref_ratio_lev));
+  }
+  fine_bl.simplify();
+
+  BoxArray ba(fine_bl);
+  ba.maxSize(max_grid_size);
+  return ba;
+}
+
 int
 main(int argc, char* argv[])
 {
@@ -332,20 +516,21 @@ main(int argc, char* argv[])
       print_usage(argc, argv);
     }
 
-    // Read parameters
     ParmParse pp;
+    ParmParse ppamr("amr");
+    ParmParse ppgeom("geometry");
 
-    // Geometry parms
+    // Geometry: number of cells on level 0
     Vector<int> n_cell(AMREX_SPACEDIM);
-    pp.getarr("amr.n_cell", n_cell, 0, AMREX_SPACEDIM);
+    ppamr.getarr("n_cell", n_cell, 0, AMREX_SPACEDIM);
 
-    // Domain parms
+    // Domain bounds
     RealBox real_box;
     Vector<Real> pp_prob_x(AMREX_SPACEDIM, 0.0);
-    pp.getarr("geometry.prob_lo", pp_prob_x, 0, AMREX_SPACEDIM);
+    ppgeom.getarr("prob_lo", pp_prob_x, 0, AMREX_SPACEDIM);
     GpuArray<Real, AMREX_SPACEDIM> prob_lo = {
       AMREX_D_DECL(pp_prob_x[0], pp_prob_x[1], pp_prob_x[2])};
-    pp.getarr("geometry.prob_hi", pp_prob_x, 0, AMREX_SPACEDIM);
+    ppgeom.getarr("prob_hi", pp_prob_x, 0, AMREX_SPACEDIM);
     GpuArray<Real, AMREX_SPACEDIM> prob_hi = {
       AMREX_D_DECL(pp_prob_x[0], pp_prob_x[1], pp_prob_x[2])};
 
@@ -356,39 +541,104 @@ main(int argc, char* argv[])
 
     // Periodicity
     IntVect pp_is_per;
-    pp.getarr("geometry.is_periodic", pp_is_per);
+    ppgeom.getarr("is_periodic", pp_is_per);
     Array<int, AMREX_SPACEDIM> is_per = {
       AMREX_D_DECL(pp_is_per[0], pp_is_per[1], pp_is_per[2])};
 
-    // Coordinate system
+    // Coordinate system (only Cartesian supported)
     int coord = 0;
-    pp.query("geometry.coord_sys", coord);
-
-    // Only cartesian supported
+    ppgeom.query("coord_sys", coord);
     AMREX_ALWAYS_ASSERT(coord == 0);
 
-    // Create geometry
+    // Level-0 geometry
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
     IntVect domain_hi(
       AMREX_D_DECL(n_cell[0] - 1, n_cell[1] - 1, n_cell[2] - 1));
     Box domain(domain_lo, domain_hi);
+    Geometry geom0(domain, real_box, coord, is_per);
 
-    Geometry geom(domain, real_box, coord, is_per);
+    // --- AMR parameters ---
+    int max_level = 0;
+    ppamr.query("max_level", max_level);
+    int Nlev = max_level + 1;
 
-    // Get cell size
-    const auto dx = geom.CellSizeArray();
+    Vector<int> ref_ratio(std::max(max_level, 1), 2);
+    if (ppamr.countval("ref_ratio") > 0) {
+      Vector<int> rr;
+      ppamr.getarr("ref_ratio", rr);
+      for (int lev = 0; lev < max_level; ++lev) {
+        ref_ratio[lev] = (lev < static_cast<int>(rr.size())) ? rr[lev] : rr.back();
+      }
+    }
 
-    // Create BoxArray and DistributionMapping
-    BoxArray ba(domain);
+    Real grid_eff = 0.7;
+    ppamr.query("grid_eff", grid_eff);
 
-    // Distribute domain
+    int blocking_factor = 8;
+    ppamr.query("blocking_factor", blocking_factor);
+
+    Vector<int> n_error_buf(std::max(max_level, 1), 1);
+    if (ppamr.countval("n_error_buf") > 0) {
+      Vector<int> neb;
+      ppamr.getarr("n_error_buf", neb);
+      for (int lev = 0; lev < max_level; ++lev) {
+        n_error_buf[lev] =
+          (lev < static_cast<int>(neb.size())) ? neb[lev] : neb.back();
+      }
+    }
+
+    // Refinement indicators
+    Vector<RefinementRegion> regions;
+    {
+      int n_ind = ppamr.countval("refinement_indicators");
+      if (n_ind > 0) {
+        Vector<std::string> ind_names(n_ind);
+        ppamr.getarr("refinement_indicators", ind_names);
+        regions.resize(n_ind);
+        for (int i = 0; i < n_ind; ++i) {
+          RefinementRegion& reg = regions[i];
+          reg.name = ind_names[i];
+          reg.max_level = max_level;
+
+          ParmParse ppi("amr." + ind_names[i]);
+          ppi.query("max_level", reg.max_level);
+
+          if (ppi.countval("in_box_lo") > 0) {
+            reg.type = RefinementType::InBox;
+            Vector<Real> blo(AMREX_SPACEDIM), bhi(AMREX_SPACEDIM);
+            ppi.getarr("in_box_lo", blo, 0, AMREX_SPACEDIM);
+            ppi.getarr("in_box_hi", bhi, 0, AMREX_SPACEDIM);
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+              reg.lo[d] = blo[d];
+              reg.hi[d] = bhi[d];
+            }
+          } else if (ppi.countval("value_greater") > 0) {
+            reg.type = RefinementType::ValueGreater;
+            ppi.get("value_greater", reg.threshold);
+            ppi.get("field_name", reg.field_name);
+          } else if (ppi.countval("value_less") > 0) {
+            reg.type = RefinementType::ValueLess;
+            ppi.get("value_less", reg.threshold);
+            ppi.get("field_name", reg.field_name);
+          } else if (ppi.countval("adjacent_difference_greater") > 0) {
+            reg.type = RefinementType::AdjacentDiffGreater;
+            ppi.get("adjacent_difference_greater", reg.threshold);
+            ppi.get("field_name", reg.field_name);
+          } else {
+            amrex::Abort(
+              "Refinement indicator '" + ind_names[i] +
+              "' has no recognized criterion (in_box_lo, value_greater, "
+              "value_less, or adjacent_difference_greater)");
+          }
+        }
+      }
+    }
+
+    // Grid decomposition parameters
     int max_grid_size = 32;
-    pp.query("amr.max_grid_size", max_grid_size);
-    ba.maxSize(max_grid_size);
-    int ngrow = 0; // Ghost cells
-    pp.query("amr.ngrow", ngrow);
-
-    DistributionMapping dm(ba);
+    ppamr.query("max_grid_size", max_grid_size);
+    int ngrow = 0;
+    ppamr.query("ngrow", ngrow);
 
     // Parse field configurations
     int ncomp = pp.countval("field.names");
@@ -448,7 +698,7 @@ main(int argc, char* argv[])
         case FieldType::CircleSmooth: {
           Vector<Real> pp_center(AMREX_SPACEDIM, 0.0);
           ppf.queryarr("center", pp_center);
-          for (int dim = 0; dim < pp_center.size(); ++dim) {
+          for (int dim = 0; dim < static_cast<int>(pp_center.size()); ++dim) {
             config.center[dim] = pp_center[dim];
           }
           ppf.query("radius", config.radius);
@@ -464,7 +714,7 @@ main(int argc, char* argv[])
         case FieldType::RingSmooth: {
           Vector<Real> pp_center(AMREX_SPACEDIM, 0.0);
           ppf.queryarr("center", pp_center);
-          for (int dim = 0; dim < pp_center.size(); ++dim) {
+          for (int dim = 0; dim < static_cast<int>(pp_center.size()); ++dim) {
             config.center[dim] = pp_center[dim];
           }
           ppf.query("radius_inner", config.radius_inner);
@@ -480,12 +730,12 @@ main(int argc, char* argv[])
         case FieldType::Sine: {
           Vector<Real> pp_frequency(AMREX_SPACEDIM, 0.0);
           ppf.queryarr("frequency", pp_frequency);
-          for (int dim = 0; dim < pp_frequency.size(); ++dim) {
+          for (int dim = 0; dim < static_cast<int>(pp_frequency.size()); ++dim) {
             config.frequency[dim] = pp_frequency[dim];
           }
           Vector<Real> pp_phase(AMREX_SPACEDIM, 0.0);
           ppf.queryarr("phase", pp_phase);
-          for (int dim = 0; dim < pp_phase.size(); ++dim) {
+          for (int dim = 0; dim < static_cast<int>(pp_phase.size()); ++dim) {
             config.phase[dim] = pp_phase[dim];
           }
           ppf.query("amplitude", config.amplitude);
@@ -498,36 +748,93 @@ main(int argc, char* argv[])
       Abort("No fields specified...");
     }
 
-    // Create MultiFab
-    MultiFab mf(ba, dm, ncomp, ngrow);
+    // Resolve field_comp for value-based refinement indicators
+    for (auto& reg : regions) {
+      if (reg.type != RefinementType::InBox) {
+        auto it =
+          std::find(field_names.begin(), field_names.end(), reg.field_name);
+        if (it == field_names.end()) {
+          amrex::Abort(
+            "Refinement indicator '" + reg.name +
+            "' references unknown field '" + reg.field_name + "'");
+        }
+        reg.field_comp = static_cast<int>(it - field_names.begin());
+      }
+    }
 
-    // Fill MultiFab with field data
-    for (MFIter mfi(mf); mfi.isValid(); ++mfi) {
-      const Box& box = mfi.validbox();
-      auto const& fab = mf.array(mfi);
+    // Build level-0 data structures
+    Vector<Geometry> geoms(Nlev);
+    Vector<BoxArray> grids(Nlev);
+    Vector<DistributionMapping> dmaps(Nlev);
+    Vector<MultiFab> mfs(Nlev);
 
-      // Copy configs to device-accessible memory
+    geoms[0] = geom0;
+    grids[0] = BoxArray(domain);
+    grids[0].maxSize(max_grid_size);
+    dmaps[0] = DistributionMapping(grids[0]);
+    mfs[0].define(grids[0], dmaps[0], ncomp, ngrow);
+
+    // Lambda to fill one level analytically
+    auto fillLevel = [&](int lev) {
+      const auto lev_dx      = geoms[lev].CellSizeArray();
+      const auto lev_prob_lo = geoms[lev].ProbLoArray();
+
       Gpu::DeviceVector<FieldConfig> d_configs(ncomp);
       Gpu::copyAsync(
         Gpu::hostToDevice, field_configs.begin(), field_configs.end(),
         d_configs.begin());
       Gpu::streamSynchronize();
-
       FieldConfig* p_configs = d_configs.data();
 
-      amrex::ParallelFor(
-        box, ncomp, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) {
-          // Get physical coordinates at cell center
-          Real x = prob_lo[0] + (i + 0.5) * dx[0];
-          Real y = prob_lo[1] + (j + 0.5) * dx[1];
-#if AMREX_SPACEDIM == 3
-          Real z = prob_lo[2] + (k + 0.5) * dx[2];
-#else
-                Real z = 0.0;
-#endif
+      for (MFIter mfi(mfs[lev]); mfi.isValid(); ++mfi) {
+        const Box& box = mfi.validbox();
+        auto const& fab = mfs[lev].array(mfi);
 
-          fab(i, j, k, n) = evaluateField(p_configs[n], x, y, z, dx, prob_lo);
-        });
+        amrex::ParallelFor(
+          box, ncomp, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) {
+            Real x = lev_prob_lo[0] + (i + 0.5) * lev_dx[0];
+            Real y = lev_prob_lo[1] + (j + 0.5) * lev_dx[1];
+#if AMREX_SPACEDIM == 3
+            Real z = lev_prob_lo[2] + (k + 0.5) * lev_dx[2];
+#else
+            Real z = 0.0;
+#endif
+            fab(i, j, k, n) =
+              evaluateField(p_configs[n], x, y, z, lev_dx, lev_prob_lo);
+          });
+      }
+    };
+
+    // Fill level 0 first (needed before tagging finer levels)
+    fillLevel(0);
+
+    // Build and fill fine levels
+    for (int lev = 1; lev < Nlev; ++lev) {
+      geoms[lev] = amrex::refine(geoms[lev - 1], ref_ratio[lev - 1]);
+
+      BoxArray fine_ba = buildFineBoxArray(
+        lev, geoms[lev - 1], grids[lev - 1], dmaps[lev - 1], regions,
+        field_configs.data(), ref_ratio[lev - 1], n_error_buf[lev - 1],
+        grid_eff, blocking_factor, max_grid_size);
+
+      if (fine_ba.empty()) {
+        amrex::Print() << "Warning: no tagged cells at level " << lev
+                       << " — truncating to level " << lev - 1 << "\n";
+        Nlev = lev;
+        geoms.resize(Nlev);
+        grids.resize(Nlev);
+        dmaps.resize(Nlev);
+        mfs.resize(Nlev);
+        break;
+      }
+
+      grids[lev] = fine_ba;
+      dmaps[lev] = DistributionMapping(grids[lev]);
+      mfs[lev].define(grids[lev], dmaps[lev], ncomp, ngrow);
+
+      amrex::Print() << "Level " << lev << ": " << grids[lev].size()
+                     << " boxes, " << grids[lev].numPts() << " cells\n";
+      fillLevel(lev);
     }
 
     // Variable names for plotfile
@@ -536,11 +843,18 @@ main(int argc, char* argv[])
       varnames[n] = field_names[n];
     }
 
-    // Write plot file
+    // Write multilevel plot file
     std::string plotfile_name = "pltTestFile";
     pp.query("plotfile_name", plotfile_name);
 
-    WriteSingleLevelPlotfile(plotfile_name, mf, varnames, geom, 0.0, 0);
+    Vector<int> isteps(Nlev, 0);
+    Vector<IntVect> refRatios(Nlev - 1);
+    for (int lev = 0; lev < Nlev - 1; ++lev) {
+      refRatios[lev] = IntVect(ref_ratio[lev]);
+    }
+    amrex::WriteMultiLevelPlotfile(
+      plotfile_name, Nlev, GetVecOfConstPtrs(mfs), varnames, geoms, 0.0,
+      isteps, refRatios);
 
     amrex::Print() << "Plotfile created: " << plotfile_name << "\n";
   }

--- a/Tests/generateTestPlt/TESTING.md
+++ b/Tests/generateTestPlt/TESTING.md
@@ -63,6 +63,15 @@ This addresses the second gap reported in issue #57: variable names containing `
 | err3 | `gen_err3_bad_refname.inp`  | Tool aborts when a refinement indicator references a non-existent field |
 | err4 | `gen_err4_no_criterion.inp` | Tool aborts when a refinement indicator has no recognised criterion key |
 
+### Phase 8 — Cylindrical coordinate system
+
+| Test | Input | What is checked |
+|------|-------|-----------------|
+| T14 | `gen_t14_cylinder.inp` | `cylinder_step` on all three axes and `cylinder_smooth` each produce range [0, 1] (3D serial) |
+| T15 | `gen_t15_rz.inp` | `geometry.coord_sys = 1` accepted; Header records `spacedim=2` and `coord_sys=1`, matching PeleLMeX 2D RZ output (**2D serial** binary required) |
+
+T14 uses 3D Cartesian coordinates and exercises `cylinder_step`/`cylinder_smooth` (infinite cylinder defined by radial distance from an axis line).  T15 requires the 2D binary (`generateTestPlt2d.gnu.ex`) and is skipped if that executable is absent.
+
 ## Python helpers
 
 | Script | Purpose |
@@ -70,3 +79,4 @@ This addresses the second gap reported in issue #57: variable names containing `
 | `check_plt_value.py`   | Assert every cell of a named variable equals an expected value (within tolerance) across all AMR levels |
 | `check_plt_range.py`   | Assert the observed min and max of a variable are within tolerance of expected values across all AMR levels |
 | `check_plt_nlevels.py` | Assert the number of `Level_N/` directories in a plotfile equals an expected count |
+| `check_plt_coord.py`   | Assert the `coord_sys` integer in the plotfile Header equals an expected value (0 = Cartesian, 1 = cylindrical/RZ) |

--- a/Tests/generateTestPlt/TESTING.md
+++ b/Tests/generateTestPlt/TESTING.md
@@ -1,0 +1,72 @@
+# generateTestPlt Test Suite
+
+Tests for `Src/generateTestPlt.cpp` — the synthetic AMReX plotfile generator.
+
+## Running
+
+```bash
+cd PeleAnalysis/Tests/generateTestPlt
+./run_tests.sh              # build + run
+./run_tests.sh --no-compile # skip build, reuse existing executable
+```
+
+Output artefacts (plotfiles, build logs) are written to `testrun/` and are not tracked by git.
+
+## Test matrix
+
+### Phase 2 — Structural (single-level)
+
+| Test | Input | What is checked |
+|------|-------|-----------------|
+| T1   | `gen_t1_all_fields.inp` | nComp=10 in Header; all 10 variable names present |
+
+### Phase 3 — Value correctness (single-level)
+
+| Test | Input | What is checked |
+|------|-------|-----------------|
+| T2 | `gen_t2_const.inp` | All cells of a `constant` field equal 7.0 |
+| T3 | `gen_t3_degenerate.inp` | Five degenerate configurations all produce 5.0 everywhere: direct constant, sphere far outside domain, ring with radii outside domain, double-plane with positions outside domain, sine with zero amplitude |
+| T4 | `gen_t4_planes.inp` | `plane_step` on x, y, z axes each produces range exactly [0, 1] |
+
+### Phase 4 — AMR structural
+
+| Test | Input | What is checked |
+|------|-------|-----------------|
+| T5  | `gen_t5_amr_inbox.inp`   | `in_box_lo/hi` criterion → 2 levels |
+| T6  | `gen_t6_amr_vgt.inp`     | `value_greater` criterion → 2 levels |
+| T7  | `gen_t7_amr_vlt.inp`     | `value_less` criterion → 2 levels |
+| T8  | `gen_t8_amr_adj.inp`     | `adjacent_difference_greater` criterion → 2 levels |
+| T9  | `gen_t9_amr_3level.inp`  | `max_level=2`, InBox → 3 levels |
+| T10 | `gen_t10_amr_refrat4.inp`| `ref_ratio=4`, InBox → 2 levels |
+| T11 | `gen_t11_amr_notags.inp` | Threshold above any field value → no tags → 1 level only (no Level_1 directory) |
+
+### Phase 5 — AMR value correctness
+
+| Test | Input | What is checked |
+|------|-------|-----------------|
+| T12 | `gen_t12_amr_const.inp` | `constant` field value 3.14 is identical on every AMR level |
+
+### Phase 6 — `output_name` (issue #57)
+
+| Test | Input | What is checked |
+|------|-------|-----------------|
+| T13 | `gen_t13_output_name.inp` | `myvar.output_name = Y(OH)` writes `Y(OH)` (not `myvar`) to the plotfile Header |
+
+This addresses the second gap reported in issue #57: variable names containing `/` or other ParmParse-reserved characters can now be produced by using a safe ParmParse prefix and overriding the plotfile name via `output_name`.
+
+### Phase 7 — Error handling
+
+| Test | Input | What is checked |
+|------|-------|-----------------|
+| err1 | `gen_err1_no_fields.inp`    | Tool aborts when `field.names` is missing |
+| err2 | `gen_err2_bad_type.inp`     | Tool aborts on unrecognised field type string |
+| err3 | `gen_err3_bad_refname.inp`  | Tool aborts when a refinement indicator references a non-existent field |
+| err4 | `gen_err4_no_criterion.inp` | Tool aborts when a refinement indicator has no recognised criterion key |
+
+## Python helpers
+
+| Script | Purpose |
+|--------|---------|
+| `check_plt_value.py`   | Assert every cell of a named variable equals an expected value (within tolerance) across all AMR levels |
+| `check_plt_range.py`   | Assert the observed min and max of a variable are within tolerance of expected values across all AMR levels |
+| `check_plt_nlevels.py` | Assert the number of `Level_N/` directories in a plotfile equals an expected count |

--- a/Tests/generateTestPlt/check_plt_coord.py
+++ b/Tests/generateTestPlt/check_plt_coord.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+check_plt_coord.py <plt_dir> <expected_coord_sys>
+
+Reads the AMReX plotfile Header and asserts that the coord_sys field equals
+<expected_coord_sys> (0 = Cartesian, 1 = cylindrical/RZ).
+
+The coord_sys integer appears in the Header after the per-level cell-size
+lines.  Formula: coord_line_idx = 11 + ncomp + finest_level (0-indexed).
+
+Exits 0 on success, 1 on mismatch or missing file.
+"""
+import sys
+import os
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("Usage: check_plt_coord.py <plt_dir> <expected_coord_sys>")
+
+    plt_dir = sys.argv[1]
+    expected = int(sys.argv[2])
+
+    hdr_path = os.path.join(plt_dir, "Header")
+    if not os.path.isfile(hdr_path):
+        print(f"Header not found: {hdr_path}")
+        sys.exit(1)
+
+    with open(hdr_path) as f:
+        lines = f.readlines()
+
+    ncomp = int(lines[1].strip())
+    finest_level = int(lines[4 + ncomp].strip())
+    coord_line_idx = 11 + ncomp + finest_level
+
+    if coord_line_idx >= len(lines):
+        print(f"Header too short (need line {coord_line_idx}, have {len(lines)})")
+        sys.exit(1)
+
+    coord_sys = int(lines[coord_line_idx].strip())
+
+    if coord_sys == expected:
+        print(f"coord_sys = {coord_sys} (as expected)")
+        sys.exit(0)
+    else:
+        print(f"coord_sys = {coord_sys}, expected {expected}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/generateTestPlt/check_plt_nlevels.py
+++ b/Tests/generateTestPlt/check_plt_nlevels.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+check_plt_nlevels.py <plt_dir> <expected_nlevels>
+
+Counts AMR levels (Level_N/ directories containing Cell_H) in <plt_dir>
+and compares with expected_nlevels.  Exits 0 on match, 1 on mismatch.
+"""
+import sys
+import os
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("Usage: check_plt_nlevels.py <plt_dir> <expected_nlevels>")
+
+    plt_dir = sys.argv[1]
+    expected = int(sys.argv[2])
+
+    if not os.path.isfile(os.path.join(plt_dir, "Header")):
+        sys.exit(f"Header not found in {plt_dir}")
+
+    actual = 0
+    while os.path.isdir(os.path.join(plt_dir, f"Level_{actual}")):
+        actual += 1
+
+    if actual == expected:
+        print(f"nlevels = {actual} (as expected)")
+        sys.exit(0)
+    else:
+        print(f"ERROR: expected {expected} levels, found {actual} in {plt_dir}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/generateTestPlt/check_plt_range.py
+++ b/Tests/generateTestPlt/check_plt_range.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+check_plt_range.py <plt_dir> <var_name> <expected_min> <expected_max> [<tol>]
+
+Reads every cell of <var_name> across all AMR levels and checks that the
+observed minimum ≈ expected_min and observed maximum ≈ expected_max within
+<tol> (default: 1e-10).  Exits 0 on success, 1 on failure.
+"""
+import sys
+import os
+import re
+import struct
+
+
+def parse_fab_hdr(line):
+    little = "8 7 6 5 4 3 2 1" in line
+    triples = re.findall(r"\((-?\d+),(-?\d+),(-?\d+)\)", line)
+    if triples:
+        lo = tuple(int(x) for x in triples[0])
+        hi = tuple(int(x) for x in triples[1])
+    else:
+        pairs = re.findall(r"\((-?\d+),(-?\d+)\)", line)
+        if len(pairs) < 2:
+            raise ValueError(f"Cannot parse box from FAB header: {line!r}")
+        lo = tuple(int(x) for x in pairs[0])
+        hi = tuple(int(x) for x in pairs[1])
+    ncomp = int(line.strip().split()[-1])
+    return ncomp, lo, hi, little
+
+
+def npts(lo, hi):
+    n = 1
+    for a, b in zip(lo, hi):
+        n *= b - a + 1
+    return n
+
+
+def main():
+    if len(sys.argv) < 5:
+        sys.exit(
+            "Usage: check_plt_range.py <plt_dir> <var_name>"
+            " <expected_min> <expected_max> [tol]"
+        )
+
+    plt_dir = sys.argv[1]
+    var_name = sys.argv[2]
+    expected_min = float(sys.argv[3])
+    expected_max = float(sys.argv[4])
+    tol = float(sys.argv[5]) if len(sys.argv) > 5 else 1e-10
+
+    hdr_path = os.path.join(plt_dir, "Header")
+    if not os.path.isfile(hdr_path):
+        sys.exit(f"Header not found: {hdr_path}")
+    with open(hdr_path) as f:
+        hdr_lines = f.readlines()
+
+    ncomp = int(hdr_lines[1].strip())
+    var_names = [hdr_lines[2 + i].strip() for i in range(ncomp)]
+    if var_name not in var_names:
+        sys.exit(
+            f"Variable '{var_name}' not in plotfile.  Available: {var_names}"
+        )
+    comp_idx = var_names.index(var_name)
+
+    obs_min = float("inf")
+    obs_max = float("-inf")
+    total_cells = 0
+
+    lev = 0
+    while True:
+        lev_dir = os.path.join(plt_dir, f"Level_{lev}")
+        if not os.path.isdir(lev_dir):
+            break
+
+        cell_h_path = os.path.join(lev_dir, "Cell_H")
+        with open(cell_h_path) as f:
+            cell_h = f.read()
+
+        for m in re.finditer(r"FabOnDisk:\s+(\S+)\s+(\d+)", cell_h):
+            fab_file = os.path.join(lev_dir, m.group(1))
+            byte_offset = int(m.group(2))
+            with open(fab_file, "rb") as f:
+                f.seek(byte_offset)
+                fab_hdr = f.readline().decode("latin-1")
+                _, lo, hi, little = parse_fab_hdr(fab_hdr)
+                n = npts(lo, hi)
+                endian = "<" if little else ">"
+                f.seek(comp_idx * n * 8, 1)
+                raw = f.read(n * 8)
+                if len(raw) < n * 8:
+                    sys.exit(
+                        f"Truncated FAB data in {fab_file} at offset {byte_offset}"
+                    )
+                vals = struct.unpack(endian + "d" * n, raw)
+            obs_min = min(obs_min, min(vals))
+            obs_max = max(obs_max, max(vals))
+            total_cells += n
+        lev += 1
+
+    if total_cells == 0:
+        sys.exit(f"No cells found in {plt_dir}")
+
+    ok = True
+    errs = []
+    if abs(obs_min - expected_min) > tol:
+        ok = False
+        errs.append(
+            f"min mismatch: got {obs_min:.6g}, expected {expected_min:.6g}"
+            f" (err={abs(obs_min-expected_min):.3e} > tol={tol})"
+        )
+    if abs(obs_max - expected_max) > tol:
+        ok = False
+        errs.append(
+            f"max mismatch: got {obs_max:.6g}, expected {expected_max:.6g}"
+            f" (err={abs(obs_max-expected_max):.3e} > tol={tol})"
+        )
+
+    summary = (
+        f"Checked {total_cells} cells: min={obs_min:.6g}, max={obs_max:.6g}"
+        f"  (expected [{expected_min}, {expected_max}] ±{tol})"
+    )
+    if errs:
+        print(summary + "  FAIL: " + "; ".join(errs))
+    else:
+        print(summary)
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/generateTestPlt/check_plt_value.py
+++ b/Tests/generateTestPlt/check_plt_value.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+check_plt_value.py <plt_dir> <var_name> <expected_value> [<tolerance>]
+
+Reads every cell of variable <var_name> across all AMR levels of an AMReX
+plotfile and asserts that each value equals <expected_value> within <tolerance>
+(default: 1e-10).  Exits 0 on success, 1 on failure, 2 on usage error.
+
+The plotfile must be in the standard AMReX binary FArrayBox format produced by
+WriteMultiLevelPlotfile.  Component-major storage is assumed (all values of
+component k before component k+1).
+"""
+import sys
+import os
+import re
+import struct
+import glob
+
+
+def parse_fab_hdr(line):
+    """Return (ncomp, lo, hi, little_endian) from an AMReX FAB header line.
+
+    AMReX encodes endianness as (8, (8 7 6 5 4 3 2 1)) for little-endian and
+    (8, (1 2 3 4 5 6 7 8)) for big-endian.
+    """
+    little = "8 7 6 5 4 3 2 1" in line
+    triples = re.findall(r"\((-?\d+),(-?\d+),(-?\d+)\)", line)
+    if triples:
+        lo = tuple(int(x) for x in triples[0])
+        hi = tuple(int(x) for x in triples[1])
+    else:
+        pairs = re.findall(r"\((-?\d+),(-?\d+)\)", line)
+        if len(pairs) < 2:
+            raise ValueError(f"Cannot parse box from FAB header: {line!r}")
+        lo = tuple(int(x) for x in pairs[0])
+        hi = tuple(int(x) for x in pairs[1])
+    ncomp = int(line.strip().split()[-1])
+    return ncomp, lo, hi, little
+
+
+def npts(lo, hi):
+    n = 1
+    for a, b in zip(lo, hi):
+        n *= b - a + 1
+    return n
+
+
+def main():
+    if len(sys.argv) < 4:
+        sys.exit(
+            "Usage: check_plt_value.py <plt_dir> <var_name> <expected> [tol]"
+        )
+
+    plt_dir = sys.argv[1]
+    var_name = sys.argv[2]
+    expected = float(sys.argv[3])
+    tol = float(sys.argv[4]) if len(sys.argv) > 4 else 1e-10
+
+    hdr_path = os.path.join(plt_dir, "Header")
+    if not os.path.isfile(hdr_path):
+        sys.exit(f"Header not found: {hdr_path}")
+    with open(hdr_path) as f:
+        hdr_lines = f.readlines()
+
+    ncomp = int(hdr_lines[1].strip())
+    var_names = [hdr_lines[2 + i].strip() for i in range(ncomp)]
+    if var_name not in var_names:
+        sys.exit(
+            f"Variable '{var_name}' not in plotfile.  Available: {var_names}"
+        )
+    comp_idx = var_names.index(var_name)
+
+    total_cells = 0
+    max_err = 0.0
+    lev = 0
+    while True:
+        lev_dir = os.path.join(plt_dir, f"Level_{lev}")
+        if not os.path.isdir(lev_dir):
+            break
+
+        cell_h_path = os.path.join(lev_dir, "Cell_H")
+        with open(cell_h_path) as f:
+            cell_h = f.read()
+
+        for m in re.finditer(r"FabOnDisk:\s+(\S+)\s+(\d+)", cell_h):
+            fab_file = os.path.join(lev_dir, m.group(1))
+            byte_offset = int(m.group(2))
+            with open(fab_file, "rb") as f:
+                f.seek(byte_offset)
+                fab_hdr = f.readline().decode("latin-1")
+                _, lo, hi, little = parse_fab_hdr(fab_hdr)
+                n = npts(lo, hi)
+                endian = "<" if little else ">"
+                f.seek(comp_idx * n * 8, 1)
+                raw = f.read(n * 8)
+                if len(raw) < n * 8:
+                    sys.exit(
+                        f"Truncated FAB data in {fab_file} at offset {byte_offset}"
+                    )
+                vals = struct.unpack(endian + "d" * n, raw)
+            err = max(abs(v - expected) for v in vals)
+            max_err = max(max_err, err)
+            total_cells += n
+        lev += 1
+
+    if total_cells == 0:
+        sys.exit(f"No cells found in {plt_dir}")
+
+    print(
+        f"Checked {total_cells} cells, var='{var_name}', "
+        f"expected={expected}, max_err={max_err:.3e}"
+    )
+    sys.exit(0 if max_err <= tol else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/generateTestPlt/gen_err1_no_fields.inp
+++ b/Tests/generateTestPlt/gen_err1_no_fields.inp
@@ -1,0 +1,7 @@
+# err1 — missing field.names; tool must abort
+amr.n_cell = 8 8 8
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_err1

--- a/Tests/generateTestPlt/gen_err2_bad_type.inp
+++ b/Tests/generateTestPlt/gen_err2_bad_type.inp
@@ -1,0 +1,10 @@
+# err2 — invalid field type string; tool must abort
+amr.n_cell = 8 8 8
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_err2
+
+field.names = myfield
+myfield.type = bad_type_xyz

--- a/Tests/generateTestPlt/gen_err3_bad_refname.inp
+++ b/Tests/generateTestPlt/gen_err3_bad_refname.inp
@@ -1,0 +1,16 @@
+# err3 — refinement indicator references a non-existent field; tool must abort
+amr.n_cell = 8 8 8
+amr.max_level = 1
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_err3
+
+amr.refinement_indicators = gthan
+amr.gthan.value_greater = 0.5
+amr.gthan.field_name = no_such_field
+
+field.names = myfield
+myfield.type = constant
+myfield.value = 1.0

--- a/Tests/generateTestPlt/gen_err4_no_criterion.inp
+++ b/Tests/generateTestPlt/gen_err4_no_criterion.inp
@@ -1,0 +1,14 @@
+# err4 — refinement indicator with no recognised criterion key; tool must abort
+amr.n_cell = 8 8 8
+amr.max_level = 1
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_err4
+
+amr.refinement_indicators = mybad
+
+field.names = myfield
+myfield.type = constant
+myfield.value = 1.0

--- a/Tests/generateTestPlt/gen_t10_amr_refrat4.inp
+++ b/Tests/generateTestPlt/gen_t10_amr_refrat4.inp
@@ -1,0 +1,21 @@
+# T10 — ref_ratio=4 InBox refinement → 2 levels
+amr.n_cell = 16 16 16
+amr.max_grid_size = 32
+amr.max_level = 1
+amr.ref_ratio = 4
+amr.grid_eff = 0.7
+amr.blocking_factor = 4
+amr.n_error_buf = 1
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t10_refrat4
+
+amr.refinement_indicators = mybox
+amr.mybox.in_box_lo = 0.3 0.3 0.3
+amr.mybox.in_box_hi = 0.7 0.7 0.7
+
+field.names = cfield
+cfield.type = constant
+cfield.value = 1.0

--- a/Tests/generateTestPlt/gen_t11_amr_notags.inp
+++ b/Tests/generateTestPlt/gen_t11_amr_notags.inp
@@ -1,0 +1,24 @@
+# T11 — threshold above any possible value → no cells tagged → 1 level only
+amr.n_cell = 16 16 16
+amr.max_grid_size = 16
+amr.max_level = 1
+amr.ref_ratio = 2
+amr.grid_eff = 0.7
+amr.blocking_factor = 4
+amr.n_error_buf = 1
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t11_notags
+
+amr.refinement_indicators = gthan
+amr.gthan.value_greater = 1000.0
+amr.gthan.field_name = sphere
+
+field.names = sphere
+sphere.type = sphere_step
+sphere.center = 0.5 0.5 0.5
+sphere.radius = 0.3
+sphere.value_inside = 1.0
+sphere.value_outside = 0.0

--- a/Tests/generateTestPlt/gen_t12_amr_const.inp
+++ b/Tests/generateTestPlt/gen_t12_amr_const.inp
@@ -1,0 +1,21 @@
+# T12 — constant field with InBox AMR; value must be identical on all levels
+amr.n_cell = 16 16 16
+amr.max_grid_size = 16
+amr.max_level = 1
+amr.ref_ratio = 2
+amr.grid_eff = 0.7
+amr.blocking_factor = 4
+amr.n_error_buf = 1
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t12_amr_const
+
+amr.refinement_indicators = mybox
+amr.mybox.in_box_lo = 0.2 0.2 0.2
+amr.mybox.in_box_hi = 0.8 0.8 0.8
+
+field.names = cfield
+cfield.type = constant
+cfield.value = 3.14

--- a/Tests/generateTestPlt/gen_t13_output_name.inp
+++ b/Tests/generateTestPlt/gen_t13_output_name.inp
@@ -1,0 +1,13 @@
+# T13 — output_name override; plotfile header must contain "Y(OH)", not "myvar"
+amr.n_cell = 8 8 8
+amr.max_grid_size = 8
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t13_output_name
+
+field.names = myvar
+myvar.type = constant
+myvar.value = 1.0
+myvar.output_name = Y(OH)

--- a/Tests/generateTestPlt/gen_t14_cylinder.inp
+++ b/Tests/generateTestPlt/gen_t14_cylinder.inp
@@ -1,0 +1,45 @@
+# T14 — cylinder_step and cylinder_smooth on all three axes
+# Domain [-1,1]^3, radius=0.5 centered on each axis through the origin.
+# Every cylinder intersects both inside and outside cells, so range must be [0,1].
+amr.n_cell = 16 16 16
+geometry.coord_sys = 0
+geometry.prob_lo = -1.0 -1.0 -1.0
+geometry.prob_hi =  1.0  1.0  1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t14_cylinder
+
+field.names = cyl_z cyl_y cyl_x cyl_z_sm
+
+# cylinder along z-axis: distance = sqrt((x-0)^2 + (y-0)^2)
+cyl_z.type = cylinder_step
+cyl_z.axis = 2
+cyl_z.center = 0.0 0.0 0.0
+cyl_z.radius = 0.5
+cyl_z.value_inside  = 1.0
+cyl_z.value_outside = 0.0
+
+# cylinder along y-axis: distance = sqrt((x-0)^2 + (z-0)^2)
+cyl_y.type = cylinder_step
+cyl_y.axis = 1
+cyl_y.center = 0.0 0.0 0.0
+cyl_y.radius = 0.5
+cyl_y.value_inside  = 1.0
+cyl_y.value_outside = 0.0
+
+# cylinder along x-axis: distance = sqrt((y-0)^2 + (z-0)^2)
+cyl_x.type = cylinder_step
+cyl_x.axis = 0
+cyl_x.center = 0.0 0.0 0.0
+cyl_x.radius = 0.5
+cyl_x.value_inside  = 1.0
+cyl_x.value_outside = 0.0
+
+# smooth cylinder along z: values must lie strictly between 0 and 1
+# (smooth_width=0.4 spans the boundary for the chosen radius and domain)
+cyl_z_sm.type = cylinder_smooth
+cyl_z_sm.axis = 2
+cyl_z_sm.center = 0.0 0.0 0.0
+cyl_z_sm.radius = 0.5
+cyl_z_sm.smooth_width = 0.4
+cyl_z_sm.value_inside  = 1.0
+cyl_z_sm.value_outside = 0.0

--- a/Tests/generateTestPlt/gen_t15_rz.inp
+++ b/Tests/generateTestPlt/gen_t15_rz.inp
@@ -1,0 +1,13 @@
+# T15 — cylindrical/RZ coordinate system (coord_sys=1), 2D build
+# Verifies that coord_sys=1 is accepted and the plotfile Header records spacedim=2
+# and coord_sys=1, matching the format produced by PeleLMeX 2D RZ simulations.
+amr.n_cell = 16 16
+geometry.coord_sys = 1
+geometry.prob_lo = 0.0 0.0
+geometry.prob_hi = 1.0 1.0
+geometry.is_periodic = 0 0
+plotfile_name = plt_t15_rz
+
+field.names = cfield
+cfield.type = constant
+cfield.value = 2.71828

--- a/Tests/generateTestPlt/gen_t1_all_fields.inp
+++ b/Tests/generateTestPlt/gen_t1_all_fields.inp
@@ -1,0 +1,75 @@
+# T1 — all 10 field types, single-level, structural check only
+amr.n_cell = 16 16 16
+amr.max_grid_size = 16
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t1_all_fields
+
+field.names = const_f plane_s plane_sm dplane_s dplane_sm circle_s circle_sm shell_s shell_sm sine_f
+
+const_f.type = constant
+const_f.value = 1.0
+
+plane_s.type = plane_step
+plane_s.axis = 0
+plane_s.position = 0.5
+plane_s.value_left = 1.0
+plane_s.value_right = 0.0
+
+plane_sm.type = plane_smooth
+plane_sm.axis = 1
+plane_sm.position = 0.5
+plane_sm.value_left = 2.0
+plane_sm.value_right = -1.0
+plane_sm.smooth_width = 0.2
+
+dplane_s.type = double_plane_step
+dplane_s.axis = 0
+dplane_s.position = 0.3
+dplane_s.position_second = 0.7
+dplane_s.value_inside = 1.0
+dplane_s.value_outside = 0.0
+
+dplane_sm.type = double_plane_smooth
+dplane_sm.axis = 1
+dplane_sm.position = 0.3
+dplane_sm.position_second = 0.7
+dplane_sm.value_inside = 2.0
+dplane_sm.value_outside = -1.0
+dplane_sm.smooth_width = 0.05
+
+circle_s.type = sphere_step
+circle_s.center = 0.5 0.5 0.5
+circle_s.radius = 0.25
+circle_s.value_inside = 10.0
+circle_s.value_outside = 0.0
+
+circle_sm.type = sphere_smooth
+circle_sm.center = 0.5 0.5 0.5
+circle_sm.radius = 0.25
+circle_sm.value_inside = 1.0
+circle_sm.value_outside = 0.0
+circle_sm.smooth_width = 0.1
+
+shell_s.type = spherical_shell_step
+shell_s.center = 0.5 0.5 0.5
+shell_s.radius_inner = 0.1
+shell_s.radius_outer = 0.3
+shell_s.value_inside = 10.0
+shell_s.value_outside = 0.0
+
+shell_sm.type = spherical_shell_smooth
+shell_sm.center = 0.5 0.5 0.5
+shell_sm.radius_inner = 0.1
+shell_sm.radius_outer = 0.3
+shell_sm.value_inside = 10.0
+shell_sm.value_outside = 0.0
+shell_sm.smooth_width = 0.05
+
+sine_f.type = sine
+sine_f.frequency = 1.0 1.0 1.0
+sine_f.phase = 0.0 0.0 0.0
+sine_f.amplitude = 1.0
+sine_f.offset = 0.0

--- a/Tests/generateTestPlt/gen_t2_const.inp
+++ b/Tests/generateTestPlt/gen_t2_const.inp
@@ -1,0 +1,12 @@
+# T2 — single constant field; every cell must equal 7.0
+amr.n_cell = 8 8 8
+amr.max_grid_size = 8
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t2_const
+
+field.names = myfield
+myfield.type = constant
+myfield.value = 7.0

--- a/Tests/generateTestPlt/gen_t3_degenerate.inp
+++ b/Tests/generateTestPlt/gen_t3_degenerate.inp
@@ -1,0 +1,43 @@
+# T3 — five degenerate configurations that all produce 5.0 everywhere
+amr.n_cell = 8 8 8
+amr.max_grid_size = 8
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t3_degen
+
+field.names = c1 c2 c3 c4 c5
+
+# constant directly
+c1.type = constant
+c1.value = 5.0
+
+# sphere centered far outside domain → all cells are "outside"
+c2.type = sphere_step
+c2.center = 100.0 100.0 100.0
+c2.radius = 1.0
+c2.value_inside = 99.0
+c2.value_outside = 5.0
+
+# ring with radii far outside domain → all cells are "outside"
+c3.type = ring_step
+c3.center = 0.5 0.5 0.5
+c3.radius_inner = 100.0
+c3.radius_outer = 200.0
+c3.value_inside = 99.0
+c3.value_outside = 5.0
+
+# double_plane with both planes outside [0,1] → all cells are "outside"
+c4.type = double_plane_step
+c4.axis = 0
+c4.position = 2.0
+c4.position_second = 3.0
+c4.value_inside = 99.0
+c4.value_outside = 5.0
+
+# sine with zero amplitude → offset only
+c5.type = sine
+c5.amplitude = 0.0
+c5.offset = 5.0
+c5.frequency = 1.0 1.0 1.0

--- a/Tests/generateTestPlt/gen_t4_planes.inp
+++ b/Tests/generateTestPlt/gen_t4_planes.inp
@@ -1,0 +1,28 @@
+# T4 — plane_step on all three axes; range must be [0, 1]
+amr.n_cell = 16 16 16
+amr.max_grid_size = 16
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t4_planes
+
+field.names = px py pz
+
+px.type = plane_step
+px.axis = 0
+px.position = 0.5
+px.value_left = 1.0
+px.value_right = 0.0
+
+py.type = plane_step
+py.axis = 1
+py.position = 0.5
+py.value_left = 1.0
+py.value_right = 0.0
+
+pz.type = plane_step
+pz.axis = 2
+pz.position = 0.5
+pz.value_left = 1.0
+pz.value_right = 0.0

--- a/Tests/generateTestPlt/gen_t5_amr_inbox.inp
+++ b/Tests/generateTestPlt/gen_t5_amr_inbox.inp
@@ -1,0 +1,21 @@
+# T5 — InBox refinement → 2 levels
+amr.n_cell = 16 16 16
+amr.max_grid_size = 16
+amr.max_level = 1
+amr.ref_ratio = 2
+amr.grid_eff = 0.7
+amr.blocking_factor = 4
+amr.n_error_buf = 1
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t5_inbox
+
+amr.refinement_indicators = mybox
+amr.mybox.in_box_lo = 0.2 0.2 0.2
+amr.mybox.in_box_hi = 0.8 0.8 0.8
+
+field.names = cfield
+cfield.type = constant
+cfield.value = 1.0

--- a/Tests/generateTestPlt/gen_t6_amr_vgt.inp
+++ b/Tests/generateTestPlt/gen_t6_amr_vgt.inp
@@ -1,0 +1,24 @@
+# T6 — value_greater refinement → 2 levels
+amr.n_cell = 16 16 16
+amr.max_grid_size = 16
+amr.max_level = 1
+amr.ref_ratio = 2
+amr.grid_eff = 0.7
+amr.blocking_factor = 4
+amr.n_error_buf = 1
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t6_vgt
+
+amr.refinement_indicators = gthan
+amr.gthan.value_greater = 5.0
+amr.gthan.field_name = sphere
+
+field.names = sphere
+sphere.type = sphere_step
+sphere.center = 0.5 0.5 0.5
+sphere.radius = 0.35
+sphere.value_inside = 10.0
+sphere.value_outside = 0.0

--- a/Tests/generateTestPlt/gen_t7_amr_vlt.inp
+++ b/Tests/generateTestPlt/gen_t7_amr_vlt.inp
@@ -1,0 +1,24 @@
+# T7 — value_less refinement → 2 levels
+amr.n_cell = 16 16 16
+amr.max_grid_size = 16
+amr.max_level = 1
+amr.ref_ratio = 2
+amr.grid_eff = 0.7
+amr.blocking_factor = 4
+amr.n_error_buf = 1
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t7_vlt
+
+amr.refinement_indicators = lthan
+amr.lthan.value_less = 5.0
+amr.lthan.field_name = sphere
+
+field.names = sphere
+sphere.type = sphere_step
+sphere.center = 0.5 0.5 0.5
+sphere.radius = 0.35
+sphere.value_inside = 10.0
+sphere.value_outside = 0.0

--- a/Tests/generateTestPlt/gen_t8_amr_adj.inp
+++ b/Tests/generateTestPlt/gen_t8_amr_adj.inp
@@ -1,0 +1,24 @@
+# T8 — adjacent_difference_greater refinement → 2 levels
+amr.n_cell = 16 16 16
+amr.max_grid_size = 16
+amr.max_level = 1
+amr.ref_ratio = 2
+amr.grid_eff = 0.7
+amr.blocking_factor = 4
+amr.n_error_buf = 1
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t8_adj
+
+amr.refinement_indicators = adjd
+amr.adjd.adjacent_difference_greater = 0.4
+amr.adjd.field_name = pstep
+
+field.names = pstep
+pstep.type = plane_step
+pstep.axis = 0
+pstep.position = 0.5
+pstep.value_left = 1.0
+pstep.value_right = 0.0

--- a/Tests/generateTestPlt/gen_t9_amr_3level.inp
+++ b/Tests/generateTestPlt/gen_t9_amr_3level.inp
@@ -1,0 +1,21 @@
+# T9 — 3-level InBox refinement → Level_0, Level_1, Level_2
+amr.n_cell = 32 32 32
+amr.max_grid_size = 32
+amr.max_level = 2
+amr.ref_ratio = 2 2
+amr.grid_eff = 0.7
+amr.blocking_factor = 4
+amr.n_error_buf = 1 1
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 1.0 1.0 1.0
+geometry.is_periodic = 0 0 0
+plotfile_name = plt_t9_3level
+
+amr.refinement_indicators = mybox
+amr.mybox.in_box_lo = 0.25 0.25 0.25
+amr.mybox.in_box_hi = 0.75 0.75 0.75
+
+field.names = cfield
+cfield.type = constant
+cfield.value = 1.0

--- a/Tests/generateTestPlt/run_tests.sh
+++ b/Tests/generateTestPlt/run_tests.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# run_tests.sh — build and run all generateTestPlt tests (3D serial)
+#
+# Usage:  ./run_tests.sh [--no-compile]
+#
+#   --no-compile   Skip the build step; assume executable already exists in Src/
+#
+# All test artefacts are written to Tests/generateTestPlt/testrun/ so the
+# source tree stays clean.  Python 3 is required for value-correctness and
+# level-count assertions.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$SCRIPT_DIR/../../Src"
+RUN_DIR="$SCRIPT_DIR/testrun"
+NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+COMPILE=true
+for arg in "$@"; do
+    case "$arg" in
+        --no-compile) COMPILE=false ;;
+        *) echo "Unknown argument: $arg"; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Terminal colours
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BOLD='\033[1m'; NC='\033[0m'
+
+PASS=0; FAIL=0
+
+section() { echo -e "\n${BOLD}=== $* ===${NC}"; }
+pass()    { echo -e "  ${GREEN}PASS${NC} $*"; ((PASS++)) || true; }
+fail()    { echo -e "  ${RED}FAIL${NC} $*"; ((FAIL++)) || true; }
+skip()    { echo -e "  ${YELLOW}SKIP${NC} $*"; }
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+check_file() {   # check_file <desc> <path>
+    if [[ -f "$2" ]]; then pass "$1"; else fail "$1 — missing: $2"; fi
+}
+
+check_dir() {    # check_dir <desc> <path>
+    if [[ -d "$2" ]]; then pass "$1"; else fail "$1 — missing dir: $2"; fi
+}
+
+no_dir() {       # no_dir <desc> <path>  — assert directory does NOT exist
+    if [[ ! -d "$2" ]]; then pass "$1"; else fail "$1 — unexpected dir: $2"; fi
+}
+
+# header_ncomp_ok <desc> <plt_dir> <expected_ncomp>
+header_ncomp_ok() {
+    local actual
+    actual=$(sed -n '2p' "$2/Header" 2>/dev/null || echo "MISSING")
+    if [[ "$actual" == "$3" ]]; then
+        pass "$1  (nComp = $actual)"
+    else
+        fail "$1  (expected nComp=$3, got '$actual')"
+    fi
+}
+
+# header_has_var <desc> <plt_dir> <var_name>
+header_has_var() {
+    if grep -qx "$3" "$2/Header" 2>/dev/null; then
+        pass "$1"
+    else
+        fail "$1 — '$3' not found in $2/Header"
+    fi
+}
+
+# header_no_var <desc> <plt_dir> <var_name>
+header_no_var() {
+    if grep -qx "$3" "$2/Header" 2>/dev/null; then
+        fail "$1 — '$3' unexpectedly found in $2/Header"
+    else
+        pass "$1"
+    fi
+}
+
+# check_plt_value <desc> <plt_dir> <var_name> <expected> [<tol>]
+check_plt_value() {
+    local desc="$1" plt_dir="$2" var_name="$3" expected="$4" tol="${5:-1e-10}"
+    if [[ ! -d "$plt_dir" ]]; then
+        fail "$desc — plotfile dir missing: $plt_dir"; return
+    fi
+    if ! command -v python3 &>/dev/null; then
+        skip "$desc — python3 not available"; return
+    fi
+    local out
+    if out=$(python3 "$SCRIPT_DIR/check_plt_value.py" \
+                "$plt_dir" "$var_name" "$expected" "$tol" 2>&1); then
+        pass "$desc  ($out)"
+    else
+        fail "$desc — $out"
+    fi
+}
+
+# check_plt_range <desc> <plt_dir> <var_name> <min> <max> [<tol>]
+check_plt_range() {
+    local desc="$1" plt_dir="$2" var_name="$3" exp_min="$4" exp_max="$5" tol="${6:-1e-10}"
+    if [[ ! -d "$plt_dir" ]]; then
+        fail "$desc — plotfile dir missing: $plt_dir"; return
+    fi
+    if ! command -v python3 &>/dev/null; then
+        skip "$desc — python3 not available"; return
+    fi
+    local out
+    if out=$(python3 "$SCRIPT_DIR/check_plt_range.py" \
+                "$plt_dir" "$var_name" "$exp_min" "$exp_max" "$tol" 2>&1); then
+        pass "$desc  ($out)"
+    else
+        fail "$desc — $out"
+    fi
+}
+
+# check_plt_nlevels <desc> <plt_dir> <expected_nlevels>
+check_plt_nlevels() {
+    local desc="$1" plt_dir="$2" expected="$3"
+    if [[ ! -d "$plt_dir" ]]; then
+        fail "$desc — plotfile dir missing: $plt_dir"; return
+    fi
+    if ! command -v python3 &>/dev/null; then
+        skip "$desc — python3 not available"; return
+    fi
+    local out
+    if out=$(python3 "$SCRIPT_DIR/check_plt_nlevels.py" \
+                "$plt_dir" "$expected" 2>&1); then
+        pass "$desc  ($out)"
+    else
+        fail "$desc — $out"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Executable discovery
+# ---------------------------------------------------------------------------
+find_exe() {   # find_exe <glob>
+    ls "$SRC_DIR"/$1 2>/dev/null | head -1 || true
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Build
+# ---------------------------------------------------------------------------
+section "Phase 1: Build"
+
+BUILD_OPTS="DEBUG=FALSE PRECISION=DOUBLE COMP=gnu -j$NPROC"
+
+if $COMPILE; then
+    echo "  Building generateTestPlt 3D..."
+    if make -C "$SRC_DIR" $BUILD_OPTS EBASE=generateTestPlt DIM=3 USE_MPI=FALSE \
+            > "$SCRIPT_DIR/build_genPlt3d.log" 2>&1; then
+        pass "generateTestPlt 3D built"
+    else
+        fail "generateTestPlt 3D build failed — see build_genPlt3d.log"
+    fi
+else
+    skip "Build skipped (--no-compile)"
+fi
+
+GEN3D=$(find_exe "generateTestPlt3d.gnu.ex")
+check_file "generateTestPlt 3D executable" "$GEN3D"
+
+if [[ -z "$GEN3D" ]]; then
+    echo -e "${RED}Cannot find executable — aborting test run.${NC}"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Structural tests (all 10 field types, single-level)
+# ---------------------------------------------------------------------------
+section "Phase 2: Structural tests"
+
+mkdir -p "$RUN_DIR"
+cd "$RUN_DIR"
+
+echo "  T1 — all 10 field types..."
+"$GEN3D" "$SCRIPT_DIR/gen_t1_all_fields.inp" > /dev/null 2>&1
+check_dir      "T1 plotfile dir"              "plt_t1_all_fields"
+check_file     "T1 Header"                    "plt_t1_all_fields/Header"
+header_ncomp_ok "T1 nComp = 10"              "plt_t1_all_fields" 10
+header_has_var  "T1 header has const_f"      "plt_t1_all_fields" "const_f"
+header_has_var  "T1 header has plane_s"      "plt_t1_all_fields" "plane_s"
+header_has_var  "T1 header has plane_sm"     "plt_t1_all_fields" "plane_sm"
+header_has_var  "T1 header has dplane_s"     "plt_t1_all_fields" "dplane_s"
+header_has_var  "T1 header has dplane_sm"    "plt_t1_all_fields" "dplane_sm"
+header_has_var  "T1 header has circle_s"     "plt_t1_all_fields" "circle_s"
+header_has_var  "T1 header has circle_sm"    "plt_t1_all_fields" "circle_sm"
+header_has_var  "T1 header has shell_s"      "plt_t1_all_fields" "shell_s"
+header_has_var  "T1 header has shell_sm"     "plt_t1_all_fields" "shell_sm"
+header_has_var  "T1 header has sine_f"       "plt_t1_all_fields" "sine_f"
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Value correctness (single-level)
+# ---------------------------------------------------------------------------
+section "Phase 3: Value correctness"
+
+echo "  T2 — constant field = 7.0..."
+"$GEN3D" "$SCRIPT_DIR/gen_t2_const.inp" > /dev/null 2>&1
+check_plt_value "T2 all cells = 7.0" "plt_t2_const" "myfield" 7.0
+
+echo "  T3 — degenerate fields all = 5.0..."
+"$GEN3D" "$SCRIPT_DIR/gen_t3_degenerate.inp" > /dev/null 2>&1
+check_plt_value "T3 c1 constant = 5.0"          "plt_t3_degen" "c1" 5.0
+check_plt_value "T3 c2 sphere (outside) = 5.0"  "plt_t3_degen" "c2" 5.0
+check_plt_value "T3 c3 ring (outside) = 5.0"    "plt_t3_degen" "c3" 5.0
+check_plt_value "T3 c4 dplane (outside) = 5.0"  "plt_t3_degen" "c4" 5.0
+check_plt_value "T3 c5 sine (zero amp) = 5.0"   "plt_t3_degen" "c5" 5.0
+
+echo "  T4 — plane_step range [0, 1] on all three axes..."
+"$GEN3D" "$SCRIPT_DIR/gen_t4_planes.inp" > /dev/null 2>&1
+check_plt_range "T4 px range [0,1]" "plt_t4_planes" "px" 0.0 1.0
+check_plt_range "T4 py range [0,1]" "plt_t4_planes" "py" 0.0 1.0
+check_plt_range "T4 pz range [0,1]" "plt_t4_planes" "pz" 0.0 1.0
+
+# ---------------------------------------------------------------------------
+# Phase 4 — AMR structural tests
+# ---------------------------------------------------------------------------
+section "Phase 4: AMR structural tests"
+
+echo "  T5 — InBox → 2 levels..."
+"$GEN3D" "$SCRIPT_DIR/gen_t5_amr_inbox.inp" > /dev/null 2>&1
+check_plt_nlevels "T5 nlevels = 2" "plt_t5_inbox" 2
+
+echo "  T6 — value_greater → 2 levels..."
+"$GEN3D" "$SCRIPT_DIR/gen_t6_amr_vgt.inp" > /dev/null 2>&1
+check_plt_nlevels "T6 nlevels = 2" "plt_t6_vgt" 2
+
+echo "  T7 — value_less → 2 levels..."
+"$GEN3D" "$SCRIPT_DIR/gen_t7_amr_vlt.inp" > /dev/null 2>&1
+check_plt_nlevels "T7 nlevels = 2" "plt_t7_vlt" 2
+
+echo "  T8 — adjacent_difference_greater → 2 levels..."
+"$GEN3D" "$SCRIPT_DIR/gen_t8_amr_adj.inp" > /dev/null 2>&1
+check_plt_nlevels "T8 nlevels = 2" "plt_t8_adj" 2
+
+echo "  T9 — 3-level InBox..."
+"$GEN3D" "$SCRIPT_DIR/gen_t9_amr_3level.inp" > /dev/null 2>&1
+check_plt_nlevels "T9 nlevels = 3" "plt_t9_3level" 3
+
+echo "  T10 — ref_ratio=4 → 2 levels..."
+"$GEN3D" "$SCRIPT_DIR/gen_t10_amr_refrat4.inp" > /dev/null 2>&1
+check_plt_nlevels "T10 nlevels = 2" "plt_t10_refrat4" 2
+
+echo "  T11 — no tagged cells → 1 level (truncated)..."
+"$GEN3D" "$SCRIPT_DIR/gen_t11_amr_notags.inp" > /dev/null 2>&1
+check_plt_nlevels "T11 nlevels = 1" "plt_t11_notags" 1
+no_dir            "T11 no Level_1 dir" "plt_t11_notags/Level_1"
+
+# ---------------------------------------------------------------------------
+# Phase 5 — AMR value correctness
+# ---------------------------------------------------------------------------
+section "Phase 5: AMR value correctness"
+
+echo "  T12 — constant field = 3.14 on all AMR levels..."
+"$GEN3D" "$SCRIPT_DIR/gen_t12_amr_const.inp" > /dev/null 2>&1
+check_plt_value "T12 constant = 3.14 (all levels)" "plt_t12_amr_const" "cfield" 3.14
+
+# ---------------------------------------------------------------------------
+# Phase 6 — output_name (issue #57)
+# ---------------------------------------------------------------------------
+section "Phase 6: output_name (slash-in-variable-name support)"
+
+echo "  T13 — output_name = Y(OH) overrides ParmParse prefix..."
+"$GEN3D" "$SCRIPT_DIR/gen_t13_output_name.inp" > /dev/null 2>&1
+header_has_var "T13 header contains 'Y(OH)'"  "plt_t13_output_name" "Y(OH)"
+header_no_var  "T13 header does not contain 'myvar'" "plt_t13_output_name" "myvar"
+
+# ---------------------------------------------------------------------------
+# Phase 7 — Error handling
+# ---------------------------------------------------------------------------
+section "Phase 7: Error handling"
+
+echo "  err1 — no field.names → abort"
+if "$GEN3D" "$SCRIPT_DIR/gen_err1_no_fields.inp" > /dev/null 2>&1; then
+    fail "err1 no fields — expected abort, tool exited 0"
+else
+    pass "err1 no fields — aborted correctly"
+fi
+
+echo "  err2 — invalid field type → abort"
+if "$GEN3D" "$SCRIPT_DIR/gen_err2_bad_type.inp" > /dev/null 2>&1; then
+    fail "err2 bad type — expected abort, tool exited 0"
+else
+    pass "err2 bad type — aborted correctly"
+fi
+
+echo "  err3 — refinement indicator references unknown field → abort"
+if "$GEN3D" "$SCRIPT_DIR/gen_err3_bad_refname.inp" > /dev/null 2>&1; then
+    fail "err3 bad refname — expected abort, tool exited 0"
+else
+    pass "err3 bad refname — aborted correctly"
+fi
+
+echo "  err4 — refinement indicator with no criterion → abort"
+if "$GEN3D" "$SCRIPT_DIR/gen_err4_no_criterion.inp" > /dev/null 2>&1; then
+    fail "err4 no criterion — expected abort, tool exited 0"
+else
+    pass "err4 no criterion — aborted correctly"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+TOTAL=$((PASS + FAIL))
+echo ""
+echo -e "${BOLD}Results: ${GREEN}$PASS${NC}${BOLD}/$TOTAL passed${NC}"
+if (( FAIL > 0 )); then
+    echo -e "${RED}$FAIL test(s) failed.${NC}"
+    exit 1
+else
+    echo -e "${GREEN}All tests passed.${NC}"
+fi

--- a/Tests/generateTestPlt/run_tests.sh
+++ b/Tests/generateTestPlt/run_tests.sh
@@ -124,6 +124,24 @@ check_plt_range() {
     fi
 }
 
+# check_plt_coord <desc> <plt_dir> <expected_coord_sys>
+check_plt_coord() {
+    local desc="$1" plt_dir="$2" expected="$3"
+    if [[ ! -d "$plt_dir" ]]; then
+        fail "$desc — plotfile dir missing: $plt_dir"; return
+    fi
+    if ! command -v python3 &>/dev/null; then
+        skip "$desc — python3 not available"; return
+    fi
+    local out
+    if out=$(python3 "$SCRIPT_DIR/check_plt_coord.py" \
+                "$plt_dir" "$expected" 2>&1); then
+        pass "$desc  ($out)"
+    else
+        fail "$desc — $out"
+    fi
+}
+
 # check_plt_nlevels <desc> <plt_dir> <expected_nlevels>
 check_plt_nlevels() {
     local desc="$1" plt_dir="$2" expected="$3"
@@ -171,14 +189,23 @@ if $COMPILE; then
     else
         fail "generateTestPlt 3D MPI build failed — see build_genPlt3dmpi.log"
     fi
+    echo "  Building generateTestPlt 2D serial..."
+    if make -C "$SRC_DIR" $BUILD_OPTS EBASE=generateTestPlt DIM=2 USE_MPI=FALSE \
+            > "$SCRIPT_DIR/build_genPlt2d.log" 2>&1; then
+        pass "generateTestPlt 2D serial built"
+    else
+        fail "generateTestPlt 2D serial build failed — see build_genPlt2d.log"
+    fi
 else
     skip "Build skipped (--no-compile)"
 fi
 
 GEN3D=$(find_exe "generateTestPlt3d.gnu.ex")
 GEN3D_MPI=$(find_exe "generateTestPlt3d.gnu.MPI.ex")
+GEN2D=$(find_exe "generateTestPlt2d.gnu.ex")
 check_file "generateTestPlt 3D serial executable" "$GEN3D"
 check_file "generateTestPlt 3D MPI executable"    "$GEN3D_MPI"
+check_file "generateTestPlt 2D serial executable" "$GEN2D"
 
 if [[ -z "$GEN3D" ]]; then
     echo -e "${RED}Cannot find serial executable — aborting test run.${NC}"
@@ -328,9 +355,30 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Phase 8 — MPI tests
+# Phase 8 — Cylindrical coordinate system support
 # ---------------------------------------------------------------------------
-section "Phase 8: MPI tests"
+section "Phase 8: Cylindrical coordinate system"
+
+echo "  T14 — cylinder_step and cylinder_smooth on all three axes..."
+"$GEN3D" "$SCRIPT_DIR/gen_t14_cylinder.inp" > /dev/null 2>&1
+check_plt_range "T14 cyl_z range [0,1]"   "plt_t14_cylinder" "cyl_z"    0.0 1.0
+check_plt_range "T14 cyl_y range [0,1]"   "plt_t14_cylinder" "cyl_y"    0.0 1.0
+check_plt_range "T14 cyl_x range [0,1]"   "plt_t14_cylinder" "cyl_x"    0.0 1.0
+check_plt_range "T14 cyl_z_sm range (0,1)" "plt_t14_cylinder" "cyl_z_sm" 0.0 1.0
+
+echo "  T15 — coord_sys=1 (cylindrical/RZ), 2D build..."
+if [[ -z "$GEN2D" ]]; then
+    skip "T15 RZ coord_sys=1 (2D executable not found)"
+else
+    "$GEN2D" "$SCRIPT_DIR/gen_t15_rz.inp" > /dev/null 2>&1
+    check_plt_coord  "T15 Header coord_sys = 1" "plt_t15_rz" 1
+    check_plt_value  "T15 RZ constant = 2.71828" "plt_t15_rz" "cfield" 2.71828 1e-5
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 9 — MPI tests
+# ---------------------------------------------------------------------------
+section "Phase 9: MPI tests"
 
 if ! $MPI_AVAILABLE; then
     skip "All MPI tests (mpirun/mpiexec not found)"

--- a/Tests/generateTestPlt/run_tests.sh
+++ b/Tests/generateTestPlt/run_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# run_tests.sh — build and run all generateTestPlt tests (3D serial)
+# run_tests.sh — build and run all generateTestPlt tests (3D serial + MPI)
 #
 # Usage:  ./run_tests.sh [--no-compile]
 #
@@ -157,23 +157,41 @@ section "Phase 1: Build"
 BUILD_OPTS="DEBUG=FALSE PRECISION=DOUBLE COMP=gnu -j$NPROC"
 
 if $COMPILE; then
-    echo "  Building generateTestPlt 3D..."
+    echo "  Building generateTestPlt 3D serial..."
     if make -C "$SRC_DIR" $BUILD_OPTS EBASE=generateTestPlt DIM=3 USE_MPI=FALSE \
             > "$SCRIPT_DIR/build_genPlt3d.log" 2>&1; then
-        pass "generateTestPlt 3D built"
+        pass "generateTestPlt 3D serial built"
     else
-        fail "generateTestPlt 3D build failed — see build_genPlt3d.log"
+        fail "generateTestPlt 3D serial build failed — see build_genPlt3d.log"
+    fi
+    echo "  Building generateTestPlt 3D MPI..."
+    if make -C "$SRC_DIR" $BUILD_OPTS EBASE=generateTestPlt DIM=3 USE_MPI=TRUE \
+            > "$SCRIPT_DIR/build_genPlt3dmpi.log" 2>&1; then
+        pass "generateTestPlt 3D MPI built"
+    else
+        fail "generateTestPlt 3D MPI build failed — see build_genPlt3dmpi.log"
     fi
 else
     skip "Build skipped (--no-compile)"
 fi
 
 GEN3D=$(find_exe "generateTestPlt3d.gnu.ex")
-check_file "generateTestPlt 3D executable" "$GEN3D"
+GEN3D_MPI=$(find_exe "generateTestPlt3d.gnu.MPI.ex")
+check_file "generateTestPlt 3D serial executable" "$GEN3D"
+check_file "generateTestPlt 3D MPI executable"    "$GEN3D_MPI"
 
 if [[ -z "$GEN3D" ]]; then
-    echo -e "${RED}Cannot find executable — aborting test run.${NC}"
+    echo -e "${RED}Cannot find serial executable — aborting test run.${NC}"
     exit 1
+fi
+
+if command -v mpirun &>/dev/null; then
+    MPI_AVAILABLE=true; MPI_CMD=mpirun
+elif command -v mpiexec &>/dev/null; then
+    MPI_AVAILABLE=true; MPI_CMD=mpiexec
+else
+    MPI_AVAILABLE=false
+    skip "mpirun/mpiexec not found — MPI tests will be skipped"
 fi
 
 # ---------------------------------------------------------------------------
@@ -307,6 +325,98 @@ if "$GEN3D" "$SCRIPT_DIR/gen_err4_no_criterion.inp" > /dev/null 2>&1; then
     fail "err4 no criterion — expected abort, tool exited 0"
 else
     pass "err4 no criterion — aborted correctly"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 8 — MPI tests
+# ---------------------------------------------------------------------------
+section "Phase 8: MPI tests"
+
+if ! $MPI_AVAILABLE; then
+    skip "All MPI tests (mpirun/mpiexec not found)"
+elif [[ -z "$GEN3D_MPI" ]]; then
+    skip "All MPI tests (generateTestPlt MPI executable not found)"
+else
+    # amr.max_grid_size=4 ensures ≥8 boxes on every grid size used here,
+    # so all 4 ranks receive work and no MPI collective deadlocks.
+    MPI_GS="amr.max_grid_size=4"
+
+    # constant field: every cell must equal 7.0 regardless of rank count
+    for NP in 2 4; do
+        echo "  MPI-${NP}a — constant field, ${NP} ranks..."
+        $MPI_CMD -np $NP "$GEN3D_MPI" \
+            "$SCRIPT_DIR/gen_t2_const.inp" \
+            plotfile_name=plt_mpi${NP}_const $MPI_GS \
+            > /dev/null 2>&1 || true
+        check_plt_value "MPI-${NP}a constant = 7.0" "plt_mpi${NP}_const" "myfield" 7.0
+    done
+
+    # InBox AMR: 2 levels must appear on all rank counts
+    for NP in 2 4; do
+        echo "  MPI-${NP}b — InBox AMR, ${NP} ranks..."
+        $MPI_CMD -np $NP "$GEN3D_MPI" \
+            "$SCRIPT_DIR/gen_t5_amr_inbox.inp" \
+            plotfile_name=plt_mpi${NP}_inbox $MPI_GS \
+            > /dev/null 2>&1 || true
+        check_plt_nlevels "MPI-${NP}b nlevels = 2" "plt_mpi${NP}_inbox" 2
+    done
+
+    # InBox AMR: fewer boxes than ranks (max_grid_size default=16 → 1 box at level 0, 4 ranks)
+    echo "  MPI-4b2 — InBox AMR, 4 ranks, fewer boxes than ranks..."
+    $MPI_CMD -np 4 "$GEN3D_MPI" \
+        "$SCRIPT_DIR/gen_t5_amr_inbox.inp" \
+        plotfile_name=plt_mpi4_inbox_fewbox \
+        > /dev/null 2>&1 || true
+    check_plt_nlevels "MPI-4b2 nlevels = 2 (fewer boxes than ranks)" "plt_mpi4_inbox_fewbox" 2
+
+
+    # value_greater AMR: 2 levels, 4 ranks
+    echo "  MPI-4c — value_greater AMR, 4 ranks..."
+    $MPI_CMD -np 4 "$GEN3D_MPI" \
+        "$SCRIPT_DIR/gen_t6_amr_vgt.inp" \
+        plotfile_name=plt_mpi4_vgt $MPI_GS \
+        > /dev/null 2>&1 || true
+    check_plt_nlevels "MPI-4c vgt nlevels = 2" "plt_mpi4_vgt" 2
+
+    # value_less AMR: the boundary-cell fix must hold under MPI decomposition
+    echo "  MPI-4d — value_less AMR (boundary-cell fix), 4 ranks..."
+    $MPI_CMD -np 4 "$GEN3D_MPI" \
+        "$SCRIPT_DIR/gen_t7_amr_vlt.inp" \
+        plotfile_name=plt_mpi4_vlt $MPI_GS \
+        > /dev/null 2>&1 || true
+    check_plt_nlevels "MPI-4d vlt nlevels = 2" "plt_mpi4_vlt" 2
+
+    # adjacent_difference_greater AMR: 2 levels, 4 ranks
+    echo "  MPI-4e — adjacent_diff AMR, 4 ranks..."
+    $MPI_CMD -np 4 "$GEN3D_MPI" \
+        "$SCRIPT_DIR/gen_t8_amr_adj.inp" \
+        plotfile_name=plt_mpi4_adj $MPI_GS \
+        > /dev/null 2>&1 || true
+    check_plt_nlevels "MPI-4e adj nlevels = 2" "plt_mpi4_adj" 2
+
+    # 3-level AMR: all 3 levels present with 4 ranks
+    echo "  MPI-4f — 3-level InBox AMR, 4 ranks..."
+    $MPI_CMD -np 4 "$GEN3D_MPI" \
+        "$SCRIPT_DIR/gen_t9_amr_3level.inp" \
+        plotfile_name=plt_mpi4_3level $MPI_GS \
+        > /dev/null 2>&1 || true
+    check_plt_nlevels "MPI-4f 3-level nlevels = 3" "plt_mpi4_3level" 3
+
+    # constant field at all AMR levels, 4 ranks
+    echo "  MPI-4g — constant field value across AMR levels, 4 ranks..."
+    $MPI_CMD -np 4 "$GEN3D_MPI" \
+        "$SCRIPT_DIR/gen_t12_amr_const.inp" \
+        plotfile_name=plt_mpi4_amr_const $MPI_GS \
+        > /dev/null 2>&1 || true
+    check_plt_value "MPI-4g constant = 3.14 (all levels)" "plt_mpi4_amr_const" "cfield" 3.14
+
+    # output_name: header must contain Y(OH) on 2 ranks
+    echo "  MPI-2h — output_name Y(OH), 2 ranks..."
+    $MPI_CMD -np 2 "$GEN3D_MPI" \
+        "$SCRIPT_DIR/gen_t13_output_name.inp" \
+        plotfile_name=plt_mpi2_output_name $MPI_GS \
+        > /dev/null 2>&1 || true
+    header_has_var "MPI-2h header contains 'Y(OH)'" "plt_mpi2_output_name" "Y(OH)"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

**Multi-level AMR generation**
`generateTestPlt` can now produce multilevel AMReX plotfiles. Refinement regions are specified by four criteria — bounding box (`in_box_lo/hi`), `value_greater`, `value_less`, and `adjacent_difference_greater` — with configurable `max_level`, `ref_ratio`, `blocking_factor`, `grid_eff`, and `n_error_buf`.

**AMR correctness fixes**
- *Out-of-bounds write:* `TagBoxArray` was constructed without ghost cells; `buffer()` would write past the end of each FAB whenever a tagged cell sat on a box boundary. Fixed by passing `n_error_buf` as the ghost-cell count, matching how AMReX's own `AmrCore` constructs `TagBoxArray` internally.
- *MPI deadlock:* `TagBoxArray::collate()` is gather-to-IO-proc — non-IO ranks held only a placeholder after the call, but all ranks then ran `ClusterList` independently, producing inconsistent `BoxArray`s that deadlocked subsequent MPI collectives. Fixed by mirroring the AMReX `AmrMesh::regrid` pattern: cluster only on the IO proc, then `BoxList::Bcast()` to all ranks.

**`output_name` support (closes #57)**
A field can now declare `myvar.output_name = Y(OH)` to write an arbitrary string — including ParmParse-reserved characters such as `/` and `(` — as the variable name in the plotfile Header, while `myvar` remains the valid ParmParse prefix.

**Cylindrical coordinate system support**
- `geometry.coord_sys = 1` (cylindrical/RZ) is now accepted for 2D builds; an `AMREX_ALWAYS_ASSERT` aborts with a clear message if `coord_sys=1` is set in a 3D build.
- New field types `cylinder_step` and `cylinder_smooth` measure radial distance from a configurable *axis line* (not a point), generating infinite cylindrical features for 3D Cartesian grids.

**Documentation and sample input**
- `generateTestPlt.rst` updated with multi-level AMR parameters, `coord_sys` semantics, the 2D-build restriction, and full parameter documentation for `cylinder_step`/`cylinder_smooth`.
- `generateTestPlt.inp` sample extended with inline-comment style and `cylinder_step`/`cylinder_smooth` examples.

## Test suite (60 tests, all passing)

| Phase | Tests | What is covered |
|-------|-------|-----------------|
| 2–3 (serial, single-level) | T1–T4 | Structural, value correctness for all field types |
| 4–5 (serial, multi-level) | T5–T12 | All 4 AMR criteria, 3-level, ref_ratio=4, no-tags, value correctness across levels |
| 6–7 (serial) | T13, err1–err4 | `output_name` round-trip, error handling |
| 8 (cylindrical) | T14, T15 | `cylinder_step`/`cylinder_smooth` range [0,1]; 2D RZ Header (`spacedim=2`, `coord_sys=1`) |
| 9 (MPI) | 11 tests | 2- and 4-rank runs, all AMR criteria, fewer-boxes-than-ranks edge case |


This will close #57 

=========== Fill your description above and fill the checklist below ===========


The steps outlined in CONTRIBUTING.md were checked. This includes:

**General**
- [x] C++ and Python code formatted
- [X] Updated the documentation
