### PR TITLE
Fix accumulation operator in curvature calculation

### DIFF
--- a/Src/curvature.cpp
+++ b/Src/curvature.cpp
@@ -799,7 +799,7 @@ main(int argc, char* argv[])
                   -gradUz(i, j, k, 1) * NzFab(i, j, k) * NyFab(i, j, k),
                   -gradUz(i, j, k, 2) * NzFab(i, j, k) *
                     NzFab(i, j, k))); //-nn:\nabla u
-              srFab(i, j, k) = AMREX_D_TERM(
+              srFab(i, j, k) += AMREX_D_TERM(
                 +gradUx(i, j, k, 0), +gradUy(i, j, k, 1),
                 +gradUz(i, j, k, 2)); // + \nabla \cdot u
             });


### PR DESCRIPTION
## Description

Restores the strain-rate accumulation fix from #64 on top of the `dev_Marwin` rewrite of `Src/curvature.cpp`. In the tangential strain-rate kernel the second term (`+ ∇·u`) was assigned with `=`, overwriting the `-nn:∇u` term computed just above it instead of accumulating onto it. This changes that line to `+=` so the full strain rate `-nn:∇u + ∇·u` is produced.

## Change

- **`Src/curvature.cpp`** — in the tangential strain-rate loop (the `do_strain` block), `srFab(i,j,k) = AMREX_D_TERM(+ gradUx…, + gradUy…, + gradUz…)` → `srFab(i,j,k) += …`, so the divergence term adds to the previously computed `-nn:∇u` rather than replacing it.

## Context

This PR is stacked: its base is `dev_Marwin` (the head of #8, "EB capabilities + CI"). The single line here is the merge-conflict resolution between #8 and `development` — #64 fixed the same bug on `development`, and #8 rewrote that kernel while carrying the old `=`. Merging this into `dev_Marwin` gives `dev_Marwin` the #64 fix and clears the `Src/curvature.cpp` conflict on #8.

## Effect

- Affects runs of the `curvature` tool with `do_strain` enabled (the reported `StrainRate_*` field). No effect on other outputs or when `do_strain` is off.

---

- [x] C++ and Python code formatted
- [x] Updated the documentation (if applicable)
