### PR TITLE
Apply clang-format across Src

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,94 @@
+# -*- mode: yaml -*-
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:   
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true 
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes: false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        2
+UseTab:          Never
+

--- a/Src/ModelSpecificAnalysis/plotQPD.cpp
+++ b/Src/ModelSpecificAnalysis/plotQPD.cpp
@@ -14,10 +14,8 @@ using namespace analysis_util;
 
 typedef std::list<Edge> EdgeList;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
@@ -27,7 +25,10 @@ print_usage (int,
 struct ELIcompare
 {
   // Order EL iters using the underlying edge
-  bool operator()(const EdgeList::const_iterator& lhs, const EdgeList::const_iterator& rhs) const {
+  bool operator()(
+    const EdgeList::const_iterator& lhs,
+    const EdgeList::const_iterator& rhs) const
+  {
     return *lhs < *rhs;
   }
 };
@@ -35,40 +36,40 @@ struct ELIcompare
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
       // ^^^ this calls ParallelDescriptor::EndParallel() and exit()
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
     int idXin = -1;
@@ -76,16 +77,18 @@ main (int   argc,
     int idRin = -1;
     Vector<std::string> spec_names = GetSpecNames();
     const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    const std::string spName= "X(" + spec_names[0] + ")";
+    const std::string spName = "X(" + spec_names[0] + ")";
     const std::string TName = "temp";
     const std::string RName = "density";
-    for (int i=0; i<plotVarNames.size(); ++i)
-    {
-      if (plotVarNames[i] == spName) idXin = i;
-      if (plotVarNames[i] == TName) idTin = i;
-      if (plotVarNames[i] == RName) idRin = i;
+    for (int i = 0; i < plotVarNames.size(); ++i) {
+      if (plotVarNames[i] == spName)
+        idXin = i;
+      if (plotVarNames[i] == TName)
+        idTin = i;
+      if (plotVarNames[i] == RName)
+        idRin = i;
     }
-    if (idXin<0 || idTin<0 || idRin<0)
+    if (idXin < 0 || idTin < 0 || idRin < 0)
       Print() << "Cannot find required data in pltfile" << std::endl;
 
     int nspecies = NumSpecies();
@@ -95,86 +98,83 @@ main (int   argc,
     Vector<int> destFillComps(nCompIn);
     const int idXlocal = 0; // Xs start here
     const int idTlocal = nspecies;
-    const int idRlocal = nspecies+1;
-    for (int i=0; i<nspecies; ++i)
-    {
+    const int idRlocal = nspecies + 1;
+    for (int i = 0; i < nspecies; ++i) {
       destFillComps[i] = idXlocal + i;
-      inNames[i] =  "X(" + spec_names[i] + ")";
+      inNames[i] = "X(" + spec_names[i] + ")";
     }
     destFillComps[idTlocal] = idTlocal;
     destFillComps[idRlocal] = idRlocal;
     inNames[idTlocal] = TName;
     inNames[idRlocal] = RName;
-    
-    Vector<Real> Qfsum(nreactions,0), Qrsum(nreactions,0);
 
-    auto rmap=GetReactionMap();
-    
+    Vector<Real> Qfsum(nreactions, 0), Qrsum(nreactions, 0);
+
+    auto rmap = GetReactionMap();
+
     const int nGrow = 0;
-    for (int lev=0; lev<Nlev; ++lev)
-    {
+    for (int lev = 0; lev < Nlev; ++lev) {
       const BoxArray ba = amrData.boxArray(lev);
       const DistributionMapping dm(ba);
-      MultiFab indata(ba,dm,nCompIn,nGrow);
+      MultiFab indata(ba, dm, nCompIn, nGrow);
 
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps);
+      amrData.FillVar(indata, lev, inNames, destFillComps);
       Print() << "Data has been read for level " << lev << std::endl;
 
-      MultiFab Qf(ba,dm,nreactions,nGrow);
-      MultiFab Qr(ba,dm,nreactions,nGrow);
+      MultiFab Qf(ba, dm, nreactions, nGrow);
+      MultiFab Qr(ba, dm, nreactions, nGrow);
 
-      // NOTE: 
+      // NOTE:
 #ifdef _OPENMP
       Abort("OMP threading currently broken");
-//#pragma omp parallel
+// #pragma omp parallel
 #endif
-      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
+      for (MFIter mfi(indata, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const Box& bx = mfi.tilebox();
         Array4<Real> const& inarr = indata.array(mfi);
-        //Array4<Real> const& Qarr = Q.array(mfi);
+        // Array4<Real> const& Qarr = Q.array(mfi);
         Array4<Real> const& Qfarr = Qf.array(mfi);
         Array4<Real> const& Qrarr = Qr.array(mfi);
 
-        AMREX_PARALLEL_FOR_3D ( bx, i, j, k,
-        {
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
           Real Xl[nspecies];
-          Real Tl = inarr(i,j,k,idTlocal);
-          Real Rl = inarr(i,j,k,idRlocal) * 1.e-3;
-          for (int n=0; n<nspecies; ++n) {
-            Xl[n] = inarr(i,j,k,idXlocal+n);
+          Real Tl = inarr(i, j, k, idTlocal);
+          Real Rl = inarr(i, j, k, idRlocal) * 1.e-3;
+          for (int n = 0; n < nspecies; ++n) {
+            Xl[n] = inarr(i, j, k, idXlocal + n);
           }
 
           Real Qf[nreactions];
           Real Qr[nreactions];
           Real Pcgs;
-          CKPX(Rl,Tl,Xl,Pcgs);
-          CKKFKR(Pcgs,Tl,Xl,Qf,Qr);
+          CKPX(Rl, Tl, Xl, Pcgs);
+          CKKFKR(Pcgs, Tl, Xl, Qf, Qr);
 
-          for (int n=0; n<nreactions; ++n) {
-            Qfarr(i,j,k,n) = Qf[n];
-            Qrarr(i,j,k,n) = Qr[n];
+          for (int n = 0; n < nreactions; ++n) {
+            Qfarr(i, j, k, n) = Qf[n];
+            Qrarr(i, j, k, n) = Qr[n];
           }
         });
-        
+
         // Zero out covered data
-        if (lev < finestLevel){
-          BoxArray baf = BoxArray(amrData.boxArray(lev)).coarsen(amrData.RefRatio()[lev]);
-          std::vector< std::pair<int,Box> > isects = baf.intersections(bx);               
-          for (int ii = 0; ii < isects.size(); ii++){
-            Qf[mfi].setVal(0,isects[ii].second,0,nreactions);
-            Qr[mfi].setVal(0,isects[ii].second,0,nreactions);
+        if (lev < finestLevel) {
+          BoxArray baf =
+            BoxArray(amrData.boxArray(lev)).coarsen(amrData.RefRatio()[lev]);
+          std::vector<std::pair<int, Box>> isects = baf.intersections(bx);
+          for (int ii = 0; ii < isects.size(); ii++) {
+            Qf[mfi].setVal(0, isects[ii].second, 0, nreactions);
+            Qr[mfi].setVal(0, isects[ii].second, 0, nreactions);
           }
         }
 
         // Increment volume-weighted sum of each reaction over all levels
         Real vol = 1;
-        for (int i=0; i<AMREX_SPACEDIM; ++i) {
+        for (int i = 0; i < AMREX_SPACEDIM; ++i) {
           vol *= amrData.ProbSize()[i] / amrData.ProbDomain()[lev].length(i);
         }
 
-        for (int i=0; i<nreactions; ++i) {
+        for (int i = 0; i < nreactions; ++i) {
           Qfsum[rmap[i]] += Qf[mfi].sum(i) * vol;
           Qrsum[rmap[i]] += Qr[mfi].sum(i) * vol;
         }
@@ -183,121 +183,126 @@ main (int   argc,
       Print() << "Derive finished for level " << lev << std::endl;
     }
 
-    //ParallelDescriptor::ReduceRealSum(Qsum.dataPtr(),nreactions,ParallelDescriptor::IOProcessorNumber());
-    ParallelDescriptor::ReduceRealSum(Qfsum.dataPtr(),nreactions,ParallelDescriptor::IOProcessorNumber());
-    ParallelDescriptor::ReduceRealSum(Qrsum.dataPtr(),nreactions,ParallelDescriptor::IOProcessorNumber());
+    // ParallelDescriptor::ReduceRealSum(Qsum.dataPtr(),nreactions,ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::ReduceRealSum(
+      Qfsum.dataPtr(), nreactions, ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::ReduceRealSum(
+      Qrsum.dataPtr(), nreactions, ParallelDescriptor::IOProcessorNumber());
 
-    std::string QPDatom="C"; pp.query("QPDatom",QPDatom);
-    std::string QPDlabel = plotFileName; pp.query("QPDlabel",QPDlabel);
-    std::string QPDfileName = plotFileName + "_QPD.dat"; pp.query("QPDfileName",QPDfileName);
-    
-    if (ParallelDescriptor::IOProcessor())
-    {
+    std::string QPDatom = "C";
+    pp.query("QPDatom", QPDatom);
+    std::string QPDlabel = plotFileName;
+    pp.query("QPDlabel", QPDlabel);
+    std::string QPDfileName = plotFileName + "_QPD.dat";
+    pp.query("QPDfileName", QPDfileName);
+
+    if (ParallelDescriptor::IOProcessor()) {
       std::ofstream osfr(QPDfileName.c_str());
       osfr << QPDlabel << std::endl;
-      for (int i=0; i<spec_names.size(); ++i)
+      for (int i = 0; i < spec_names.size(); ++i)
         osfr << spec_names[i] << " ";
       osfr << std::endl;
 
-      auto edges = getEdges(QPDatom,1,1);
-      std::cout<<"\n total edges "<<edges.size()<<std::endl;
+      auto edges = getEdges(QPDatom, 1, 1);
+      std::cout << "\n total edges " << edges.size() << std::endl;
       bool dump_edges = false;
-      pp.query("dump_edges",dump_edges);
+      pp.query("dump_edges", dump_edges);
       if (dump_edges) {
         for (auto eit : edges) {
           Print() << eit << std::endl;
         }
       }
 
-      std::map<EdgeList::const_iterator,Real,ELIcompare> Qf,Qr;
-      
+      std::map<EdgeList::const_iterator, Real, ELIcompare> Qf, Qr;
+
       Real normVal = 1;
-      for (EdgeList::const_iterator it = edges.begin(); it!=edges.end(); ++it)
-      {
-        const Vector<std::pair<int,Real> > RWL=it->rwl();
-        for (int i=0; i<RWL.size(); ++i)
-        {
-          //Note: Assumes that the edges are in terms of *mapped* reactions
-          Qf[it] += Qfsum[ RWL[i].first ]*RWL[i].second;
-          Qr[it] += Qrsum[ RWL[i].first ]*RWL[i].second;
+      for (EdgeList::const_iterator it = edges.begin(); it != edges.end();
+           ++it) {
+        const Vector<std::pair<int, Real>> RWL = it->rwl();
+        for (int i = 0; i < RWL.size(); ++i) {
+          // Note: Assumes that the edges are in terms of *mapped* reactions
+          Qf[it] += Qfsum[RWL[i].first] * RWL[i].second;
+          Qr[it] += Qrsum[RWL[i].first] * RWL[i].second;
         }
-        if (it->touchesSp("CH4") && it->touchesSp("CH3"))
-        {
-          normVal = 1./(Qf[it]-Qr[it]); // Normalize to CH4 destruction on CH4->CH3 edge
-          if (it->right()=="CH4")
+        if (it->touchesSp("CH4") && it->touchesSp("CH3")) {
+          normVal =
+            1. /
+            (Qf[it] - Qr[it]); // Normalize to CH4 destruction on CH4->CH3 edge
+          if (it->right() == "CH4")
             normVal *= -1;
         }
       }
       if (pp.countval("scaleNorm") > 0) {
         Real scaleNorm;
-        pp.get("scaleNorm",scaleNorm);
+        pp.get("scaleNorm", scaleNorm);
         normVal *= scaleNorm;
       }
       std::cout << "NormVal: " << normVal << std::endl;
 
-      for (EdgeList::const_iterator it = edges.begin(); it!=edges.end(); ++it)
-      {
-        if (normVal!=0)
-        {
+      for (EdgeList::const_iterator it = edges.begin(); it != edges.end();
+           ++it) {
+        if (normVal != 0) {
           Qf[it] *= normVal;
           Qr[it] *= normVal;
         }
-        osfr << it->left() << " " << it->right() << " " << Qf[it] << " " << -Qr[it] << '\n'; 
+        osfr << it->left() << " " << it->right() << " " << Qf[it] << " "
+             << -Qr[it] << '\n';
       }
 
       std::string fuelSpec;
       bool do_dump = false;
       if (pp.countval("fuelSpec") > 0) {
         do_dump = true;
-        pp.get("fuelSpec",fuelSpec);
+        pp.get("fuelSpec", fuelSpec);
       }
-      
+
       // Dump a subset of the edges to the screen
-      if (do_dump)
-      {
-        for (EdgeList::const_iterator it = edges.begin(); it!=edges.end(); ++it)
-        {
-          if (it->touchesSp(fuelSpec))
-          {
+      if (do_dump) {
+        for (EdgeList::const_iterator it = edges.begin(); it != edges.end();
+             ++it) {
+          if (it->touchesSp(fuelSpec)) {
             std::cout << *it << std::endl;
-            std::map<std::string,Real> edgeContrib;
-            int rSgn = ( it->left()==fuelSpec  ?  -1  :  +1);
-            const Vector<std::pair<int,Real> > RWL=it->rwl();
-            for (int i=0; i<RWL.size(); ++i) {
+            std::map<std::string, Real> edgeContrib;
+            int rSgn = (it->left() == fuelSpec ? -1 : +1);
+            const Vector<std::pair<int, Real>> RWL = it->rwl();
+            for (int i = 0; i < RWL.size(); ++i) {
               int rxn = RWL[i].first;
               Real wgt = RWL[i].second;
               auto specCoefs = specCoeffsInReactions(rxn);
 
               // Find name of reaction partner(s), NP = no partner
               int thisSgn;
-              for (int j=0; j<specCoefs.size(); ++j)
-              {
+              for (int j = 0; j < specCoefs.size(); ++j) {
                 if (specCoefs[j].first == fuelSpec)
                   thisSgn = specCoefs[j].second;
               }
               std::string partnerName = "";
-              for (int j=0; j<specCoefs.size(); ++j)
-              {
+              for (int j = 0; j < specCoefs.size(); ++j) {
                 const std::string& sp = specCoefs[j].first;
-                if (sp != fuelSpec  &&  thisSgn*specCoefs[j].second > 0)
-                  partnerName = ( partnerName != ""  ?  partnerName + "+" + sp : sp);
+                if (sp != fuelSpec && thisSgn * specCoefs[j].second > 0)
+                  partnerName =
+                    (partnerName != "" ? partnerName + "+" + sp : sp);
               }
-              if (partnerName=="")
-                partnerName="NP";
+              if (partnerName == "")
+                partnerName = "NP";
 
-              edgeContrib[partnerName] += wgt*((Qrsum[rxn])-Qrsum[rxn])*normVal;
+              edgeContrib[partnerName] +=
+                wgt * ((Qrsum[rxn]) - Qrsum[rxn]) * normVal;
             }
 
-            Real sump=0, sumn=0;
-            for (std::map<std::string,Real>::const_iterator cit=edgeContrib.begin(); cit!=edgeContrib.end(); ++cit)
-            {
-              std::cout << "   partner: " << cit->first << " " << cit->second << std::endl;
+            Real sump = 0, sumn = 0;
+            for (std::map<std::string, Real>::const_iterator cit =
+                   edgeContrib.begin();
+                 cit != edgeContrib.end(); ++cit) {
+              std::cout << "   partner: " << cit->first << " " << cit->second
+                        << std::endl;
               if (cit->second > 0.)
                 sump += cit->second;
               else
                 sumn += cit->second;
             }
-            std::cout << "     sum +ve,-ve: " << sump << " " << sumn << std::endl;
+            std::cout << "     sum +ve,-ve: " << sump << " " << sumn
+                      << std::endl;
           }
         }
       }

--- a/Src/ModelSpecificAnalysis/plotTYtoLe.cpp
+++ b/Src/ModelSpecificAnalysis/plotTYtoLe.cpp
@@ -19,10 +19,8 @@ pele::physics::PeleParams<pele::physics::transport::TransParm<
   pele::physics::PhysicsType::transport_type>>
   trans_parms;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
@@ -32,33 +30,33 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
       // ^^^ this calls ParallelDescriptor::EndParallel() and exit()
     }
@@ -67,41 +65,43 @@ main (int   argc,
     trans_parms.initialize();
 
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
     int idYin = -1;
     int idTin = -1;
     int idRin = -1;
     Vector<std::string> spec_names;
-    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(spec_names);
+    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
+      spec_names);
     const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    const std::string spName= "Y(" + spec_names[0] + ")";
+    const std::string spName = "Y(" + spec_names[0] + ")";
     const std::string TName = "temp";
     const std::string RName = "density";
-    for (int i=0; i<plotVarNames.size(); ++i)
-    {
-      if (plotVarNames[i] == spName) idYin = i;
-      if (plotVarNames[i] == TName)  idTin = i;
-      if (plotVarNames[i] == RName)  idRin = i;
+    for (int i = 0; i < plotVarNames.size(); ++i) {
+      if (plotVarNames[i] == spName)
+        idYin = i;
+      if (plotVarNames[i] == TName)
+        idTin = i;
+      if (plotVarNames[i] == RName)
+        idRin = i;
     }
-    if (idYin<0 || idTin<0 || idRin<0)
+    if (idYin < 0 || idTin < 0 || idRin < 0)
       Print() << "Cannot find required data in pltfile" << std::endl;
 
-    const int nCompIn  = NUM_SPECIES + 2;
-    const int idLeout   = 0;
+    const int nCompIn = NUM_SPECIES + 2;
+    const int idLeout = 0;
     const int nCompOut = idLeout + NUM_SPECIES;
 
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
-    const int idYlocal = 0; // Xs start here
-    const int idTlocal = NUM_SPECIES;   // T starts here
-    const int idRlocal = NUM_SPECIES+1; // R starts here
-    for (int i=0; i<NUM_SPECIES; ++i)
-    {
+    const int idYlocal = 0;               // Xs start here
+    const int idTlocal = NUM_SPECIES;     // T starts here
+    const int idRlocal = NUM_SPECIES + 1; // R starts here
+    for (int i = 0; i < NUM_SPECIES; ++i) {
       destFillComps[i] = idYlocal + i;
-      inNames[i] =  "Y(" + spec_names[i] + ")";
+      inNames[i] = "Y(" + spec_names[i] + ")";
       outNames[idLeout + i] = "Le(" + spec_names[i] + ")";
     }
     destFillComps[idTlocal] = idTlocal;
@@ -112,32 +112,28 @@ main (int   argc,
     Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     Vector<std::unique_ptr<MultiFab>> tempdata(Nlev);
     Vector<Geometry> geoms(Nlev);
-    amrex::RealBox real_box({AMREX_D_DECL(amrData.ProbLo()[0],
-                                          amrData.ProbLo()[1],
-                                          amrData.ProbLo()[2])},
-                            {AMREX_D_DECL(amrData.ProbHi()[0],
-                                          amrData.ProbHi()[1],
-                                          amrData.ProbHi()[2])});
+    amrex::RealBox real_box(
+      {AMREX_D_DECL(
+        amrData.ProbLo()[0], amrData.ProbLo()[1], amrData.ProbLo()[2])},
+      {AMREX_D_DECL(
+        amrData.ProbHi()[0], amrData.ProbHi()[1], amrData.ProbHi()[2])});
     amrex::Array<int, AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(1, 1, 1)};
-    geoms[0] = amrex::Geometry((amrData.ProbDomain())[0],
-                               real_box,
-                               amrData.CoordSys(),
-                               is_periodic);
+    geoms[0] = amrex::Geometry(
+      (amrData.ProbDomain())[0], real_box, amrData.CoordSys(), is_periodic);
     const int nGrow = 0;
 
-    for (int lev=0; lev<Nlev; ++lev)
-    {
+    for (int lev = 0; lev < Nlev; ++lev) {
       const BoxArray ba = amrData.boxArray(lev);
       const DistributionMapping dm(ba);
-      outdata[lev].reset(new MultiFab(ba,dm,nCompOut,nGrow));
-      tempdata[lev].reset(new MultiFab(ba,dm,2*NUM_SPECIES+3,nGrow));
-      if ( lev > 0 ) {
-         geoms[lev] = amrex::refine(geoms[lev - 1], 2);
+      outdata[lev].reset(new MultiFab(ba, dm, nCompOut, nGrow));
+      tempdata[lev].reset(new MultiFab(ba, dm, 2 * NUM_SPECIES + 3, nGrow));
+      if (lev > 0) {
+        geoms[lev] = amrex::refine(geoms[lev - 1], 2);
       }
-      MultiFab indata(ba,dm,nCompIn,nGrow);
+      MultiFab indata(ba, dm, nCompIn, nGrow);
 
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps);
+      amrData.FillVar(indata, lev, inNames, destFillComps);
       Print() << "Data has been read for level " << lev << std::endl;
 
       // Get the transport data pointer
@@ -150,34 +146,35 @@ main (int   argc,
            ++mfi) {
 
         const Box& bx = mfi.tilebox();
-        Array4<Real> const& Y_a = indata.array(mfi,idYlocal);
-        Array4<Real> const& T_a = indata.array(mfi,idTlocal);
-        Array4<Real> const& rho_a = indata.array(mfi,idRlocal);
-        Array4<Real> const& D_a = tempdata[lev]->array(mfi,0);
-	Array4<Real> const& chi_a = tempdata[lev]->array(mfi,NUM_SPECIES);
-        Array4<Real> const& mu_a = tempdata[lev]->array(mfi,2*NUM_SPECIES);
-        Array4<Real> const& xi_a = tempdata[lev]->array(mfi,2*NUM_SPECIES+1);
-        Array4<Real> const& lam_a = tempdata[lev]->array(mfi,2*NUM_SPECIES+2);
-        Array4<Real> const& Le_a = outdata[lev]->array(mfi,idLeout);
+        Array4<Real> const& Y_a = indata.array(mfi, idYlocal);
+        Array4<Real> const& T_a = indata.array(mfi, idTlocal);
+        Array4<Real> const& rho_a = indata.array(mfi, idRlocal);
+        Array4<Real> const& D_a = tempdata[lev]->array(mfi, 0);
+        Array4<Real> const& chi_a = tempdata[lev]->array(mfi, NUM_SPECIES);
+        Array4<Real> const& mu_a = tempdata[lev]->array(mfi, 2 * NUM_SPECIES);
+        Array4<Real> const& xi_a =
+          tempdata[lev]->array(mfi, 2 * NUM_SPECIES + 1);
+        Array4<Real> const& lam_a =
+          tempdata[lev]->array(mfi, 2 * NUM_SPECIES + 2);
+        Array4<Real> const& Le_a = outdata[lev]->array(mfi, idLeout);
 
         amrex::launch(bx, [=] AMREX_GPU_DEVICE(amrex::Box const& tbx) {
           auto trans = pele::physics::PhysicsType::transport();
           trans.get_transport_coeffs(
-				     tbx, Y_a, T_a, rho_a, D_a, chi_a, mu_a, xi_a, lam_a, ltransparm);
+            tbx, Y_a, T_a, rho_a, D_a, chi_a, mu_a, xi_a, lam_a, ltransparm);
         });
-        amrex::ParallelFor(bx, [=]
-        AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-        {
-          Real Cpmix = 0.0;
-          Real Yloc[NUM_SPECIES] = {0.0};
-          for (int n=0; n<NUM_SPECIES; ++n) {
-              Yloc[n] = Y_a(i,j,k,n);
-          }
-          CKCPBS(T_a(i,j,k),Yloc,Cpmix);
-          for (int n=0; n<NUM_SPECIES; ++n) {
-            Le_a(i,j,k,n) = D_a(i,j,k,n) / (lam_a(i,j,k) / Cpmix);
-          }
-        });
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            Real Cpmix = 0.0;
+            Real Yloc[NUM_SPECIES] = {0.0};
+            for (int n = 0; n < NUM_SPECIES; ++n) {
+              Yloc[n] = Y_a(i, j, k, n);
+            }
+            CKCPBS(T_a(i, j, k), Yloc, Cpmix);
+            for (int n = 0; n < NUM_SPECIES; ++n) {
+              Le_a(i, j, k, n) = D_a(i, j, k, n) / (lam_a(i, j, k) / Cpmix);
+            }
+          });
       }
 
       Print() << "Derive finished for level " << lev << std::endl;
@@ -186,9 +183,10 @@ main (int   argc,
     std::string outfile(getFileRoot(plotFileName) + "_Le");
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(outdata), outNames,
-                                   geoms, 0.0, isteps, refRatios);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps,
+      refRatios);
   }
   Finalize();
   return 0;

--- a/Src/ModelSpecificAnalysis/plotTransportCoeff.cpp
+++ b/Src/ModelSpecificAnalysis/plotTransportCoeff.cpp
@@ -19,10 +19,8 @@ pele::physics::PeleParams<pele::physics::transport::TransParm<
   pele::physics::PhysicsType::transport_type>>
   trans_parms;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
@@ -32,80 +30,82 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
       // ^^^ this calls ParallelDescriptor::EndParallel() and exit()
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     trans_parms.initialize();
-    
+
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
     int idYin = -1;
     int idTin = -1;
     int idRin = -1;
     Vector<std::string> spec_names;
-    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(spec_names);
+    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
+      spec_names);
     const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    const std::string spName= "Y(" + spec_names[0] + ")";
+    const std::string spName = "Y(" + spec_names[0] + ")";
     const std::string TName = "temp";
     const std::string RName = "density";
-    for (int i=0; i<plotVarNames.size(); ++i)
-    {
-      if (plotVarNames[i] == spName) idYin = i;
-      if (plotVarNames[i] == TName)  idTin = i;
-      if (plotVarNames[i] == RName)  idRin = i;
+    for (int i = 0; i < plotVarNames.size(); ++i) {
+      if (plotVarNames[i] == spName)
+        idYin = i;
+      if (plotVarNames[i] == TName)
+        idTin = i;
+      if (plotVarNames[i] == RName)
+        idRin = i;
     }
-    if (idYin<0 || idTin<0 || idRin<0)
+    if (idYin < 0 || idTin < 0 || idRin < 0)
       Print() << "Cannot find required data in pltfile" << std::endl;
 
-    const int nCompIn  = NUM_SPECIES + 2;
-    const int idDout   = 0;
-    const int idChiout = idDout + NUM_SPECIES; 
-    const int idMuout  = idChiout + NUM_SPECIES;
-    const int idXiout  = idMuout + 1;
+    const int nCompIn = NUM_SPECIES + 2;
+    const int idDout = 0;
+    const int idChiout = idDout + NUM_SPECIES;
+    const int idMuout = idChiout + NUM_SPECIES;
+    const int idXiout = idMuout + 1;
     const int idLamout = idXiout + 1;
     const int nCompOut = idLamout + 1;
 
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
-    const int idYlocal = 0; // Xs start here
-    const int idTlocal = NUM_SPECIES;   // T starts here
-    const int idRlocal = NUM_SPECIES+1; // R starts here
-    for (int i=0; i<NUM_SPECIES; ++i)
-    {
+    const int idYlocal = 0;               // Xs start here
+    const int idTlocal = NUM_SPECIES;     // T starts here
+    const int idRlocal = NUM_SPECIES + 1; // R starts here
+    for (int i = 0; i < NUM_SPECIES; ++i) {
       destFillComps[i] = idYlocal + i;
-      inNames[i] =  "Y(" + spec_names[i] + ")";
+      inNames[i] = "Y(" + spec_names[i] + ")";
       outNames[i] = "rhoD(" + spec_names[i] + ")";
       outNames[idChiout + i] = "chi(" + spec_names[i] + ")";
     }
@@ -119,31 +119,27 @@ main (int   argc,
 
     Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
-    amrex::RealBox real_box({AMREX_D_DECL(amrData.ProbLo()[0],
-                                          amrData.ProbLo()[1],
-                                          amrData.ProbLo()[2])},
-                            {AMREX_D_DECL(amrData.ProbHi()[0],
-                                          amrData.ProbHi()[1],
-                                          amrData.ProbHi()[2])});
+    amrex::RealBox real_box(
+      {AMREX_D_DECL(
+        amrData.ProbLo()[0], amrData.ProbLo()[1], amrData.ProbLo()[2])},
+      {AMREX_D_DECL(
+        amrData.ProbHi()[0], amrData.ProbHi()[1], amrData.ProbHi()[2])});
     amrex::Array<int, AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(1, 1, 1)};
-    geoms[0] = amrex::Geometry((amrData.ProbDomain())[0],
-                               real_box,
-                               amrData.CoordSys(),
-                               is_periodic);
+    geoms[0] = amrex::Geometry(
+      (amrData.ProbDomain())[0], real_box, amrData.CoordSys(), is_periodic);
     const int nGrow = 0;
 
-    for (int lev=0; lev<Nlev; ++lev)
-    {
+    for (int lev = 0; lev < Nlev; ++lev) {
       const BoxArray ba = amrData.boxArray(lev);
       const DistributionMapping dm(ba);
-      outdata[lev].reset(new MultiFab(ba,dm,nCompOut,nGrow));
-      if ( lev > 0 ) {
-         geoms[lev] = amrex::refine(geoms[lev - 1], 2);
+      outdata[lev].reset(new MultiFab(ba, dm, nCompOut, nGrow));
+      if (lev > 0) {
+        geoms[lev] = amrex::refine(geoms[lev - 1], 2);
       }
-      MultiFab indata(ba,dm,nCompIn,nGrow);
+      MultiFab indata(ba, dm, nCompIn, nGrow);
 
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps);
+      amrData.FillVar(indata, lev, inNames, destFillComps);
       Print() << "Data has been read for level " << lev << std::endl;
 
       // Get the transport data pointer
@@ -156,19 +152,19 @@ main (int   argc,
            ++mfi) {
 
         const Box& bx = mfi.tilebox();
-        Array4<Real> const& Y_a = indata.array(mfi,idYlocal);
-        Array4<Real> const& T_a = indata.array(mfi,idTlocal);
-        Array4<Real> const& rho_a = indata.array(mfi,idRlocal);
-        Array4<Real> const& D_a = outdata[lev]->array(mfi,idDout);
-	Array4<Real> const& chi_a = outdata[lev]->array(mfi,idChiout);
-	Array4<Real> const& mu_a = outdata[lev]->array(mfi,idMuout);
-        Array4<Real> const& xi_a = outdata[lev]->array(mfi,idXiout);
-        Array4<Real> const& lam_a = outdata[lev]->array(mfi,idLamout);
+        Array4<Real> const& Y_a = indata.array(mfi, idYlocal);
+        Array4<Real> const& T_a = indata.array(mfi, idTlocal);
+        Array4<Real> const& rho_a = indata.array(mfi, idRlocal);
+        Array4<Real> const& D_a = outdata[lev]->array(mfi, idDout);
+        Array4<Real> const& chi_a = outdata[lev]->array(mfi, idChiout);
+        Array4<Real> const& mu_a = outdata[lev]->array(mfi, idMuout);
+        Array4<Real> const& xi_a = outdata[lev]->array(mfi, idXiout);
+        Array4<Real> const& lam_a = outdata[lev]->array(mfi, idLamout);
 
         amrex::launch(bx, [=] AMREX_GPU_DEVICE(amrex::Box const& tbx) {
           auto trans = pele::physics::PhysicsType::transport();
           trans.get_transport_coeffs(
-				     tbx, Y_a, T_a, rho_a, D_a, chi_a, mu_a, xi_a, lam_a, ltransparm);
+            tbx, Y_a, T_a, rho_a, D_a, chi_a, mu_a, xi_a, lam_a, ltransparm);
         });
       }
       Print() << "Derive finished for level " << lev << std::endl;
@@ -177,9 +173,10 @@ main (int   argc,
     std::string outfile(getFileRoot(plotFileName) + "_D");
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(outdata), outNames,
-                                   geoms, 0.0, isteps, refRatios);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps,
+      refRatios);
   }
   Finalize();
   return 0;

--- a/Src/ModelSpecificAnalysis/plotXtoY.cpp
+++ b/Src/ModelSpecificAnalysis/plotXtoY.cpp
@@ -14,10 +14,8 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
@@ -27,56 +25,58 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
       // ^^^ this calls ParallelDescriptor::EndParallel() and exit()
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
     int idXin = -1;
     int idTin = -1;
     Vector<std::string> spec_names;
-    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(spec_names);
+    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
+      spec_names);
     auto eos = pele::physics::PhysicsType::eos();
     const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    const std::string spName= "X(" + spec_names[0] + ")";
+    const std::string spName = "X(" + spec_names[0] + ")";
     const std::string TName = "Temp";
-    for (int i=0; i<plotVarNames.size(); ++i)
-    {
-      if (plotVarNames[i] == spName) idXin = i;
-      if (plotVarNames[i] == TName) idTin = i;
+    for (int i = 0; i < plotVarNames.size(); ++i) {
+      if (plotVarNames[i] == spName)
+        idXin = i;
+      if (plotVarNames[i] == TName)
+        idTin = i;
     }
-    if (idXin<0 || idTin<0)
+    if (idXin < 0 || idTin < 0)
       Print() << "Cannot find required data in pltfile" << std::endl;
 
     const int idYout = 0;
@@ -87,67 +87,60 @@ main (int   argc,
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
-    const int idXlocal = 0; // Xs start here
+    const int idXlocal = 0;           // Xs start here
     const int idTlocal = NUM_SPECIES; // T start here
-    for (int i=0; i<NUM_SPECIES; ++i)
-    {
+    for (int i = 0; i < NUM_SPECIES; ++i) {
       destFillComps[i] = idXlocal + i;
-      inNames[i] =  "X(" + spec_names[i] + ")";
+      inNames[i] = "X(" + spec_names[i] + ")";
       outNames[i] = "Y(" + spec_names[i] + ")";
     }
     destFillComps[idTlocal] = idTlocal;
     inNames[idTlocal] = TName;
     outNames[idTout] = TName;
-    
+
     Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
-    amrex::RealBox real_box({AMREX_D_DECL(amrData.ProbLo()[0],
-                                          amrData.ProbLo()[1],
-                                          amrData.ProbLo()[2])},
-                            {AMREX_D_DECL(amrData.ProbHi()[0],
-                                          amrData.ProbHi()[1],
-                                          amrData.ProbHi()[2])});
+    amrex::RealBox real_box(
+      {AMREX_D_DECL(
+        amrData.ProbLo()[0], amrData.ProbLo()[1], amrData.ProbLo()[2])},
+      {AMREX_D_DECL(
+        amrData.ProbHi()[0], amrData.ProbHi()[1], amrData.ProbHi()[2])});
     amrex::Array<int, AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(1, 1, 1)};
-    geoms[0] = amrex::Geometry((amrData.ProbDomain())[0],
-                               real_box,
-                               amrData.CoordSys(),
-                               is_periodic);
+    geoms[0] = amrex::Geometry(
+      (amrData.ProbDomain())[0], real_box, amrData.CoordSys(), is_periodic);
     const int nGrow = 0;
 
-    for (int lev=0; lev<Nlev; ++lev)
-    {
+    for (int lev = 0; lev < Nlev; ++lev) {
       const BoxArray ba = amrData.boxArray(lev);
       const DistributionMapping dm(ba);
-      outdata[lev].reset(new MultiFab(ba,dm,nCompOut,nGrow));
-      if ( lev > 0 ) {
-         geoms[lev] = amrex::refine(geoms[lev - 1], 2);
+      outdata[lev].reset(new MultiFab(ba, dm, nCompOut, nGrow));
+      if (lev > 0) {
+        geoms[lev] = amrex::refine(geoms[lev - 1], 2);
       }
-      MultiFab indata(ba,dm,nCompIn,nGrow);
+      MultiFab indata(ba, dm, nCompIn, nGrow);
 
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps);
+      amrData.FillVar(indata, lev, inNames, destFillComps);
       Print() << "Data has been read for level " << lev << std::endl;
 
-      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
+      for (MFIter mfi(indata, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const Box& bx = mfi.tilebox();
         Array4<Real> const& X = indata.array(mfi);
         Array4<Real> const& Tin = indata.array(mfi);
         Array4<Real> const& Y = (*outdata[lev]).array(mfi);
         Array4<Real> const& Tout = (*outdata[lev]).array(mfi);
 
-        AMREX_PARALLEL_FOR_3D ( bx, i, j, k,
-        {
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
           Real Yl[NUM_SPECIES];
           Real Xl[NUM_SPECIES];
-          for (int n=0; n<NUM_SPECIES; ++n) {
-            Xl[n] = X(i,j,k,idXlocal+n);
+          for (int n = 0; n < NUM_SPECIES; ++n) {
+            Xl[n] = X(i, j, k, idXlocal + n);
           }
-          eos.X2Y(Xl,Yl);
-          for (int n=0; n<NUM_SPECIES; ++n) {
-            Y(i,j,k,idYout+n) = Yl[n];
+          eos.X2Y(Xl, Yl);
+          for (int n = 0; n < NUM_SPECIES; ++n) {
+            Y(i, j, k, idYout + n) = Yl[n];
           }
-          Tout(i,j,k,idTout) = Tin(i,j,k,idTlocal);
+          Tout(i, j, k, idTout) = Tin(i, j, k, idTlocal);
         });
       }
 
@@ -157,9 +150,10 @@ main (int   argc,
     std::string outfile(getFileRoot(plotFileName) + "_Y");
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(outdata), outNames,
-                                   geoms, 0.0, isteps, refRatios);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps,
+      refRatios);
   }
   Finalize();
   return 0;

--- a/Src/ModelSpecificAnalysis/plotYtoX.cpp
+++ b/Src/ModelSpecificAnalysis/plotYtoX.cpp
@@ -14,10 +14,8 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
@@ -27,56 +25,58 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
       // ^^^ this calls ParallelDescriptor::EndParallel() and exit()
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
     int idYin = -1;
     int idTin = -1;
     Vector<std::string> spec_names;
-    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(spec_names);
+    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
+      spec_names);
     auto eos = pele::physics::PhysicsType::eos();
     const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    const std::string spName= "Y(" + spec_names[0] + ")";
+    const std::string spName = "Y(" + spec_names[0] + ")";
     const std::string TName = "Temp";
-    for (int i=0; i<plotVarNames.size(); ++i)
-    {
-      if (plotVarNames[i] == spName) idYin = i;
-      if (plotVarNames[i] == TName) idTin = i;
+    for (int i = 0; i < plotVarNames.size(); ++i) {
+      if (plotVarNames[i] == spName)
+        idYin = i;
+      if (plotVarNames[i] == TName)
+        idTin = i;
     }
-    if (idYin<0 || idTin<0)
+    if (idYin < 0 || idTin < 0)
       Print() << "Cannot find required data in pltfile" << std::endl;
 
     const int idXout = 0;
@@ -87,67 +87,60 @@ main (int   argc,
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
-    const int idYlocal = 0; // Xs start here
+    const int idYlocal = 0;           // Xs start here
     const int idTlocal = NUM_SPECIES; // T start here
-    for (int i=0; i<NUM_SPECIES; ++i)
-    {
+    for (int i = 0; i < NUM_SPECIES; ++i) {
       destFillComps[i] = idYlocal + i;
-      inNames[i] =  "Y(" + spec_names[i] + ")";
+      inNames[i] = "Y(" + spec_names[i] + ")";
       outNames[i] = "X(" + spec_names[i] + ")";
     }
     destFillComps[idTlocal] = idTlocal;
     inNames[idTlocal] = TName;
     outNames[idTout] = TName;
-    
+
     Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
-    amrex::RealBox real_box({AMREX_D_DECL(amrData.ProbLo()[0],
-                                          amrData.ProbLo()[1],
-                                          amrData.ProbLo()[2])},
-                            {AMREX_D_DECL(amrData.ProbHi()[0],
-                                          amrData.ProbHi()[1],
-                                          amrData.ProbHi()[2])});
+    amrex::RealBox real_box(
+      {AMREX_D_DECL(
+        amrData.ProbLo()[0], amrData.ProbLo()[1], amrData.ProbLo()[2])},
+      {AMREX_D_DECL(
+        amrData.ProbHi()[0], amrData.ProbHi()[1], amrData.ProbHi()[2])});
     amrex::Array<int, AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(1, 1, 1)};
-    geoms[0] = amrex::Geometry((amrData.ProbDomain())[0],
-                               real_box,
-                               amrData.CoordSys(),
-                               is_periodic);
+    geoms[0] = amrex::Geometry(
+      (amrData.ProbDomain())[0], real_box, amrData.CoordSys(), is_periodic);
     const int nGrow = 0;
 
-    for (int lev=0; lev<Nlev; ++lev)
-    {
+    for (int lev = 0; lev < Nlev; ++lev) {
       const BoxArray ba = amrData.boxArray(lev);
       const DistributionMapping dm(ba);
-      outdata[lev].reset(new MultiFab(ba,dm,nCompOut,nGrow));
-      if ( lev > 0 ) {
-         geoms[lev] = amrex::refine(geoms[lev - 1], 2);
+      outdata[lev].reset(new MultiFab(ba, dm, nCompOut, nGrow));
+      if (lev > 0) {
+        geoms[lev] = amrex::refine(geoms[lev - 1], 2);
       }
-      MultiFab indata(ba,dm,nCompIn,nGrow);
+      MultiFab indata(ba, dm, nCompIn, nGrow);
 
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps);
+      amrData.FillVar(indata, lev, inNames, destFillComps);
       Print() << "Data has been read for level " << lev << std::endl;
 
-      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
+      for (MFIter mfi(indata, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const Box& bx = mfi.tilebox();
         Array4<Real> const& Y = indata.array(mfi);
         Array4<Real> const& Tin = indata.array(mfi);
         Array4<Real> const& X = (*outdata[lev]).array(mfi);
         Array4<Real> const& Tout = (*outdata[lev]).array(mfi);
 
-        AMREX_PARALLEL_FOR_3D ( bx, i, j, k,
-        {
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
           Real Yl[NUM_SPECIES];
           Real Xl[NUM_SPECIES];
-          for (int n=0; n<NUM_SPECIES; ++n) {
-            Yl[n] = Y(i,j,k,idYlocal+n);
+          for (int n = 0; n < NUM_SPECIES; ++n) {
+            Yl[n] = Y(i, j, k, idYlocal + n);
           }
-          eos.Y2X(Yl,Xl);
-          for (int n=0; n<NUM_SPECIES; ++n) {
-            X(i,j,k,idXout+n) = Xl[n];
+          eos.Y2X(Yl, Xl);
+          for (int n = 0; n < NUM_SPECIES; ++n) {
+            X(i, j, k, idXout + n) = Xl[n];
           }
-          Tout(i,j,k,idTout) = Tin(i,j,k,idTlocal);
+          Tout(i, j, k, idTout) = Tin(i, j, k, idTlocal);
         });
       }
 
@@ -157,9 +150,10 @@ main (int   argc,
     std::string outfile(getFileRoot(plotFileName) + "_X");
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(outdata), outNames,
-                                   geoms, 0.0, isteps, refRatios);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps,
+      refRatios);
   }
   Finalize();
   return 0;

--- a/Src/ModelSpecificAnalysis/plotZC.cpp
+++ b/Src/ModelSpecificAnalysis/plotZC.cpp
@@ -9,14 +9,12 @@
 #include <AMReX_PlotFileUtil.H>
 #include <PelePhysics.H>
 
-//#include <mechanism.H>
+// #include <mechanism.H>
 
 using namespace amrex;
 
-static
-void
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
@@ -26,107 +24,112 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(false);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
-    std::string fuelName = "H2"; pp.query("fuelName",fuelName);
-    //Real s = 8.0; pp.query("stoichRatio",s);
-    //Real Y_O_air = 0.233; pp.query("YO2Air",Y_O_air);
-    //Real S = s/Y_O_air;
-    //const Real Z_st = Y_O_air/(s+Y_O_air);
-    std::string productName = "H2O"; pp.query("productName",productName);
-    int clipProgress = 0; pp.query("clipProgress",clipProgress);
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
+    std::string fuelName = "H2";
+    pp.query("fuelName", fuelName);
+    // Real s = 8.0; pp.query("stoichRatio",s);
+    // Real Y_O_air = 0.233; pp.query("YO2Air",Y_O_air);
+    // Real S = s/Y_O_air;
+    // const Real Z_st = Y_O_air/(s+Y_O_air);
+    std::string productName = "H2O";
+    pp.query("productName", productName);
+    int clipProgress = 0;
+    pp.query("clipProgress", clipProgress);
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
     Vector<std::string> spec_names;
-    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(spec_names);
+    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
+      spec_names);
     auto eos = pele::physics::PhysicsType::eos();
-    const Vector<std::string>& plotVarNames = amrData.PlotVarNames();    
-    const std::string spName= "Y("+fuelName+")";
-    //const std::string oxName= "Y(O2)";
-    const std::string prodName= "Y("+productName+")";
+    const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
+    const std::string spName = "Y(" + fuelName + ")";
+    // const std::string oxName= "Y(O2)";
+    const std::string prodName = "Y(" + productName + ")";
 
     constexpr int nCompIn = NUM_SPECIES;
     constexpr int nCompOut = 3;
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
-    
-    for (int i=0; i<NUM_SPECIES; ++i)
-    {
+
+    for (int i = 0; i < NUM_SPECIES; ++i) {
       destFillComps[i] = i;
-      inNames[i] =  "Y(" + spec_names[i] + ")";
+      inNames[i] = "Y(" + spec_names[i] + ")";
     }
-    //out
-    constexpr int idZlocal = 0; // Z out here
+    // out
+    constexpr int idZlocal = 0;  // Z out here
     constexpr int idCFlocal = 1; // CF out here
     constexpr int idCPlocal = 2; // CP out here
     outNames[idZlocal] = "Z";
     outNames[idCFlocal] = "CF";
-    outNames[idCPlocal] = "CP";       
+    outNames[idCPlocal] = "CP";
 
     Vector<MultiFab> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
-    RealBox rb(&(amrData.ProbLo()[0]),&(amrData.ProbHi()[0]));
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
     constexpr int nGrow = 0;
-    Vector<Real> YFminmax = {1e100,-1e100};
-    Vector<Real> YPminmax = {1e100,-1e100};    
+    Vector<Real> YFminmax = {1e100, -1e100};
+    Vector<Real> YPminmax = {1e100, -1e100};
     Vector<Box> probDomain = amrData.ProbDomain();
 
-    const int YFcomp = amrData.StateNumber("Y("+fuelName+")")-amrData.StateNumber("Y("+spec_names[0]+")");
-    const int YPcomp = amrData.StateNumber("Y("+productName+")")-amrData.StateNumber("Y("+spec_names[0]+")");
-    
-    for (int lev=0; lev<Nlev;++lev) {
-      Real min,max;	
-      amrData.MinMax(probDomain[lev], "Y("+fuelName+")", lev,min,max);
+    const int YFcomp = amrData.StateNumber("Y(" + fuelName + ")") -
+                       amrData.StateNumber("Y(" + spec_names[0] + ")");
+    const int YPcomp = amrData.StateNumber("Y(" + productName + ")") -
+                       amrData.StateNumber("Y(" + spec_names[0] + ")");
+
+    for (int lev = 0; lev < Nlev; ++lev) {
+      Real min, max;
+      amrData.MinMax(probDomain[lev], "Y(" + fuelName + ")", lev, min, max);
       if (YFminmax[0] > min) {
-	YFminmax[0] = min;
+        YFminmax[0] = min;
       }
       if (YFminmax[1] < max) {
-	YFminmax[1] = max;
-      }      
-      amrData.MinMax(probDomain[lev], "Y("+productName+")",lev,min,max);
+        YFminmax[1] = max;
+      }
+      amrData.MinMax(probDomain[lev], "Y(" + productName + ")", lev, min, max);
       if (YPminmax[0] > min) {
-	YPminmax[0] = min;
+        YPminmax[0] = min;
       }
       if (YPminmax[1] < max) {
-	YPminmax[1] = max;
+        YPminmax[1] = max;
       }
     }
-    //TODO: add some verb and manual querying
-    pp.queryarr("YFminmax",YFminmax);
-    pp.queryarr("YPminmax",YPminmax);
+    // TODO: add some verb and manual querying
+    pp.queryarr("YFminmax", YFminmax);
+    pp.queryarr("YPminmax", YPminmax);
     Real Zfu = -1.0;
     Real Zox = -1.0;
 
@@ -135,33 +138,34 @@ main (int   argc,
       YF[i] = 0.0;
       YO[i] = 0.0;
       if (spec_names[i] == "O2") {
-	YO[i] = 0.233;
+        YO[i] = 0.233;
       }
       if (spec_names[i] == "N2") {
-	YO[i] = 0.767;
+        YO[i] = 0.767;
       }
       if (i == YFcomp) {
-	YF[i] = 1.0;
+        YF[i] = 1.0;
       }
     }
 
-    
     // Detailed chem - compute Bilger coefficients
     // Only interested in CHON -in that order. Compute Bilger weights
     Array<amrex::Real, 4> Beta_mix;
     Real atwCHON[4] = {0.0};
-    pele::physics::eos::atomic_weightsCHON<pele::physics::PhysicsType::eos_type>(atwCHON);
+    pele::physics::eos::atomic_weightsCHON<
+      pele::physics::PhysicsType::eos_type>(atwCHON);
     Beta_mix[0] = (atwCHON[0] != 0.0) ? 2.0 / atwCHON[0] : 0.0;
     Beta_mix[1] = (atwCHON[1] != 0.0) ? 1.0 / (2.0 * atwCHON[1]) : 0.0;
     Beta_mix[2] = (atwCHON[2] != 0.0) ? -1.0 / atwCHON[2] : 0.0;
     Beta_mix[3] = 0.0;
-    
+
     // Compute each species weight for the Bilger formulation based on elemental
     // compo Only interested in CHON -in that order.
     amrex::Array<amrex::Real, NUM_SPECIES> spec_Bilger_fact;
 
     int ecompCHON[NUM_SPECIES * 4];
-    pele::physics::eos::element_compositionCHON<pele::physics::PhysicsType::eos_type>(ecompCHON);
+    pele::physics::eos::element_compositionCHON<
+      pele::physics::PhysicsType::eos_type>(ecompCHON);
     amrex::Real mwt[NUM_SPECIES];
     eos.molecular_weight(mwt);
     Zfu = 0.0;
@@ -169,41 +173,44 @@ main (int   argc,
     for (int i = 0; i < NUM_SPECIES; ++i) {
       spec_Bilger_fact[i] = 0.0;
       for (int k = 0; k < 4; k++) {
-	spec_Bilger_fact[i] +=
-	  Beta_mix[k] * (ecompCHON[i * 4 + k] * atwCHON[k] / mwt[i]);
+        spec_Bilger_fact[i] +=
+          Beta_mix[k] * (ecompCHON[i * 4 + k] * atwCHON[k] / mwt[i]);
       }
       Zfu += spec_Bilger_fact[i] * YF[i];
       Zox += spec_Bilger_fact[i] * YO[i];
     }
     const Real denom_inv = 1.0 / (Zfu - Zox);
-    //amrex::GpuArray<amrex::Real, NUM_SPECIES> fact_Bilger;
-    //for (int n = 0; n < NUM_SPECIES; ++n) {
-    //  fact_Bilger[n] = a_pelelm->spec_Bilger_fact[n];
-    //}
+    // amrex::GpuArray<amrex::Real, NUM_SPECIES> fact_Bilger;
+    // for (int n = 0; n < NUM_SPECIES; ++n) {
+    //   fact_Bilger[n] = a_pelelm->spec_Bilger_fact[n];
+    // }
 
-    
-    for (int lev=0; lev<Nlev; ++lev) {
+    for (int lev = 0; lev < Nlev; ++lev) {
       const BoxArray ba = amrData.boxArray(lev);
       const Vector<Real>& delta = amrData.DxLevel()[lev];
       const DistributionMapping dm(ba);
-      MultiFab indata(ba,dm,nCompIn,nGrow);
-      outdata[lev].define(ba,dm,nCompOut,nGrow);
-      
+      MultiFab indata(ba, dm, nCompIn, nGrow);
+      outdata[lev].define(ba, dm, nCompOut, nGrow);
+
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps); //Problem
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb,0,&(is_per[0]));
+      amrData.FillVar(indata, lev, inNames, destFillComps); // Problem
+      geoms[lev] = Geometry(amrData.ProbDomain()[lev], &rb, 0, &(is_per[0]));
       Print() << "Data has been read for level " << lev << std::endl;
       auto in_ma = indata.const_arrays();
       auto out_ma = outdata[lev].arrays();
-      amrex::ParallelFor(outdata[lev],[=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept {	
-	out_ma[box_no](i,j,k,idCFlocal) = 1.0 - in_ma[box_no](i,j,k,YFcomp)/YFminmax[1];
-	out_ma[box_no](i,j,k,idCPlocal) = in_ma[box_no](i,j,k,YPcomp)/YPminmax[1];
-	Real Zloc = 0.0;
-	for (int n = 0; n < NUM_SPECIES; ++n) {
-	  Zloc += in_ma[box_no](i,j,k,n) * spec_Bilger_fact[n];
-	}
-	out_ma[box_no](i,j,k,idZlocal) = (Zloc - Zox)*denom_inv;
-      });
+      amrex::ParallelFor(
+        outdata[lev],
+        [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept {
+          out_ma[box_no](i, j, k, idCFlocal) =
+            1.0 - in_ma[box_no](i, j, k, YFcomp) / YFminmax[1];
+          out_ma[box_no](i, j, k, idCPlocal) =
+            in_ma[box_no](i, j, k, YPcomp) / YPminmax[1];
+          Real Zloc = 0.0;
+          for (int n = 0; n < NUM_SPECIES; ++n) {
+            Zloc += in_ma[box_no](i, j, k, n) * spec_Bilger_fact[n];
+          }
+          out_ma[box_no](i, j, k, idZlocal) = (Zloc - Zox) * denom_inv;
+        });
       Print() << "Derive finished for level " << lev << std::endl;
     }
 
@@ -211,8 +218,10 @@ main (int   argc,
     Print() << "Writing new data to " << outfile << std::endl;
     const bool verb = false;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outfile,Nlev,GetVecOfConstPtrs(outdata),outNames,geoms, 0.0, isteps, refRatios);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps,
+      refRatios);
   }
   Finalize();
   return 0;

--- a/Src/ModelSpecificAnalysis/plotZCelem.cpp
+++ b/Src/ModelSpecificAnalysis/plotZCelem.cpp
@@ -11,110 +11,115 @@
 
 using namespace amrex;
 
-static
-void
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
   std::cerr << "\tfuelNames=H2 CH4       (list of fuel species)\n";
-  std::cerr << "\tfuelMoleFracs=0.4 0.6  (mole fractions of each fuel species, must sum to 1)\n";
+  std::cerr << "\tfuelMoleFracs=0.4 0.6  (mole fractions of each fuel species, "
+               "must sum to 1)\n";
   exit(1);
 }
 
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(false);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
 
     // ---- Multi-species fuel input ----
     // Default: pure H2
     Vector<std::string> fuelNames;
-    Vector<Real>        fuelMoleFracs;
+    Vector<Real> fuelMoleFracs;
     if (pp.countval("fuelNames") > 0) {
-      pp.getarr("fuelNames",      fuelNames);
-      pp.getarr("fuelMoleFracs",  fuelMoleFracs);
+      pp.getarr("fuelNames", fuelNames);
+      pp.getarr("fuelMoleFracs", fuelMoleFracs);
       if (fuelNames.size() != fuelMoleFracs.size())
         amrex::Abort("fuelNames and fuelMoleFracs must have the same length");
       // Normalise just in case
       Real sumX = 0.0;
-      for (Real x : fuelMoleFracs) sumX += x;
-      for (Real& x : fuelMoleFracs) x /= sumX;
+      for (Real x : fuelMoleFracs)
+        sumX += x;
+      for (Real& x : fuelMoleFracs)
+        x /= sumX;
     } else {
       // Legacy single-fuel path
-      std::string singleFuel = "H2"; pp.query("fuelName", singleFuel);
-      fuelNames     = {singleFuel};
+      std::string singleFuel = "H2";
+      pp.query("fuelName", singleFuel);
+      fuelNames = {singleFuel};
       fuelMoleFracs = {1.0};
     }
 
-    std::string productName = "H2O"; pp.query("productName",productName);
-    int clipProgress = 0; pp.query("clipProgress",clipProgress);
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    std::string productName = "H2O";
+    pp.query("productName", productName);
+    int clipProgress = 0;
+    pp.query("clipProgress", clipProgress);
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk())
+    if (!dataServices.AmrDataOk())
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     AmrData& amrData = dataServices.AmrDataRef();
 
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
     Vector<std::string> spec_names;
-    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(spec_names);
+    pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
+      spec_names);
     auto eos = pele::physics::PhysicsType::eos();
 
     // ---- Output components ----
     // Z, CF, CP  +  Z_H, Z_C, Z_O, Z_N
-    constexpr int nCompIn  = NUM_SPECIES;
-    constexpr int nCompOut = 7;          // Z  CF  CP  Z_H  Z_C  Z_O  Z_N
-    constexpr int idZlocal  = 0;
+    constexpr int nCompIn = NUM_SPECIES;
+    constexpr int nCompOut = 7; // Z  CF  CP  Z_H  Z_C  Z_O  Z_N
+    constexpr int idZlocal = 0;
     constexpr int idCFlocal = 1;
     constexpr int idCPlocal = 2;
-    constexpr int idZH      = 3;
-    constexpr int idZC      = 4;
-    constexpr int idZO      = 5;
-    constexpr int idZN      = 6;
+    constexpr int idZH = 3;
+    constexpr int idZC = 4;
+    constexpr int idZO = 5;
+    constexpr int idZN = 6;
 
     Vector<std::string> outNames(nCompOut);
-    outNames[idZlocal]  = "Z";
+    outNames[idZlocal] = "Z";
     outNames[idCFlocal] = "CF";
     outNames[idCPlocal] = "CP";
-    outNames[idZH]      = "Z_H";
-    outNames[idZC]      = "Z_C";
-    outNames[idZO]      = "Z_O";
-    outNames[idZN]      = "Z_N";
+    outNames[idZH] = "Z_H";
+    outNames[idZC] = "Z_C";
+    outNames[idZO] = "Z_O";
+    outNames[idZN] = "Z_N";
 
     Vector<std::string> inNames(nCompIn);
-    Vector<int>         destFillComps(nCompIn);
+    Vector<int> destFillComps(nCompIn);
     for (int i = 0; i < NUM_SPECIES; ++i) {
       destFillComps[i] = i;
-      inNames[i]       = "Y(" + spec_names[i] + ")";
+      inNames[i] = "Y(" + spec_names[i] + ")";
     }
 
     // ---- EOS data ----
@@ -122,17 +127,19 @@ main (int   argc,
     eos.molecular_weight(mwt);
 
     int ecompCHON[NUM_SPECIES * 4];
-    pele::physics::eos::element_compositionCHON<pele::physics::PhysicsType::eos_type>(ecompCHON);
+    pele::physics::eos::element_compositionCHON<
+      pele::physics::PhysicsType::eos_type>(ecompCHON);
 
     Real atwCHON[4] = {0.0};
-    pele::physics::eos::atomic_weightsCHON<pele::physics::PhysicsType::eos_type>(atwCHON);
+    pele::physics::eos::atomic_weightsCHON<
+      pele::physics::PhysicsType::eos_type>(atwCHON);
 
     // Bilger weights  (C, H, O, N  in CHON order: index 0=C,1=H,2=O,3=N)
     Array<amrex::Real, 4> Beta_mix;
-    Beta_mix[0] = (atwCHON[0] != 0.0) ? 2.0 / atwCHON[0] : 0.0;   // C
+    Beta_mix[0] = (atwCHON[0] != 0.0) ? 2.0 / atwCHON[0] : 0.0;         // C
     Beta_mix[1] = (atwCHON[1] != 0.0) ? 1.0 / (2.0 * atwCHON[1]) : 0.0; // H
-    Beta_mix[2] = (atwCHON[2] != 0.0) ? -1.0 / atwCHON[2] : 0.0;  // O
-    Beta_mix[3] = 0.0;                                               // N
+    Beta_mix[2] = (atwCHON[2] != 0.0) ? -1.0 / atwCHON[2] : 0.0;        // O
+    Beta_mix[3] = 0.0;                                                  // N
 
     amrex::Array<amrex::Real, NUM_SPECIES> spec_Bilger_fact;
     for (int i = 0; i < NUM_SPECIES; ++i) {
@@ -143,42 +150,47 @@ main (int   argc,
     }
 
     // ---- Per-element mass-fraction weights for each species ----
-    // w_elem[e][i] = (atoms_e_in_i * atw_e) / mwt_i   => mass fraction of element e in species i
-    // CHON order: 0=C, 1=H, 2=O, 3=N
-    amrex::Array2D<amrex::Real, 0, 3, 0, NUM_SPECIES-1> w_elem;
+    // w_elem[e][i] = (atoms_e_in_i * atw_e) / mwt_i   => mass fraction of
+    // element e in species i CHON order: 0=C, 1=H, 2=O, 3=N
+    amrex::Array2D<amrex::Real, 0, 3, 0, NUM_SPECIES - 1> w_elem;
     for (int e = 0; e < 4; ++e)
       for (int i = 0; i < NUM_SPECIES; ++i)
-        w_elem(e,i) = (atwCHON[e] > 0.0)
-                      ? ecompCHON[i * 4 + e] * atwCHON[e] / mwt[i]
-                      : 0.0;
+        w_elem(e, i) =
+          (atwCHON[e] > 0.0) ? ecompCHON[i * 4 + e] * atwCHON[e] / mwt[i] : 0.0;
 
     // ---- Build fuel / oxidiser Y arrays from mole fractions ----
     // Convert mole fractions X_k to mass fractions Y_k:
     //   Y_k = X_k * W_k / sum_j(X_j * W_j)
     Real YF[NUM_SPECIES], YO[NUM_SPECIES];
-    for (int i = 0; i < NUM_SPECIES; ++i) { YF[i] = 0.0; YO[i] = 0.0; }
+    for (int i = 0; i < NUM_SPECIES; ++i) {
+      YF[i] = 0.0;
+      YO[i] = 0.0;
+    }
 
     // Oxidiser: standard air
     for (int i = 0; i < NUM_SPECIES; ++i) {
-      if (spec_names[i] == "O2") YO[i] = 0.233;
-      if (spec_names[i] == "N2") YO[i] = 0.767;
+      if (spec_names[i] == "O2")
+        YO[i] = 0.233;
+      if (spec_names[i] == "N2")
+        YO[i] = 0.767;
     }
 
     // Fuel: multi-species mixture
     {
       // Build a map from species name to index for quick lookup
-      std::map<std::string,int> specIdx;
-      for (int i = 0; i < NUM_SPECIES; ++i) specIdx[spec_names[i]] = i;
+      std::map<std::string, int> specIdx;
+      for (int i = 0; i < NUM_SPECIES; ++i)
+        specIdx[spec_names[i]] = i;
 
       // Numerator  W_k * X_k for each fuel species
       Real denom = 0.0;
-      Vector<int>  fuelIdx(fuelNames.size(), -1);
+      Vector<int> fuelIdx(fuelNames.size(), -1);
       for (int f = 0; f < (int)fuelNames.size(); ++f) {
         auto it = specIdx.find(fuelNames[f]);
         if (it == specIdx.end())
           amrex::Abort("Fuel species not found in mechanism: " + fuelNames[f]);
         fuelIdx[f] = it->second;
-        denom     += fuelMoleFracs[f] * mwt[fuelIdx[f]];
+        denom += fuelMoleFracs[f] * mwt[fuelIdx[f]];
       }
       for (int f = 0; f < (int)fuelNames.size(); ++f)
         YF[fuelIdx[f]] = fuelMoleFracs[f] * mwt[fuelIdx[f]] / denom;
@@ -197,27 +209,32 @@ main (int   argc,
     const Real denom_inv = 1.0 / (Zfu - Zox);
     Print() << "Zfu = " << Zfu << "  Zox = " << Zox << "\n";
 
-    // ---- Find fuel-species index for CF (use first / dominant fuel species) ----
-    // For multi-fuel we track the species with the highest mass fraction in the fuel stream.
+    // ---- Find fuel-species index for CF (use first / dominant fuel species)
+    // ---- For multi-fuel we track the species with the highest mass fraction
+    // in the fuel stream.
     int YFcomp = -1;
     {
       Real maxYF = -1.0;
       for (int i = 0; i < NUM_SPECIES; ++i)
-        if (YF[i] > maxYF) { maxYF = YF[i]; YFcomp = i; }
+        if (YF[i] > maxYF) {
+          maxYF = YF[i];
+          YFcomp = i;
+        }
     }
-    const int YPcomp = amrData.StateNumber("Y("+productName+")")
-                     - amrData.StateNumber("Y("+spec_names[0]+")");
+    const int YPcomp = amrData.StateNumber("Y(" + productName + ")") -
+                       amrData.StateNumber("Y(" + spec_names[0] + ")");
 
     // ---- Global min/max for normalisation ----
     Vector<Box> probDomain = amrData.ProbDomain();
-    Vector<Real> YFminmax = {1e100,-1e100};
-    Vector<Real> YPminmax = {1e100,-1e100};
+    Vector<Real> YFminmax = {1e100, -1e100};
+    Vector<Real> YPminmax = {1e100, -1e100};
     for (int lev = 0; lev < Nlev; ++lev) {
       Real mn, mx;
-      amrData.MinMax(probDomain[lev], "Y("+spec_names[YFcomp]+")", lev, mn, mx);
+      amrData.MinMax(
+        probDomain[lev], "Y(" + spec_names[YFcomp] + ")", lev, mn, mx);
       YFminmax[0] = std::min(YFminmax[0], mn);
       YFminmax[1] = std::max(YFminmax[1], mx);
-      amrData.MinMax(probDomain[lev], "Y("+productName+")", lev, mn, mx);
+      amrData.MinMax(probDomain[lev], "Y(" + productName + ")", lev, mn, mx);
       YPminmax[0] = std::min(YPminmax[0], mn);
       YPminmax[1] = std::max(YPminmax[1], mx);
     }
@@ -227,7 +244,7 @@ main (int   argc,
             << ") range: [" << YFminmax[0] << ", " << YFminmax[1] << "]\n";
 
     // ---- Level loop ----
-    RealBox rb(&(amrData.ProbLo()[0]),&(amrData.ProbHi()[0]));
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
     constexpr int nGrow = 0;
     Vector<MultiFab> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
@@ -243,49 +260,50 @@ main (int   argc,
       geoms[lev] = Geometry(amrData.ProbDomain()[lev], &rb, 0, &(is_per[0]));
       Print() << "Data has been read for level " << lev << std::endl;
 
-      auto in_ma  = indata.const_arrays();
+      auto in_ma = indata.const_arrays();
       auto out_ma = outdata[lev].arrays();
 
-      amrex::ParallelFor(outdata[lev],
-        [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept
-      {
-        // Progress variables
-        out_ma[box_no](i,j,k,idCFlocal) =
-          1.0 - in_ma[box_no](i,j,k,YFcomp) / YFminmax[1];
-        out_ma[box_no](i,j,k,idCPlocal) =
-          in_ma[box_no](i,j,k,YPcomp) / YPminmax[1];
+      amrex::ParallelFor(
+        outdata[lev],
+        [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept {
+          // Progress variables
+          out_ma[box_no](i, j, k, idCFlocal) =
+            1.0 - in_ma[box_no](i, j, k, YFcomp) / YFminmax[1];
+          out_ma[box_no](i, j, k, idCPlocal) =
+            in_ma[box_no](i, j, k, YPcomp) / YPminmax[1];
 
-        // Bilger mixture fraction Z
-        Real Zloc = 0.0;
-        for (int n = 0; n < NUM_SPECIES; ++n)
-          Zloc += in_ma[box_no](i,j,k,n) * spec_Bilger_fact[n];
-        out_ma[box_no](i,j,k,idZlocal) = (Zloc - Zox) * denom_inv;
+          // Bilger mixture fraction Z
+          Real Zloc = 0.0;
+          for (int n = 0; n < NUM_SPECIES; ++n)
+            Zloc += in_ma[box_no](i, j, k, n) * spec_Bilger_fact[n];
+          out_ma[box_no](i, j, k, idZlocal) = (Zloc - Zox) * denom_inv;
 
-        // Elemental mass fractions  Z_H, Z_C, Z_O, Z_N
-        // CHON order: 0=C, 1=H, 2=O, 3=N
-        Real ZC_loc = 0.0, ZH_loc = 0.0, ZO_loc = 0.0, ZN_loc = 0.0;
-        for (int n = 0; n < NUM_SPECIES; ++n) {
-          const Real Yn = in_ma[box_no](i,j,k,n);
-          ZC_loc += w_elem(0,n) * Yn;
-          ZH_loc += w_elem(1,n) * Yn;
-          ZO_loc += w_elem(2,n) * Yn;
-          ZN_loc += w_elem(3,n) * Yn;
-        }
-        out_ma[box_no](i,j,k,idZH) = ZH_loc;
-        out_ma[box_no](i,j,k,idZC) = ZC_loc;
-        out_ma[box_no](i,j,k,idZO) = ZO_loc;
-        out_ma[box_no](i,j,k,idZN) = ZN_loc;
-      });
+          // Elemental mass fractions  Z_H, Z_C, Z_O, Z_N
+          // CHON order: 0=C, 1=H, 2=O, 3=N
+          Real ZC_loc = 0.0, ZH_loc = 0.0, ZO_loc = 0.0, ZN_loc = 0.0;
+          for (int n = 0; n < NUM_SPECIES; ++n) {
+            const Real Yn = in_ma[box_no](i, j, k, n);
+            ZC_loc += w_elem(0, n) * Yn;
+            ZH_loc += w_elem(1, n) * Yn;
+            ZO_loc += w_elem(2, n) * Yn;
+            ZN_loc += w_elem(3, n) * Yn;
+          }
+          out_ma[box_no](i, j, k, idZH) = ZH_loc;
+          out_ma[box_no](i, j, k, idZC) = ZC_loc;
+          out_ma[box_no](i, j, k, idZO) = ZO_loc;
+          out_ma[box_no](i, j, k, idZN) = ZN_loc;
+        });
 
       Print() << "Derive finished for level " << lev << std::endl;
     }
 
     std::string outfile(getFileRoot(plotFileName) + "_ZC");
     Print() << "Writing new data to " << outfile << std::endl;
-    Vector<int>     isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1, {AMREX_D_DECL(2,2,2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev,
-      GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps, refRatios);
+    Vector<int> isteps(Nlev, 0);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps,
+      refRatios);
   }
   Finalize();
   return 0;

--- a/Src/ModelSpecificAnalysis/sCO2/main.cpp
+++ b/Src/ModelSpecificAnalysis/sCO2/main.cpp
@@ -5,343 +5,365 @@
 
 using namespace amrex;
 
-Real VolWgtAvgC(const FArrayBox& Val, int valComp,
-                const FArrayBox& Vol, int volComp)
+Real
+VolWgtAvgC(const FArrayBox& Val, int valComp, const FArrayBox& Vol, int volComp)
 {
   Box box = Val.box() & Vol.box();
-  FArrayBox tmp(box,1);
-  tmp.copy<RunOn::Device>(Val,box,valComp,box,0,1);
-  tmp.mult<RunOn::Device>(Vol,box,volComp,0,1);
-  return tmp.sum<RunOn::Device>(box,0,1) / Vol.sum<RunOn::Device>(box,volComp,1);
+  FArrayBox tmp(box, 1);
+  tmp.copy<RunOn::Device>(Val, box, valComp, box, 0, 1);
+  tmp.mult<RunOn::Device>(Vol, box, volComp, 0, 1);
+  return tmp.sum<RunOn::Device>(box, 0, 1) /
+         Vol.sum<RunOn::Device>(box, volComp, 1);
 }
 
-Real VolWgtAvg(const FArrayBox& Val,
-               const FArrayBox& Vol)
+Real
+VolWgtAvg(const FArrayBox& Val, const FArrayBox& Vol)
 {
   Box box = Val.box() & Vol.box();
-  FArrayBox tmp(box,1);
+  FArrayBox tmp(box, 1);
   tmp.copy<RunOn::Device>(Val);
-  tmp.mult<RunOn::Device>(Vol,0,0);
+  tmp.mult<RunOn::Device>(Vol, 0, 0);
   return tmp.sum<RunOn::Device>(0) / Vol.sum<RunOn::Device>(0);
 }
 
-int main(int argc, char* argv[])
+int
+main(int argc, char* argv[])
 {
-    amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
 
-    ParmParse pp;
+  ParmParse pp;
 
-    if (pp.contains("help")) {
-      //print_usage(argc,argv);
+  if (pp.contains("help")) {
+    // print_usage(argc,argv);
+  }
+
+  std::string infile;
+  pp.get("infile", infile);
+
+  // Initialize DataService
+  DataServices::SetBatchMode();
+  Amrvis::FileType fileType(Amrvis::NEWPLT);
+  DataServices dataServices(infile, fileType);
+  if (!dataServices.AmrDataOk()) {
+    DataServices::Dispatch(DataServices::ExitRequest, NULL);
+  }
+  AmrData& amrData = dataServices.AmrDataRef();
+
+  // Plotfile global infos
+  int finestLevel = amrData.FinestLevel();
+  pp.query("finestLevel", finestLevel);
+  AMREX_ALWAYS_ASSERT(finestLevel >= 0 && finestLevel <= amrData.FinestLevel());
+
+  const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
+  RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
+
+  int nc = pp.countval("comps");
+  AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+    nc == 6, "comps must be a list of 6 integers (adv_0, adv_1, Var1, Var2, "
+             "Var3, vfrac");
+  Vector<int> comps(6);
+  pp.getarr("comps", comps, 0, nc);
+
+  Box subbox = amrData.ProbDomain()[finestLevel];
+  Vector<int> inBox;
+
+  if (int nx = pp.countval("box")) {
+    pp.getarr("box", inBox, 0, nx);
+    int d = AMREX_SPACEDIM;
+    AMREX_ASSERT(inBox.size() == 2 * d);
+    subbox = Box(
+      IntVect(D_DECL(inBox[0], inBox[1], inBox[2])),
+      IntVect(D_DECL(inBox[d], inBox[d + 1], inBox[d + 2])),
+      IndexType::TheCellType());
+  }
+
+  subbox &= amrData.ProbDomain()[finestLevel];
+
+  Vector<std::string> names(comps.size());
+  Vector<int> fillComps(comps.size());
+
+  for (int i = 0; i < comps.size(); ++i) {
+    names[i] = amrData.PlotVarNames()[comps[i]];
+    fillComps[i] = i;
+  }
+
+  int planeCoord = 0;
+  pp.get("planeCoord", planeCoord);
+  const Vector<Real>& plo = amrData.ProbLo();
+  Vector<Real> dx = amrData.CellSize(finestLevel);
+
+  IntVect se = subbox.smallEnd();
+  IntVect be = subbox.bigEnd();
+  int clo = se[planeCoord];
+  int chi = be[planeCoord];
+
+  Real v0min = 0;
+  Real v0max = 1;
+  int nBin0 = 64;
+  pp.query("nBins", nBin0);
+  int nBin1 = nBin0;
+  Real v1min = 0;
+  Real v1max = 1;
+  Box binbox(
+    IntVect(AMREX_D_DECL(0, 0, 0)),
+    IntVect(AMREX_D_DECL(nBin0 - 1, nBin1 - 1, 0)));
+  int nBinR = nBin0;
+  Box rbinbox(
+    IntVect(AMREX_D_DECL(0, 0, 0)), IntVect(AMREX_D_DECL(0, nBinR - 1, 0)));
+
+  FArrayBox outbins(binbox, 2);
+  FArrayBox outrbins(rbinbox, 2);
+  outbins.setVal<RunOn::Device>(0);
+  outrbins.setVal<RunOn::Device>(0);
+  int nBinPlanes = 10;
+  pp.query("nBinPlanes", nBinPlanes);
+  int numPlanesSoFar = 0;
+
+  GpuArray<Real, AMREX_SPACEDIM - 1> na;
+  int icnt = 0;
+  for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+    if (i != planeCoord) {
+      na[icnt++] = i;
     }
+  }
+  GpuArray<Real, AMREX_SPACEDIM> ploa = {AMREX_D_DECL(plo[0], plo[1], plo[2])};
+  GpuArray<Real, AMREX_SPACEDIM> dxa = {AMREX_D_DECL(dx[0], dx[1], dx[2])};
+  Real R = amrData.ProbHi()[na[0]];
 
-    std::string infile;
-    pp.get("infile",infile);
+  // Only the I/O processor makes the directory if it doesn't already exist.
+  std::string output_dir = "Output";
+  if (ParallelDescriptor::IOProcessor())
+    if (!amrex::UtilCreateDirectory(output_dir, 0755))
+      amrex::CreateDirectoryFailed(output_dir);
 
-    // Initialize DataService
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
-    DataServices dataServices(infile, fileType);
-    if( ! dataServices.AmrDataOk()) {
-      DataServices::Dispatch(DataServices::ExitRequest, NULL);
+  // Force other processors to wait till directory is built.
+  ParallelDescriptor::Barrier();
+
+  std::string out_mean_file(output_dir + "/" + "mean.dat");
+  pp.query("out_mean_file", out_mean_file);
+  std::string out_mcmt_file(output_dir + "/" + "mcmt.dat");
+  pp.query("out_mcmt_file", out_mcmt_file);
+  std::ofstream os_mean(out_mean_file.c_str());
+  std::ofstream os_mcmt(out_mcmt_file.c_str());
+
+  int nPlanesPerPass = nBinPlanes;
+  bool parallelBin = 1;
+  pp.query("parallelBin", parallelBin);
+
+  if (parallelBin) {
+    BoxList bl;
+    for (int c = clo; c <= chi; c += nPlanesPerPass) {
+      int cbhi = amrex::min(c + nPlanesPerPass - 1, chi);
+      se[planeCoord] = c;
+      be[planeCoord] = cbhi;
+      bl.push_back(Box(se, be));
     }
-    AmrData& amrData = dataServices.AmrDataRef();
+    BoxArray ba(bl);
+    MultiFab data(ba, DistributionMapping(ba), comps.size(), 0);
+    int nBoxes = ba.size();
 
-    // Plotfile global infos
-    int finestLevel = amrData.FinestLevel(); pp.query("finestLevel",finestLevel);
-    AMREX_ALWAYS_ASSERT(finestLevel >= 0 && finestLevel<=amrData.FinestLevel());
+    Print() << "Reading data..." << std::endl;
+    amrData.FillVar(data, finestLevel, names, fillComps);
+    Print() << "Data has been read.  Processing..." << std::endl;
 
-    const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    RealBox rb(&(amrData.ProbLo()[0]), 
-               &(amrData.ProbHi()[0]));
+    Vector<Real> volWgtAvg2(nBoxes, 0);
+    Vector<Real> volWgtAvg3(nBoxes, 0);
+    Vector<Real> volWgtAvg4(nBoxes, 0);
+    Vector<Real> mcmt(nBoxes, 0);
+    Vector<Real> planeLoc(nBoxes, 0);
 
-    int nc = pp.countval("comps");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nc==6,"comps must be a list of 6 integers (adv_0, adv_1, Var1, Var2, Var3, vfrac");
-    Vector<int> comps(6);
-    pp.getarr("comps",comps,0,nc);
+    for (MFIter mfi(data); mfi.isValid(); ++mfi) {
+      const Box& b = mfi.validbox();
+      int idx = mfi.index();
+      FArrayBox bins(binbox, 2);       // Bins for adv0,adv1
+      FArrayBox rbins(rbinbox, 2);     // Bins for radius
+      Elixir e_bins = bins.elixir();   // Keep the fabs around until gpus done
+      Elixir e_rbins = rbins.elixir(); // --ditto
 
-    Box subbox = amrData.ProbDomain()[finestLevel];
-    Vector<int> inBox;
+      bins.setVal<RunOn::Device>(0);
+      rbins.setVal<RunOn::Device>(0);
 
-    if (int nx=pp.countval("box"))
-    {
-        pp.getarr("box",inBox,0,nx);
-        int d=AMREX_SPACEDIM;
-        AMREX_ASSERT(inBox.size()==2*d);
-        subbox=Box(IntVect(D_DECL(inBox[0],inBox[1],inBox[2])),
-                   IntVect(D_DECL(inBox[d],inBox[d+1],inBox[d+2])),
-                   IndexType::TheCellType());
+      const auto& f0a = data[mfi].array(0);  // Array4 for adv0
+      const auto& f1a = data[mfi].array(1);  // Array4 for adv1
+      const auto& vala = data[mfi].array(2); // Qty to bin in (adv0,adv1)
+      const auto& vola =
+        data[mfi].array(comps.size() - 1); // Volume (=1 for full cells)
+      const auto& outa = bins.array();     // Array4 for adv0,adv1 bins
+      const auto& outra = rbins.array();   // Array4 for radial bins
+
+      ParallelFor(b, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        int bin0 = amrex::max(
+          0, amrex::min(
+               nBin0 - 1,
+               (int)((nBin0 - 1) * (f0a(i, j, k) - v0min) / (v0max - v0min))));
+        int bin1 = amrex::max(
+          0, amrex::min(
+               nBin1 - 1,
+               (int)((nBin0 - 1) * (f1a(i, j, k) - v1min) / (v1max - v1min))));
+        HostDevice::Atomic::Add(
+          &outa(bin0, bin1, 0, 0), vala(i, j, k) * vola(i, j, k));
+        HostDevice::Atomic::Add(&outa(bin0, bin1, 0, 1), vola(i, j, k));
+
+        Real y = ploa[na[0]] + (j + 0.5) * dxa[na[0]];
+        Real z = ploa[na[1]] + (k + 0.5) * dxa[na[1]];
+        Real r = sqrt(y * y + z * z);
+        int binr =
+          amrex::max(0, amrex::min(nBinR, (int)((nBinR - 1) * (r / R))));
+        HostDevice::Atomic::Add(
+          &outra(0, binr, 0), vala(i, j, k) * vola(i, j, k));
+        HostDevice::Atomic::Add(&outra(0, binr, 1), vola(i, j, k));
+      });
+
+      amrex::Gpu::synchronize();
+
+      ParallelFor(binbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        if (outa(i, j, k, 1) > 0) {
+          outa(i, j, k, 0) = outa(i, j, k, 0) / outa(i, j, k, 1);
+        }
+      });
+
+      ParallelFor(rbinbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        if (outra(i, j, k, 1) > 0) {
+          outra(i, j, k, 0) = outra(i, j, k, 0) / outra(i, j, k, 1);
+        }
+      });
+
+      amrex::Gpu::synchronize();
+
+      planeLoc[idx] =
+        plo[planeCoord] +
+        (0.5 * (b.smallEnd(planeCoord) + b.bigEnd(planeCoord)) + 0.5) *
+          dx[planeCoord];
+
+      volWgtAvg2[idx] = VolWgtAvgC(data[mfi], 2, data[mfi], comps.size() - 1);
+      volWgtAvg3[idx] = VolWgtAvgC(data[mfi], 3, data[mfi], comps.size() - 1);
+      volWgtAvg4[idx] = VolWgtAvgC(data[mfi], 4, data[mfi], comps.size() - 1);
+      mcmt[idx] = rbins.max<RunOn::Device>(0);
     }
+    ParallelDescriptor::ReduceRealSum(volWgtAvg2.dataPtr(), nBoxes);
+    ParallelDescriptor::ReduceRealSum(volWgtAvg3.dataPtr(), nBoxes);
+    ParallelDescriptor::ReduceRealSum(volWgtAvg4.dataPtr(), nBoxes);
+    ParallelDescriptor::ReduceRealSum(mcmt.dataPtr(), nBoxes);
+    ParallelDescriptor::ReduceRealSum(planeLoc.dataPtr(), nBoxes);
 
-    subbox &= amrData.ProbDomain()[finestLevel];
-    
-    Vector<std::string> names(comps.size());
-    Vector<int> fillComps(comps.size());
-    
-    for (int i=0; i<comps.size(); ++i)
-    {
-      names[i] = amrData.PlotVarNames()[comps[i]];
-      fillComps[i] = i;
-    }
-
-    int planeCoord = 0; pp.get("planeCoord",planeCoord);
-    const Vector<Real>& plo = amrData.ProbLo();
-    Vector<Real> dx = amrData.CellSize(finestLevel);
-        
-    IntVect se = subbox.smallEnd();
-    IntVect be = subbox.bigEnd();
-    int clo = se[planeCoord];
-    int chi = be[planeCoord];
-
-    Real v0min = 0;
-    Real v0max = 1;
-    int nBin0 = 64; pp.query("nBins",nBin0);
-    int nBin1 = nBin0;
-    Real v1min = 0;
-    Real v1max = 1;
-    Box binbox(IntVect(AMREX_D_DECL(0,0,0)),
-               IntVect(AMREX_D_DECL(nBin0-1,nBin1-1,0)));
-    int nBinR = nBin0;
-    Box rbinbox(IntVect(AMREX_D_DECL(0,0,0)),
-                IntVect(AMREX_D_DECL(0,nBinR-1,0)));
-
-    FArrayBox outbins(binbox,2);
-    FArrayBox outrbins(rbinbox,2);
-    outbins.setVal<RunOn::Device>(0);
-    outrbins.setVal<RunOn::Device>(0);
-    int nBinPlanes = 10; pp.query("nBinPlanes",nBinPlanes);
-    int numPlanesSoFar = 0;
-    
-    GpuArray<Real,AMREX_SPACEDIM-1> na;
-    int icnt = 0;
-    for (int i=0; i<AMREX_SPACEDIM; ++i) {
-      if (i!=planeCoord) {
-        na[icnt++] = i;
+    if (ParallelDescriptor::IOProcessor()) {
+      for (int i = 0; i < nBoxes; ++i) {
+        os_mcmt << planeLoc[i] << " " << mcmt[i] << std::endl;
+        os_mean << planeLoc[i] << " " << volWgtAvg2[i] << " " << volWgtAvg3[i]
+                << " " << volWgtAvg4[i] << std::endl;
       }
     }
-    GpuArray<Real,AMREX_SPACEDIM> ploa = {AMREX_D_DECL(plo[0],plo[1],plo[2])};
-    GpuArray<Real,AMREX_SPACEDIM> dxa  = {AMREX_D_DECL( dx[0], dx[1], dx[2])};
-    Real R = amrData.ProbHi()[na[0]];
+  } else {
+    for (int c = clo; c <= chi; c += nPlanesPerPass) {
 
-    // Only the I/O processor makes the directory if it doesn't already exist.
-    std::string output_dir = "Output";
-    if (ParallelDescriptor::IOProcessor())
-      if (!amrex::UtilCreateDirectory(output_dir, 0755))
-        amrex::CreateDirectoryFailed(output_dir);
+      int cbhi = amrex::min(c + nPlanesPerPass - 1, chi);
+      Real planeLoc =
+        plo[planeCoord] + (0.5 * (c + cbhi) + 0.5) * dx[planeCoord];
+      Print() << "Planes " << c << ":" << cbhi << " at " << planeLoc
+              << std::endl;
 
-    // Force other processors to wait till directory is built.
-    ParallelDescriptor::Barrier();
-
-
-    std::string out_mean_file(output_dir + "/" + "mean.dat"); pp.query("out_mean_file",out_mean_file);
-    std::string out_mcmt_file(output_dir + "/" + "mcmt.dat"); pp.query("out_mcmt_file",out_mcmt_file);
-    std::ofstream os_mean(out_mean_file.c_str());
-    std::ofstream os_mcmt(out_mcmt_file.c_str());
-
-    int nPlanesPerPass = nBinPlanes;
-    bool parallelBin = 1; pp.query("parallelBin",parallelBin);
-
-    if (parallelBin)
-    {
-      BoxList bl;
-      for (int c=clo; c<=chi; c+=nPlanesPerPass)
-      {
-        int cbhi = amrex::min(c + nPlanesPerPass - 1, chi);
-        se[planeCoord] = c;
-        be[planeCoord] = cbhi;
-        bl.push_back(Box(se,be));
+      se[planeCoord] = c;
+      be[planeCoord] = cbhi;
+      Box fabbox(se, be);
+      Array<std::unique_ptr<FArrayBox>, 6> datav;
+      if (ParallelDescriptor::IOProcessor()) {
+        for (int ic = 0; ic < comps.size(); ic++) {
+          datav[ic] = std::unique_ptr<FArrayBox>(new FArrayBox(fabbox, 1));
+        }
       }
-      BoxArray ba(bl);
-      MultiFab data(ba,DistributionMapping(ba),comps.size(),0);
-      int nBoxes = ba.size();
 
-      Print() << "Reading data..." << std::endl;
-      amrData.FillVar(data,finestLevel,names,fillComps);
-      Print() << "Data has been read.  Processing..." << std::endl;
+      // get the data
+      for (int ic = 0; ic < comps.size(); ++ic) {
+        amrData.FillVar(
+          datav[ic].get(), fabbox, finestLevel, names[ic],
+          ParallelDescriptor::IOProcessorNumber());
+      }
 
-      Vector<Real> volWgtAvg2(nBoxes,0);
-      Vector<Real> volWgtAvg3(nBoxes,0);
-      Vector<Real> volWgtAvg4(nBoxes,0);
-      Vector<Real> mcmt(nBoxes,0);
-      Vector<Real> planeLoc(nBoxes,0);
+      if (ParallelDescriptor::IOProcessor()) {
 
-      for (MFIter mfi(data); mfi.isValid(); ++mfi)
-      {
-        const Box& b = mfi.validbox();
-        int idx = mfi.index();
-        FArrayBox bins(binbox,2);   // Bins for adv0,adv1
-        FArrayBox rbins(rbinbox,2); // Bins for radius
-        Elixir e_bins = bins.elixir();   // Keep the fabs around until gpus done
-        Elixir e_rbins = rbins.elixir(); // --ditto
+        // for each cell, find the 2D bin, and increment the volume and var
+        // value in the result fab
+        const auto& f0a = datav[0]->array();
+        const auto& f1a = datav[1]->array();
+        const auto& vala = datav[2]->array();
+        const auto& vola = datav[comps.size() - 1]->array();
+        const auto& outa = outbins.array();
+        const auto& outra = outrbins.array();
 
-        bins.setVal<RunOn::Device>(0);
-        rbins.setVal<RunOn::Device>(0);
+        ParallelFor(fabbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+          int bin0 = amrex::max(
+            0, amrex::min(
+                 nBin0 - 1, (int)((nBin0 - 1) * (f0a(i, j, k) - v0min) /
+                                  (v0max - v0min))));
+          int bin1 = amrex::max(
+            0, amrex::min(
+                 nBin1 - 1, (int)((nBin0 - 1) * (f1a(i, j, k) - v1min) /
+                                  (v1max - v1min))));
+          HostDevice::Atomic::Add(
+            &outa(bin0, bin1, 0, 0), vala(i, j, k) * vola(i, j, k));
+          HostDevice::Atomic::Add(&outa(bin0, bin1, 0, 1), vola(i, j, k));
 
-        const auto& f0a = data[mfi].array(0); // Array4 for adv0
-        const auto& f1a = data[mfi].array(1); // Array4 for adv1
-        const auto& vala = data[mfi].array(2); // Qty to bin in (adv0,adv1)
-        const auto& vola = data[mfi].array(comps.size()-1); //Volume (=1 for full cells)
-        const auto& outa = bins.array();   // Array4 for adv0,adv1 bins
-        const auto& outra = rbins.array(); // Array4 for radial bins
-
-        ParallelFor(b,
-                    [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-                      {
-                        int bin0 = amrex::max(0,amrex::min(nBin0-1,(int)((nBin0-1)*(f0a(i,j,k) - v0min)/(v0max - v0min))));
-                        int bin1 = amrex::max(0,amrex::min(nBin1-1,(int)((nBin0-1)*(f1a(i,j,k) - v1min)/(v1max - v1min))));
-                        HostDevice::Atomic::Add(&outa(bin0,bin1,0,0),vala(i,j,k) * vola(i,j,k));
-                        HostDevice::Atomic::Add(&outa(bin0,bin1,0,1),vola(i,j,k));
-
-                        Real y = ploa[na[0]] + (j+0.5)*dxa[na[0]];
-                        Real z = ploa[na[1]] + (k+0.5)*dxa[na[1]];
-                        Real r = sqrt(y*y + z*z);
-                        int binr = amrex::max(0,amrex::min(nBinR,(int)((nBinR-1)*(r/R))));
-                        HostDevice::Atomic::Add(&outra(0,binr,0),vala(i,j,k)*vola(i,j,k));
-                        HostDevice::Atomic::Add(&outra(0,binr,1),vola(i,j,k));
-                      });
-
+          Real y = ploa[na[0]] + (j + 0.5) * dxa[na[0]];
+          Real z = ploa[na[1]] + (k + 0.5) * dxa[na[1]];
+          Real r = sqrt(y * y + z * z);
+          int binr =
+            amrex::max(0, amrex::min(nBinR, (int)((nBinR - 1) * (r / R))));
+          HostDevice::Atomic::Add(
+            &outra(0, binr, 0), vala(i, j, k) * vola(i, j, k));
+          HostDevice::Atomic::Add(&outra(0, binr, 1), vola(i, j, k));
+        });
         amrex::Gpu::synchronize();
 
-        ParallelFor(binbox,
-                    [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-                      {
-                        if (outa(i,j,k,1) > 0) {
-                          outa(i,j,k,0) = outa(i,j,k,0) / outa(i,j,k,1);
-                        }
-                      });
+        numPlanesSoFar += nPlanesPerPass;
+        if (numPlanesSoFar >= nBinPlanes) {
 
-        ParallelFor(rbinbox,
-                    [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-                      {
-                        if (outra(i,j,k,1) > 0) {
-                          outra(i,j,k,0) = outra(i,j,k,0) / outra(i,j,k,1);
-                        }
-                      });
+          ParallelFor(
+            binbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+              if (outa(i, j, k, 1) > 0) {
+                outa(i, j, k, 0) = outa(i, j, k, 0) / outa(i, j, k, 1);
+              }
+            });
 
-        amrex::Gpu::synchronize();
-      
-        planeLoc[idx] = plo[planeCoord] + ( 0.5*(b.smallEnd(planeCoord)+b.bigEnd(planeCoord))+0.5)*dx[planeCoord];
+          ParallelFor(
+            rbinbox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+              if (outra(i, j, k, 1) > 0) {
+                outra(i, j, k, 0) = outra(i, j, k, 0) / outra(i, j, k, 1);
+              }
+            });
 
-        volWgtAvg2[idx] = VolWgtAvgC(data[mfi], 2, data[mfi], comps.size()-1);
-        volWgtAvg3[idx] = VolWgtAvgC(data[mfi], 3, data[mfi], comps.size()-1);
-        volWgtAvg4[idx] = VolWgtAvgC(data[mfi], 4, data[mfi], comps.size()-1);
-        mcmt[idx] = rbins.max<RunOn::Device>(0);
-      }
-      ParallelDescriptor::ReduceRealSum(volWgtAvg2.dataPtr(), nBoxes);
-      ParallelDescriptor::ReduceRealSum(volWgtAvg3.dataPtr(), nBoxes);
-      ParallelDescriptor::ReduceRealSum(volWgtAvg4.dataPtr(), nBoxes);
-      ParallelDescriptor::ReduceRealSum(mcmt.dataPtr(),       nBoxes);
-      ParallelDescriptor::ReduceRealSum(planeLoc.dataPtr(),   nBoxes);
-
-      if (ParallelDescriptor::IOProcessor())
-      {
-        for (int i=0; i<nBoxes; ++i) {
-          os_mcmt << planeLoc[i] << " " << mcmt[i] << std::endl;
-          os_mean << planeLoc[i] << " " << volWgtAvg2[i] <<  " " << volWgtAvg3[i] <<  " " << volWgtAvg4[i] << std::endl;
-        }
-      }
-    }
-    else
-    {
-      for (int c=clo; c<=chi; c+=nPlanesPerPass) {
-
-        int cbhi = amrex::min(c + nPlanesPerPass - 1, chi);
-        Real planeLoc = plo[planeCoord] + ( 0.5*(c+cbhi)+0.5)*dx[planeCoord];
-        Print() << "Planes " << c << ":" << cbhi << " at " << planeLoc << std::endl;
-      
-        se[planeCoord] = c;
-        be[planeCoord] = cbhi;
-        Box fabbox(se,be);
-        Array<std::unique_ptr<FArrayBox>, 6> datav;
-        if (ParallelDescriptor::IOProcessor()) {
-          for (int ic=0; ic<comps.size(); ic++) {
-            datav[ic] = std::unique_ptr<FArrayBox>(new FArrayBox(fabbox,1));
-          }
-        }
-
-        // get the data
-        for (int ic=0; ic<comps.size(); ++ic) {
-          amrData.FillVar(datav[ic].get(),fabbox,finestLevel,names[ic],ParallelDescriptor::IOProcessorNumber());
-        }
-
-        if (ParallelDescriptor::IOProcessor()) {
-
-          // for each cell, find the 2D bin, and increment the volume and var value in the result fab
-          const auto& f0a = datav[0]->array();
-          const auto& f1a = datav[1]->array();
-          const auto& vala = datav[2]->array();
-          const auto& vola = datav[comps.size()-1]->array();
-          const auto& outa = outbins.array();
-          const auto& outra = outrbins.array();
-
-          ParallelFor(fabbox,
-                      [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-                        {
-                          int bin0 = amrex::max(0,amrex::min(nBin0-1,(int)((nBin0-1)*(f0a(i,j,k) - v0min)/(v0max - v0min))));
-                          int bin1 = amrex::max(0,amrex::min(nBin1-1,(int)((nBin0-1)*(f1a(i,j,k) - v1min)/(v1max - v1min))));
-                          HostDevice::Atomic::Add(&outa(bin0,bin1,0,0),vala(i,j,k) * vola(i,j,k));
-                          HostDevice::Atomic::Add(&outa(bin0,bin1,0,1),vola(i,j,k));
-
-                          Real y = ploa[na[0]] + (j+0.5)*dxa[na[0]];
-                          Real z = ploa[na[1]] + (k+0.5)*dxa[na[1]];
-                          Real r = sqrt(y*y + z*z);
-                          int binr = amrex::max(0,amrex::min(nBinR,(int)((nBinR-1)*(r/R))));
-                          HostDevice::Atomic::Add(&outra(0,binr,0),vala(i,j,k)*vola(i,j,k));
-                          HostDevice::Atomic::Add(&outra(0,binr,1),vola(i,j,k));
-                        });
           amrex::Gpu::synchronize();
-        
-          numPlanesSoFar+=nPlanesPerPass;
-          if (numPlanesSoFar>=nBinPlanes) {
-          
-            ParallelFor(binbox,
-                        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-                          {
-                            if (outa(i,j,k,1) > 0) {
-                              outa(i,j,k,0) = outa(i,j,k,0) / outa(i,j,k,1);
-                            }
-                          });
 
-            ParallelFor(rbinbox,
-                        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-                          {
-                            if (outra(i,j,k,1) > 0) {
-                              outra(i,j,k,0) = outra(i,j,k,0) / outra(i,j,k,1);
-                            }
-                          });
+          std::string plane_file = Concatenate("Output/bins_", c, 5) + ".fab";
+          std::ofstream osf;
+          osf.open(plane_file.c_str());
+          outbins.writeOn(osf);
+          osf.close();
 
-            amrex::Gpu::synchronize();
+          std::string rplane_file = Concatenate("Output/rbins_", c, 5) + ".fab";
+          std::ofstream osfr;
+          osfr.open(rplane_file.c_str());
+          outrbins.writeOn(osfr);
+          osfr.close();
 
-            std::string plane_file = Concatenate("Output/bins_",c,5) + ".fab";
-            std::ofstream osf;
-            osf.open(plane_file.c_str());
-            outbins.writeOn(osf);
-            osf.close();
+          os_mcmt << planeLoc << " " << outrbins.max<RunOn::Device>(0)
+                  << std::endl;
 
-            std::string rplane_file = Concatenate("Output/rbins_",c,5) + ".fab";
-            std::ofstream osfr;
-            osfr.open(rplane_file.c_str());
-            outrbins.writeOn(osfr);
-            osfr.close();
-
-            os_mcmt << planeLoc << " " << outrbins.max<RunOn::Device>(0) << std::endl;
-
-            numPlanesSoFar = 0;
-            outbins.setVal<RunOn::Device>(0);
-            outrbins.setVal<RunOn::Device>(0);
-          }
-
-          Real volWgtAvg2 = VolWgtAvg(*datav[2],*datav[comps.size()-1]);
-          Real volWgtAvg3 = VolWgtAvg(*datav[3],*datav[comps.size()-1]);
-          Real volWgtAvg4 = VolWgtAvg(*datav[4],*datav[comps.size()-1]);
-
-          os_mean << planeLoc << " " << volWgtAvg2 <<  " " << volWgtAvg3 <<  " " << volWgtAvg4 << std::endl;
-
+          numPlanesSoFar = 0;
+          outbins.setVal<RunOn::Device>(0);
+          outrbins.setVal<RunOn::Device>(0);
         }
+
+        Real volWgtAvg2 = VolWgtAvg(*datav[2], *datav[comps.size() - 1]);
+        Real volWgtAvg3 = VolWgtAvg(*datav[3], *datav[comps.size() - 1]);
+        Real volWgtAvg4 = VolWgtAvg(*datav[4], *datav[comps.size() - 1]);
+
+        os_mean << planeLoc << " " << volWgtAvg2 << " " << volWgtAvg3 << " "
+                << volWgtAvg4 << std::endl;
       }
     }
-    
-    os_mean.close();
-    os_mcmt.close();
-    amrex::Finalize();
+  }
+
+  os_mean.close();
+  os_mcmt.close();
+  amrex::Finalize();
 }

--- a/Src/ModelSpecificAnalysis/testQPDtools.cpp
+++ b/Src/ModelSpecificAnalysis/testQPDtools.cpp
@@ -15,10 +15,9 @@ using namespace amrex;
 using namespace analysis_util;
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     ParmParse pp;
 
@@ -26,7 +25,7 @@ main (int   argc,
     Vector<std::string> elem_names;
     CKSYME_STR(elem_names);
     Print() << "{ ";
-    for (int i=0; i<NUM_ELEMENTS; ++i) {
+    for (int i = 0; i < NUM_ELEMENTS; ++i) {
       Print() << elem_names[i] << " ";
     }
     Print() << "}" << std::endl;
@@ -35,18 +34,18 @@ main (int   argc,
     Vector<std::string> spec_names;
     CKSYMS_STR(spec_names);
     Print() << "{ ";
-    for (int i=0; i<NUM_SPECIES; ++i) {
+    for (int i = 0; i < NUM_SPECIES; ++i) {
       Print() << spec_names[i] << " ";
     }
     Print() << "}" << std::endl;
 
     Print() << "\n ==> Species composition \n";
-    for (int i=0; i<NUM_SPECIES; ++i) {
+    for (int i = 0; i < NUM_SPECIES; ++i) {
       Print() << spec_names[i] << " = { ";
-      for (int j=0; j<NUM_ELEMENTS; ++j) {
-        int ne = NumElemXinSpecY(j,i);
+      for (int j = 0; j < NUM_ELEMENTS; ++j) {
+        int ne = NumElemXinSpecY(j, i);
         if (ne > 0) {
-          Print() << elem_names[j] << ":" << ne << " "; 
+          Print() << elem_names[j] << ":" << ne << " ";
         }
       }
       Print() << "}\n";
@@ -55,19 +54,19 @@ main (int   argc,
     Print() << "\n ==> NumReactions: " << NUM_REACTIONS << std::endl;
 
     Print() << "\n ==> Species in reactions \n";
-    for (int i=0; i<NUM_SPECIES; ++i) {
+    for (int i = 0; i < NUM_SPECIES; ++i) {
       Vector<int> rnsL;
-      getReactWithXOnL(rnsL,i);
-      Print() << "Spec, rnsL, rnsR: " << spec_names[i] <<  ": ";
+      getReactWithXOnL(rnsL, i);
+      Print() << "Spec, rnsL, rnsR: " << spec_names[i] << ": ";
       Print() << "{ ";
-      for (int j=0; j<rnsL.size(); ++j) {
+      for (int j = 0; j < rnsL.size(); ++j) {
         Print() << rnsL[j] << " ";
       }
       Print() << "}";
       Vector<int> rnsR;
-      getReactWithXOnR(rnsR,i);
+      getReactWithXOnR(rnsR, i);
       Print() << " { ";
-      for (int j=0; j<rnsR.size(); ++j) {
+      for (int j = 0; j < rnsR.size(); ++j) {
         Print() << rnsR[j] << " ";
       }
       Print() << "}" << std::endl;
@@ -76,28 +75,28 @@ main (int   argc,
     Print() << "\n ==> RMAP \n";
     Vector<int> rmap = GetReactionMap();
     Print() << "{ ";
-    for (int j=0; j<rmap.size(); ++j) {
+    for (int j = 0; j < rmap.size(); ++j) {
       Print() << rmap[j] << " ";
     }
     Print() << "}\n";
 
     // Build revese reaction map
     Vector<int> rrmap(NUM_REACTIONS);
-    for (int i=0; i<NUM_REACTIONS; ++i) {
+    for (int i = 0; i < NUM_REACTIONS; ++i) {
       rrmap[rmap[i]] = i;
     }
     Print() << "\n ==> RRMAP \n";
     Print() << "{ ";
-    for (int j=0; j<rrmap.size(); ++j) {
+    for (int j = 0; j < rrmap.size(); ++j) {
       Print() << rrmap[j] << " ";
     }
     Print() << "}\n";
 
     Print() << "\n ==> Stoich coeffs \n";
-    for (int j=0; j<NUM_REACTIONS; ++j) {
+    for (int j = 0; j < NUM_REACTIONS; ++j) {
       auto sc = specCoeffsInReactions(rmap[j]);
       Print() << "rn[" << j << "] (" << rmap[j] << ") = { ";
-      for (int i=0; i<sc.size(); ++i) {
+      for (int i = 0; i < sc.size(); ++i) {
         Print() << sc[i].first << ":" << sc[i].second << " ";
       }
       Print() << "}\n";
@@ -105,9 +104,10 @@ main (int   argc,
 
     Print() << "\n ==> Edges \n";
     std::string trElem = "C";
-    pp.query("trElem",trElem);
-    AMREX_ALWAYS_ASSERT(IndexElem(trElem)>=0 && IndexElem(trElem)<NUM_ELEMENTS);
-    auto edges = getEdges(trElem,1,1);
+    pp.query("trElem", trElem);
+    AMREX_ALWAYS_ASSERT(
+      IndexElem(trElem) >= 0 && IndexElem(trElem) < NUM_ELEMENTS);
+    auto edges = getEdges(trElem, 1, 1);
     for (auto edge : edges) {
       Print() << edge << std::endl;
     }

--- a/Src/ModelSpecificAnalysis/testTsolve.cpp
+++ b/Src/ModelSpecificAnalysis/testTsolve.cpp
@@ -16,10 +16,8 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
@@ -29,33 +27,33 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
       // ^^^ this calls ParallelDescriptor::EndParallel() and exit()
     }
@@ -64,7 +62,7 @@ main (int   argc,
     EOS::init();
 
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
     int idYin = -1;
@@ -72,14 +70,15 @@ main (int   argc,
     Vector<std::string> spec_names;
     EOS::speciesNames(spec_names);
     const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    const std::string spName= "Y(" + spec_names[0] + ")";
+    const std::string spName = "Y(" + spec_names[0] + ")";
     const std::string TName = "temp";
-    for (int i=0; i<plotVarNames.size(); ++i)
-    {
-      if (plotVarNames[i] == spName) idYin = i;
-      if (plotVarNames[i] == TName) idTin = i;
+    for (int i = 0; i < plotVarNames.size(); ++i) {
+      if (plotVarNames[i] == spName)
+        idYin = i;
+      if (plotVarNames[i] == TName)
+        idTin = i;
     }
-    if (idYin<0 || idTin<0)
+    if (idYin < 0 || idTin < 0)
       Print() << "Cannot find required data in pltfile" << std::endl;
 
     const int idTout = 0;
@@ -90,54 +89,50 @@ main (int   argc,
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
-    const int idYlocal = 0; // Ys start here
+    const int idYlocal = 0;           // Ys start here
     const int idTlocal = NUM_SPECIES; // T start here
-    for (int i=0; i<NUM_SPECIES; ++i)
-    {
+    for (int i = 0; i < NUM_SPECIES; ++i) {
       destFillComps[i] = idYlocal + i;
-      inNames[i] =  "Y(" + spec_names[i] + ")";
+      inNames[i] = "Y(" + spec_names[i] + ")";
     }
     destFillComps[idTlocal] = idTlocal;
     inNames[idTlocal] = TName;
     outNames[idTout] = TName;
     outNames[iddTout] = "d" + TName;
-    
+
     Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     const int nGrow = 0;
 
-    for (int lev=0; lev<Nlev; ++lev)
-    {
+    for (int lev = 0; lev < Nlev; ++lev) {
       const BoxArray ba = amrData.boxArray(lev);
       const DistributionMapping dm(ba);
-      outdata[lev].reset(new MultiFab(ba,dm,nCompOut,nGrow));
-      MultiFab indata(ba,dm,nCompIn,nGrow);
+      outdata[lev].reset(new MultiFab(ba, dm, nCompOut, nGrow));
+      MultiFab indata(ba, dm, nCompIn, nGrow);
 
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps);
+      amrData.FillVar(indata, lev, inNames, destFillComps);
       Print() << "Data has been read for level " << lev << std::endl;
 
-      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
+      for (MFIter mfi(indata, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const Box& bx = mfi.tilebox();
-        Array4<Real> const& Y = indata.array(mfi,idYlocal);
-        Array4<Real> const& Tin = indata.array(mfi,idTlocal);
-        Array4<Real> const& Tout = (*outdata[lev]).array(mfi,idTout);
-        Array4<Real> const& dTout = (*outdata[lev]).array(mfi,iddTout);
+        Array4<Real> const& Y = indata.array(mfi, idYlocal);
+        Array4<Real> const& Tin = indata.array(mfi, idTlocal);
+        Array4<Real> const& Tout = (*outdata[lev]).array(mfi, idTout);
+        Array4<Real> const& dTout = (*outdata[lev]).array(mfi, iddTout);
 
-        AMREX_PARALLEL_FOR_3D ( bx, i, j, k,
-        {
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
           Real Yl[NUM_SPECIES];
           Real Xl[NUM_SPECIES];
-          for (int n=0; n<NUM_SPECIES; ++n) {
-            Yl[n] = Y(i,j,k,idYlocal+n);
+          for (int n = 0; n < NUM_SPECIES; ++n) {
+            Yl[n] = Y(i, j, k, idYlocal + n);
           }
           Real H;
-          EOS::TY2H(Tin(i,j,k),Yl,H);
+          EOS::TY2H(Tin(i, j, k), Yl, H);
 
           Real Tsolve = 300;
-          EOS::HY2T(H,Yl,Tsolve);
-          Tout(i,j,k) = Tsolve;
-          dTout(i,j,k) = Tsolve - Tin(i,j,k);
+          EOS::HY2T(H, Yl, Tsolve);
+          Tout(i, j, k) = Tsolve;
+          dTout(i, j, k) = Tsolve - Tin(i, j, k);
         });
       }
 
@@ -147,7 +142,7 @@ main (int   argc,
     std::string outfile(getFileRoot(plotFileName) + "_T");
     Print() << "Writing new data to " << outfile << std::endl;
     const bool verb = false;
-    WritePlotFile(GetVecOfPtrs(outdata),amrData,outfile,verb,outNames);
+    WritePlotFile(GetVecOfPtrs(outdata), amrData, outfile, verb, outNames);
   }
   Finalize();
   return 0;

--- a/Src/StreamData.H
+++ b/Src/StreamData.H
@@ -3,17 +3,13 @@
 
 #include <AMReX_AmrData.H>
 
-
-class StreamData
-  : protected amrex::AmrData
+class StreamData : protected amrex::AmrData
 {
 public:
   struct MLloc
   {
-    MLloc() :
-      amr_lev(-1), box_idx(-1), pt_idx(-1) {}
-    MLloc(int lev,int box,int pt) :
-      amr_lev(lev), box_idx(box), pt_idx(pt) {}
+    MLloc() : amr_lev(-1), box_idx(-1), pt_idx(-1) {}
+    MLloc(int lev, int box, int pt) : amr_lev(lev), box_idx(box), pt_idx(pt) {}
     int amr_lev, box_idx, pt_idx;
   };
 
@@ -21,55 +17,71 @@ public:
   bool ReadInfo();
   int NElts() const { return num_global_elements; }
   int NLines() const { return nLines; }
-  const amrex::BoxArray &boxArray(int level) const;
-  const amrex::Vector<std::string>& ComponentNames() const {return plotVars;}
-  const std::string& StreamFileVersion() const {return plotFileVersion;}
+  const amrex::BoxArray& boxArray(int level) const;
+  const amrex::Vector<std::string>& ComponentNames() const { return plotVars; }
+  const std::string& StreamFileVersion() const { return plotFileVersion; }
   const amrex::Vector<int>& InsideNodes(int level, int box_id) const;
   int StreamIdxLo() const { return streamIdxLo; }
   int StreamIdxHi() const { return streamIdxHi; }
-  static amrex::Box& invalidBox() {return ZBOX;}
-  const amrex::FArrayBox* getFab (int level,
-                                  int fabIdx,
-                                  int compIdx);
-  const amrex::DistributionMapping& DistributionMap (int level) const;
-  void WriteFile(std::string&              outfile,
-                 const amrex::Vector<amrex::MultiFab*>&  data,
-                 int                       sComp,
-                 int                       nComp,
-                 const amrex::Vector<std::string>& names,
-                 const std::string&        FileFormatName = StreamData::FileFormatName00()) const;
+  static amrex::Box& invalidBox() { return ZBOX; }
+  const amrex::FArrayBox* getFab(int level, int fabIdx, int compIdx);
+  const amrex::DistributionMapping& DistributionMap(int level) const;
+  void WriteFile(
+    std::string& outfile,
+    const amrex::Vector<amrex::MultiFab*>& data,
+    int sComp,
+    int nComp,
+    const amrex::Vector<std::string>& names,
+    const std::string& FileFormatName = StreamData::FileFormatName00()) const;
 
-  void WriteFile(std::string&       outfile,
-                 const amrex::Vector<int>&  comps,
-                 const std::string& FileFormatName = StreamData::FileFormatName00()) const;
+  void WriteFile(
+    std::string& outfile,
+    const amrex::Vector<int>& comps,
+    const std::string& FileFormatName = StreamData::FileFormatName00()) const;
 
-  int NodesPerElt() const {return nodes_per_element;}
-  const amrex::Vector<int>& GlobalElements () const {return global_element_node_ids;}
-  const amrex::Vector<int>& LocalElements (); // The list of globally-numbered nodes forming each element on this processor
-  const amrex::Vector<int>& LocalElementIDs (); // The list of globally numbered elements local to this processor
+  int NodesPerElt() const { return nodes_per_element; }
+  const amrex::Vector<int>& GlobalElements() const
+  {
+    return global_element_node_ids;
+  }
+  const amrex::Vector<int>&
+  LocalElements(); // The list of globally-numbered nodes forming each element
+                   // on this processor
+  const amrex::Vector<int>&
+  LocalElementIDs(); // The list of globally numbered elements local to this
+                     // processor
   const std::vector<StreamData::MLloc>& GlobalNodeMap() const;
-  const std::map<int,StreamData::MLloc>& LocalNodeMap();
-  void PartitionElements (int nCompPass = 5);
-  void PartitionElements (int nCompPass, const amrex::Vector<int>& comps);
+  const std::map<int, StreamData::MLloc>& LocalNodeMap();
+  void PartitionElements(int nCompPass = 5);
+  void PartitionElements(int nCompPass, const amrex::Vector<int>& comps);
 
   // Promote some AmrData functions
-  using AmrData::NComp;
-  using AmrData::GetFileName;
-  using AmrData::StateNumber;
-  using AmrData::GetGrids;
   using AmrData::FinestLevel;
+  using AmrData::GetFileName;
+  using AmrData::GetGrids;
   using AmrData::MinMax;
+  using AmrData::NComp;
   using AmrData::ProbDomain;
+  using AmrData::StateNumber;
 
   void FlushGrids(int componentIndex);
 
-  const amrex::Vector<std::string> &StreamVarNames() const { return PlotVarNames(); }
+  const amrex::Vector<std::string>& StreamVarNames() const
+  {
+    return PlotVarNames();
+  }
 
-  static std::string FileFormatName00() { return "Oddball-multilevel-connected-data-format";}
-  static std::string FileFormatName10() { return "Oddball-multilevel-connected-data-format-1.0";}
+  static std::string FileFormatName00()
+  {
+    return "Oddball-multilevel-connected-data-format";
+  }
+  static std::string FileFormatName10()
+  {
+    return "Oddball-multilevel-connected-data-format-1.0";
+  }
 
-  void SetStreamVerbose(int v) {stream_verbose = v;}
-  int StreamVerbose() const {return stream_verbose;}
+  void SetStreamVerbose(int v) { stream_verbose = v; }
+  int StreamVerbose() const { return stream_verbose; }
 
 protected:
   void BuildGlobalNodeMap() const;
@@ -82,7 +94,7 @@ protected:
   int num_global_elements;
   int nLines;
   int nodes_per_element;
-  amrex::Vector<amrex::Vector<amrex::Vector<int> > > inside_nodes;
+  amrex::Vector<amrex::Vector<amrex::Vector<int>>> inside_nodes;
   int streamIdxLo, streamIdxHi;
   static amrex::Box ZBOX;
   bool is_version_0;
@@ -90,15 +102,15 @@ protected:
   std::string ElementFileName;
   std::string ElementFileFormat;
   mutable std::vector<StreamData::MLloc> global_node_map;
-  mutable std::map<int,StreamData::MLloc> local_node_map;
+  mutable std::map<int, StreamData::MLloc> local_node_map;
 
   // Used in the partitioning
-  mutable std::map<int,std::map<int,const MLloc*> > remote_nodes;
-  mutable std::map<int,std::map<int,const MLloc*> > tosend_nodes;
+  mutable std::map<int, std::map<int, const MLloc*>> remote_nodes;
+  mutable std::map<int, std::map<int, const MLloc*>> tosend_nodes;
   mutable amrex::Vector<int> local_element_node_ids;
   mutable amrex::Vector<int> local_element_ids;
-  mutable std::map<int,int> global_to_local_node_ids;
-  mutable std::map<int,int> local_to_global_node_ids;
+  mutable std::map<int, int> global_to_local_node_ids;
+  mutable std::map<int, int> local_to_global_node_ids;
   mutable amrex::Vector<amrex::FArrayBox*> boundaryNodes;
   int stream_verbose;
 };

--- a/Src/StreamData.cpp
+++ b/Src/StreamData.cpp
@@ -3,8 +3,8 @@
 
 using namespace amrex;
 using std::cerr;
-using std::endl;
 using std::cout;
+using std::endl;
 using std::ios;
 
 #include <AMReX_Utility.H>
@@ -13,533 +13,536 @@ const std::string HeaderFileName_DEF("Header");
 const std::string ElementFileName_DEF("Elements");
 const std::string ElementFileFormat_DEF("ELEMENT_DATA_ASCII");
 
+Box StreamData::ZBOX(IntVect::TheZeroVector(), IntVect::TheZeroVector());
 
-Box StreamData::ZBOX(IntVect::TheZeroVector(),IntVect::TheZeroVector());
-
-StreamData::StreamData(const std::string& file)
-    : AmrData(), filename(file)
+StreamData::StreamData(const std::string& file) : AmrData(), filename(file)
 {
-    if (! (ReadInfo() ) )
-        Abort(std::string(std::string("StreamData failed - bad filename: ")+file).c_str());
+  if (!(ReadInfo()))
+    Abort(std::string(std::string("StreamData failed - bad filename: ") + file)
+            .c_str());
 }
 
 bool
 StreamData::DefineFab(int level, int componentIndex, int fabIndex)
-{   
-    if( ! dataGridsDefined[level][componentIndex][fabIndex]) {
-        AMREX_ASSERT(componentIndex < compIndexToVisMFMap.size());
-        AMREX_ASSERT(componentIndex < compIndexToVisMFComponentMap.size());
-        int whichVisMF(compIndexToVisMFMap[componentIndex]);
-        int whichVisMFComponent(compIndexToVisMFComponentMap[componentIndex]);
-        dataGrids[level][componentIndex]->setFab(
-            fabIndex,
-            std::unique_ptr<FArrayBox>(visMF[level][whichVisMF]->readFAB(fabIndex, whichVisMFComponent)));
-        dataGridsDefined[level][componentIndex][fabIndex] = true;
-    }
-    return true;
+{
+  if (!dataGridsDefined[level][componentIndex][fabIndex]) {
+    AMREX_ASSERT(componentIndex < compIndexToVisMFMap.size());
+    AMREX_ASSERT(componentIndex < compIndexToVisMFComponentMap.size());
+    int whichVisMF(compIndexToVisMFMap[componentIndex]);
+    int whichVisMFComponent(compIndexToVisMFComponentMap[componentIndex]);
+    dataGrids[level][componentIndex]->setFab(
+      fabIndex, std::unique_ptr<FArrayBox>(visMF[level][whichVisMF]->readFAB(
+                  fabIndex, whichVisMFComponent)));
+    dataGridsDefined[level][componentIndex][fabIndex] = true;
+  }
+  return true;
 }
 
 const FArrayBox*
-StreamData::getFab (int level,
-                    int fabIdx,
-                    int compIdx)
+StreamData::getFab(int level, int fabIdx, int compIdx)
 {
-  if (fabIdx<0) {
-      // Intends to access boundary/ghost data
-      if (compIdx < boundaryNodes.size()) {
-        if (!(boundaryNodes.size()>compIdx)
-              || boundaryNodes[compIdx] == nullptr) {
-              std::cout << "Boundary data not correctly partitioned for component " << compIdx << std::endl;
-              Abort("Data not correctly partitioned");
-          }
-          return boundaryNodes[compIdx];
+  if (fabIdx < 0) {
+    // Intends to access boundary/ghost data
+    if (compIdx < boundaryNodes.size()) {
+      if (
+        !(boundaryNodes.size() > compIdx) ||
+        boundaryNodes[compIdx] == nullptr) {
+        std::cout << "Boundary data not correctly partitioned for component "
+                  << compIdx << std::endl;
+        Abort("Data not correctly partitioned");
       }
-      else {
-          Abort("Data not correctly partitioned");
-      }
+      return boundaryNodes[compIdx];
+    } else {
+      Abort("Data not correctly partitioned");
+    }
   }
-  DefineFab(level,compIdx,fabIdx);
+  DefineFab(level, compIdx, fabIdx);
   return &((*dataGrids[level][compIdx])[fabIdx]);
 }
 
 const BoxArray&
 StreamData::boxArray(int level) const
 {
-    // use visMF[][0]:  all boxArrays are
-    // guaranteed to be the same for each MultiFab
-    return visMF[level][0]->boxArray();
+  // use visMF[][0]:  all boxArrays are
+  // guaranteed to be the same for each MultiFab
+  return visMF[level][0]->boxArray();
 }
 
 const Vector<int>&
 StreamData::InsideNodes(int level, int box_id) const
 {
-    AMREX_ASSERT(level<=finestLevel);
-    AMREX_ASSERT(box_id<inside_nodes[level].size());
-    return inside_nodes[level][box_id];
+  AMREX_ASSERT(level <= finestLevel);
+  AMREX_ASSERT(box_id < inside_nodes[level].size());
+  return inside_nodes[level][box_id];
 }
 
 bool
 StreamData::ReadInfo()
 {
-    VisMF::IO_Buffer io_buffer(VisMF::IO_Buffer_Size);
+  VisMF::IO_Buffer io_buffer(VisMF::IO_Buffer_Size);
 
-    std::ifstream isPltIn;
+  std::ifstream isPltIn;
 
-    isPltIn.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
+  isPltIn.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
 
-    if(stream_verbose && ParallelDescriptor::IOProcessor()) {
-            cout << "StreamData::opening file = " << filename << endl;
+  if (stream_verbose && ParallelDescriptor::IOProcessor()) {
+    cout << "StreamData::opening file = " << filename << endl;
+  }
+
+  // Read header for path traces
+  HeaderFileName = HeaderFileName_DEF;
+  std::string HdrName = filename + "/" + HeaderFileName;
+
+  isPltIn.open(HdrName.c_str(), ios::in);
+  if (isPltIn.fail()) {
+    if (ParallelDescriptor::IOProcessor()) {
+      cerr << "Unable to open file: " << HdrName << endl;
     }
+    return false;
+  }
 
-    // Read header for path traces
-    HeaderFileName = HeaderFileName_DEF;
-    std::string HdrName = filename + "/" + HeaderFileName;
+  isPltIn >> plotFileVersion;
+  if (plotFileVersion == FileFormatName00()) {
+    is_version_0 = true;
+  } else if (plotFileVersion == FileFormatName10()) {
+    is_version_0 = false;
+  } else {
+    Abort("Bad stream file version");
+  }
 
-    isPltIn.open(HdrName.c_str(), ios::in);
-    if(isPltIn.fail()) {
-        if(ParallelDescriptor::IOProcessor()) {
-            cerr << "Unable to open file: " << HdrName << endl;
-        }
-        return false;
+  if (stream_verbose && ParallelDescriptor::IOProcessor()) {
+    cout << "Stream file version:  " << plotFileVersion << endl;
+  }
+
+  int Nlev;
+  isPltIn >> Nlev;
+  finestLevel = Nlev - 1;
+
+  isPltIn >> nComp;
+
+  plotVars.resize(nComp);
+  if (stream_verbose > 1 && ParallelDescriptor::IOProcessor()) {
+    cout << "Stream file variables (" << nComp << "): ";
+  }
+  std::set<std::string> unique_names;
+  for (int i = 0; i < nComp; ++i) {
+    isPltIn >> plotVars[i];
+    if (unique_names.count(plotVars[i]) > 0) {
+      plotVars[i] += "_";
     }
-
-    isPltIn >> plotFileVersion;
-    if (plotFileVersion == FileFormatName00()) {
-        is_version_0 = true;
-    } else if (plotFileVersion == FileFormatName10()) {
-        is_version_0 = false;
+    unique_names.insert(plotVars[i]);
+    if (stream_verbose > 1 && ParallelDescriptor::IOProcessor()) {
+      cout << plotVars[i] << "[" << i << "] ";
     }
-    else {
-        Abort("Bad stream file version");
+  }
+  if (stream_verbose > 1 && ParallelDescriptor::IOProcessor()) {
+    cout << endl;
+  }
+
+  probDomain.resize(Nlev);
+
+  if (is_version_0) {
+    ElementFileName = ElementFileName_DEF;
+    ElementFileFormat = ElementFileFormat_DEF;
+  } else {
+
+    isPltIn >> ElementFileName;
+    isPltIn >> ElementFileFormat;
+
+    for (int i = 0; i < AMREX_SPACEDIM; ++i)
+      isPltIn >> probLo[i];
+    for (int i = 0; i < AMREX_SPACEDIM; ++i)
+      isPltIn >> probHi[i];
+    for (int lev = 0; lev < Nlev; ++lev) {
+      isPltIn >> probDomain[lev];
+      // dont read ba
     }
+  }
 
-    if(stream_verbose && ParallelDescriptor::IOProcessor()) {
-        cout << "Stream file version:  " << plotFileVersion << endl;
-    }
+  ElementFileName = filename + "/" + ElementFileName;
+  if (stream_verbose && ParallelDescriptor::IOProcessor()) {
+    cout << "Reading streamline metadata" << endl;
+  }
+  dataGrids.resize(finestLevel + 1);
+  dataGridsDefined.resize(finestLevel + 1);
+  visMF.resize(finestLevel + 1);
+  compIndexToVisMFMap.resize(nComp);
+  compIndexToVisMFComponentMap.resize(nComp);
 
-    int Nlev;
-    isPltIn >> Nlev;
-    finestLevel = Nlev - 1;
+  MFInfo Fab_noallocate;
+  Fab_noallocate.SetAlloc(false);
 
-    isPltIn >> nComp;
+  bool found_valid_line_extent = false;
+  for (int i = 0; i <= finestLevel; ++i) {
 
-    plotVars.resize(nComp);
-    if(stream_verbose>1 && ParallelDescriptor::IOProcessor()) {
-        cout << "Stream file variables (" << nComp << "): ";
-    }
-    std::set<std::string> unique_names;
-    for (int i=0; i<nComp; ++i) {
-        isPltIn >> plotVars[i];
-        if (unique_names.count(plotVars[i])>0) {
-          plotVars[i] += "_";
-        }
-        unique_names.insert(plotVars[i]);
-        if(stream_verbose>1 && ParallelDescriptor::IOProcessor()) {
-            cout << plotVars[i] << "[" << i << "] ";
-        }
-    }
-    if(stream_verbose>1 && ParallelDescriptor::IOProcessor()) {
-        cout << endl;
-    }
+    // copied, but mostly bypassed code to account for multiple multifabs in a
+    // plot file
+    int currentIndexComp(0);
+    int currentVisMF(0);
+    dataGrids[i].resize(nComp);
+    dataGridsDefined[i].resize(nComp);
 
-    probDomain.resize(Nlev);
+    while (currentIndexComp < nComp) {
 
-    if (is_version_0)
-    {
-        ElementFileName = ElementFileName_DEF;
-        ElementFileFormat = ElementFileFormat_DEF;
-    }
-    else {
+      std::string ThisStreamFile = filename + "/";
 
-        isPltIn >> ElementFileName; 
-        isPltIn >>  ElementFileFormat; 
+      if (is_version_0) {
+        ThisStreamFile += Concatenate("Level_", i, 1) + "/Str";
+      } else {
+        std::string mfNameRelative;
+        isPltIn >> mfNameRelative;
+        ThisStreamFile += mfNameRelative;
+      }
 
-        for (int i=0; i<AMREX_SPACEDIM; ++i)  isPltIn >> probLo[i];
-        for (int i=0; i<AMREX_SPACEDIM; ++i)  isPltIn >> probHi[i];
-        for (int lev=0; lev<Nlev; ++lev) {
-            isPltIn >> probDomain[lev];
-            // dont read ba
-        }
-    }
+      visMF[i].resize(currentVisMF + 1); // this preserves previous ones
+      visMF[i][currentVisMF] = new VisMF(ThisStreamFile);
+      int iComp(currentIndexComp);
+      nGrow = visMF[i][currentVisMF]->nGrow();
+      currentIndexComp += visMF[i][currentVisMF]->nComp();
+      int currentVisMFComponent(0);
+      for (; iComp < currentIndexComp; ++iComp) {
 
-    ElementFileName = filename + "/" + ElementFileName;
-    if(stream_verbose && ParallelDescriptor::IOProcessor()) {
-      cout << "Reading streamline metadata" << endl;
-    }
-    dataGrids.resize(finestLevel + 1);
-    dataGridsDefined.resize(finestLevel + 1);
-    visMF.resize(finestLevel + 1);
-    compIndexToVisMFMap.resize(nComp);
-    compIndexToVisMFComponentMap.resize(nComp);
-
-    MFInfo Fab_noallocate;
-    Fab_noallocate.SetAlloc(false);
-
-    bool found_valid_line_extent = false;
-    for (int i = 0; i <= finestLevel; ++i) {
-
-        // copied, but mostly bypassed code to account for multiple multifabs in a plot file
-        int currentIndexComp(0);
-        int currentVisMF(0);
-        dataGrids[i].resize(nComp);
-        dataGridsDefined[i].resize(nComp);
-        
-        while(currentIndexComp < nComp) {
-            
-          std::string ThisStreamFile = filename + "/";
-            
-          if (is_version_0) {
-            ThisStreamFile += Concatenate("Level_",i,1) + "/Str";
-          } else {
-            std::string mfNameRelative;
-            isPltIn >> mfNameRelative;
-            ThisStreamFile += mfNameRelative;
+        const BoxArray& ba = visMF[i][currentVisMF]->boxArray();
+        // Find a valid box entry so that we can determine
+        //    the lo,hi range of the pathlines
+        for (int j = 0; j < ba.size() && !found_valid_line_extent; ++j) {
+          const Box& bx = ba[j];
+          if (bx != ZBOX) {
+            streamIdxLo = bx.smallEnd(1);
+            streamIdxHi = bx.bigEnd(1);
+            found_valid_line_extent = true;
           }
-
-            visMF[i].resize(currentVisMF + 1);  // this preserves previous ones
-            visMF[i][currentVisMF] = new VisMF(ThisStreamFile);
-            int iComp(currentIndexComp);
-            nGrow = visMF[i][currentVisMF]->nGrow();
-            currentIndexComp += visMF[i][currentVisMF]->nComp();
-            int currentVisMFComponent(0);
-            for( ; iComp < currentIndexComp; ++iComp) {
-
-                const BoxArray& ba = visMF[i][currentVisMF]->boxArray();
-                // Find a valid box entry so that we can determine
-                //    the lo,hi range of the pathlines
-                for (int j=0; j<ba.size() && !found_valid_line_extent; ++j) {
-                    const Box& bx = ba[j];
-                    if (bx != ZBOX) {
-                        streamIdxLo = bx.smallEnd(1);
-                        streamIdxHi = bx.bigEnd(1);
-                        found_valid_line_extent = true;
-                    }
-                }
-
-                // make single component multifabs
-                // defer reading the MultiFab data
-                dataGrids[i][iComp] = new MultiFab(ba, DistributionMapping(ba), 1,
-                                                   visMF[i][currentVisMF]->nGrow(),Fab_noallocate);
-                dataGridsDefined[i][iComp].resize(visMF[i][currentVisMF]->size(),
-                                                  false);
-                compIndexToVisMFMap[iComp] = currentVisMF;
-                compIndexToVisMFComponentMap[iComp] = currentVisMFComponent;
-                ++currentVisMFComponent;
-            }
-            ++currentVisMF;
-        }  // end while        
-    }  // end for(i...finestLevel)
-
-    isPltIn.close();
-
-    // Read elements
-    // FIXME: Should we read in serial and broadcast these??
-    isPltIn.open(ElementFileName.c_str());
-    if(isPltIn.fail()) {
-        if(ParallelDescriptor::IOProcessor()) {
-            cerr << "Unable to open file: " << ElementFileName << endl;
         }
-        return false;
-    }
 
-    isPltIn >> num_global_elements;
-    isPltIn >> nodes_per_element;
-    if(stream_verbose && ParallelDescriptor::IOProcessor()) {
-            cout << "Reading elements (num_global_elements,nodes_per_element): ("
-                 << num_global_elements << ", " << nodes_per_element << ")" << endl;
-    }
-    global_element_node_ids.resize(num_global_elements*nodes_per_element);
-    for (int i=0; i<num_global_elements*nodes_per_element; ++i) {
-        isPltIn >> global_element_node_ids[i];
-        global_element_node_ids[i]--; // Historical crud, these are written as 1-based
-    }
+        // make single component multifabs
+        // defer reading the MultiFab data
+        dataGrids[i][iComp] = new MultiFab(
+          ba, DistributionMapping(ba), 1, visMF[i][currentVisMF]->nGrow(),
+          Fab_noallocate);
+        dataGridsDefined[i][iComp].resize(
+          visMF[i][currentVisMF]->size(), false);
+        compIndexToVisMFMap[iComp] = currentVisMF;
+        compIndexToVisMFComponentMap[iComp] = currentVisMFComponent;
+        ++currentVisMFComponent;
+      }
+      ++currentVisMF;
+    } // end while
+  } // end for(i...finestLevel)
 
-    // Read element distribution after we know number of boxes/level
-    if(stream_verbose && ParallelDescriptor::IOProcessor()) {
-            cout << "Populating map of node distribution... " << endl;
+  isPltIn.close();
+
+  // Read elements
+  // FIXME: Should we read in serial and broadcast these??
+  isPltIn.open(ElementFileName.c_str());
+  if (isPltIn.fail()) {
+    if (ParallelDescriptor::IOProcessor()) {
+      cerr << "Unable to open file: " << ElementFileName << endl;
     }
-    inside_nodes.resize(finestLevel + 1);
+    return false;
+  }
 
-    nLines = 0;
-    for (int lev=0; lev<=finestLevel; ++lev)
-    {
-        inside_nodes[lev].resize(visMF[lev][0]->size());
-        
-        // Get number of nonempty boxes
-        int num_non_zero;
-        isPltIn >> num_non_zero;
-        
-        for (int j=0; j<num_non_zero; ++j)
-        {
-            // Get index of non-empty box, and number of entries
-            int box_id, num_ids;
-            isPltIn >> box_id >> num_ids;
-            
-            inside_nodes[lev][box_id].resize(num_ids);
-            nLines += num_ids;
-            
-            for (int k=0; k<num_ids; ++k)
-                isPltIn >> inside_nodes[lev][box_id][k];
-        }
+  isPltIn >> num_global_elements;
+  isPltIn >> nodes_per_element;
+  if (stream_verbose && ParallelDescriptor::IOProcessor()) {
+    cout << "Reading elements (num_global_elements,nodes_per_element): ("
+         << num_global_elements << ", " << nodes_per_element << ")" << endl;
+  }
+  global_element_node_ids.resize(num_global_elements * nodes_per_element);
+  for (int i = 0; i < num_global_elements * nodes_per_element; ++i) {
+    isPltIn >> global_element_node_ids[i];
+    global_element_node_ids[i]--; // Historical crud, these are written as
+                                  // 1-based
+  }
+
+  // Read element distribution after we know number of boxes/level
+  if (stream_verbose && ParallelDescriptor::IOProcessor()) {
+    cout << "Populating map of node distribution... " << endl;
+  }
+  inside_nodes.resize(finestLevel + 1);
+
+  nLines = 0;
+  for (int lev = 0; lev <= finestLevel; ++lev) {
+    inside_nodes[lev].resize(visMF[lev][0]->size());
+
+    // Get number of nonempty boxes
+    int num_non_zero;
+    isPltIn >> num_non_zero;
+
+    for (int j = 0; j < num_non_zero; ++j) {
+      // Get index of non-empty box, and number of entries
+      int box_id, num_ids;
+      isPltIn >> box_id >> num_ids;
+
+      inside_nodes[lev][box_id].resize(num_ids);
+      nLines += num_ids;
+
+      for (int k = 0; k < num_ids; ++k)
+        isPltIn >> inside_nodes[lev][box_id][k];
     }
-    isPltIn.close();
+  }
+  isPltIn.close();
 
-    if(stream_verbose && ParallelDescriptor::IOProcessor()) {
-        cout << "Finished reading headers for " << nLines << " stream lines and " << num_global_elements << " elements" << endl;
-    }
+  if (stream_verbose && ParallelDescriptor::IOProcessor()) {
+    cout << "Finished reading headers for " << nLines << " stream lines and "
+         << num_global_elements << " elements" << endl;
+  }
 
-    return true;
-
+  return true;
 }
 
 void
-StreamData::WriteFile(std::string&       outfile,
-                      const Vector<int>&  comps,
-                      const std::string& FileFormatName) const
+StreamData::WriteFile(
+  std::string& outfile,
+  const Vector<int>& comps,
+  const std::string& FileFormatName) const
 {
   Abort("Not implemented yet");
 }
 
 void
-StreamData::WriteFile(std::string&               outfile,
-                      const Vector<MultiFab*>&   data,
-                      int                        sComp,
-                      int                        _nComp,
-                      const Vector<std::string>& names,
-                      const std::string&         FileFormatName) const
+StreamData::WriteFile(
+  std::string& outfile,
+  const Vector<MultiFab*>& data,
+  int sComp,
+  int _nComp,
+  const Vector<std::string>& names,
+  const std::string& FileFormatName) const
 {
-    AMREX_ASSERT(names.size() == _nComp);
+  AMREX_ASSERT(names.size() == _nComp);
 
-    const std::string LevelDirName("Level");
-    const std::string StreamDataFileName("Str");
+  const std::string LevelDirName("Level");
+  const std::string StreamDataFileName("Str");
+
+  if (ParallelDescriptor::IOProcessor()) {
+    if (!UtilCreateDirectory(outfile, 0755))
+      CreateDirectoryFailed(outfile);
+
+    // Write Header
+    const std::string FullHeaderFileName = outfile + "/" + HeaderFileName_DEF;
+    std::ofstream ofh;
+    ofh.open(FullHeaderFileName.c_str());
+    ofh << FileFormatName << '\n';
+    ofh << data.size() << '\n';  // number of levels
+    ofh << names.size() << '\n'; // number of variables per node
+    for (int i = 0; i < names.size(); ++i) {
+      ofh << names[i] << '\n';
+    }
+
+    if (!is_version_0) {
+      ofh << ElementFileName << '\n';
+      ofh << ElementFileFormat << '\n';
+
+      for (int i = 0; i < AMREX_SPACEDIM; ++i)
+        ofh << probLo[i] << " ";
+      ofh << '\n';
+      for (int i = 0; i < AMREX_SPACEDIM; ++i)
+        ofh << probHi[i] << " ";
+      ofh << '\n';
+      for (int lev = 0; lev < data.size(); ++lev) {
+        ofh << ProbDomain()[lev] << '\n';
+        ofh << boxArray(lev) << '\n';
+      }
+    }
+    ofh.close();
+
+    // Write elements
+    const std::string FullElementFileName = outfile + "/" + ElementFileName;
+    int my_nodes_per_element =
+      global_element_node_ids.size() / num_global_elements;
+    std::ofstream ofe;
+    ofe.open(FullElementFileName.c_str());
+    ofe << num_global_elements << '\n';
+    ofe << my_nodes_per_element << '\n';
+    for (int i = 0; i < global_element_node_ids.size(); ++i)
+      ofe << global_element_node_ids[i] + 1
+          << " "; // Historical crud, these are written as 1-based
+    ofe << '\n';
+
+    // Write element distribution
+    for (int i = 0; i < inside_nodes.size(); ++i) {
+      const Vector<Vector<int>>& inside_nodes_i = inside_nodes[i];
+
+      // Count the non-zero-length entries
+      int num_non_zero = 0;
+      for (int j = 0; j < inside_nodes_i.size(); ++j)
+        if (inside_nodes_i[j].size() > 0)
+          num_non_zero++;
+
+      ofe << num_non_zero << '\n';
+      for (int j = 0; j < inside_nodes_i.size(); ++j) {
+        const Vector<int>& inside_nodes_i_j = inside_nodes[i][j];
+        if (inside_nodes_i[j].size() > 0) {
+          ofe << j << " " << inside_nodes_i_j.size();
+          for (int k = 0; k < inside_nodes_i_j.size(); ++k)
+            ofe << " " << inside_nodes_i_j[k];
+          ofe << '\n';
+        }
+      }
+    }
+    ofe.close();
+  }
+  //
+  // Force other processors to wait till directory is built and Header is
+  // written.
+  //
+  ParallelDescriptor::Barrier();
+
+  // Write data
+  for (int lev = 0; lev < data.size(); ++lev) {
+    char buf[64];
+    sprintf(buf, "Level_%d", lev);
+    std::string DataFile = outfile + "/" + std::string(buf);
 
     if (ParallelDescriptor::IOProcessor())
-    {
-        if (!UtilCreateDirectory(outfile, 0755))
-            CreateDirectoryFailed(outfile);
-
-        // Write Header
-        const std::string FullHeaderFileName = outfile + "/" + HeaderFileName_DEF;
-        std::ofstream ofh;
-        ofh.open(FullHeaderFileName.c_str());
-        ofh << FileFormatName << '\n';
-        ofh << data.size() << '\n'; // number of levels
-        ofh << names.size() << '\n'; // number of variables per node
-        for (int i=0; i<names.size(); ++i) {
-            ofh << names[i] << '\n'; 
-        }
-
-        if (!is_version_0) {
-            ofh << ElementFileName << '\n'; 
-            ofh << ElementFileFormat << '\n'; 
-            
-            for (int i=0; i<AMREX_SPACEDIM; ++i)  ofh << probLo[i] << " ";
-            ofh << '\n';
-            for (int i=0; i<AMREX_SPACEDIM; ++i)  ofh << probHi[i] << " ";
-            ofh << '\n';
-            for (int lev=0; lev<data.size(); ++lev) {
-                ofh << ProbDomain()[lev] << '\n';
-                ofh << boxArray(lev) << '\n';
-            }
-        }
-        ofh.close();
-
-        // Write elements
-        const std::string FullElementFileName = outfile + "/" + ElementFileName;
-        int my_nodes_per_element = global_element_node_ids.size() / num_global_elements;
-        std::ofstream ofe;
-        ofe.open(FullElementFileName.c_str());
-        ofe << num_global_elements << '\n';
-        ofe << my_nodes_per_element << '\n';
-        for (int i=0; i < global_element_node_ids.size(); ++i)
-            ofe << global_element_node_ids[i] + 1 << " "; // Historical crud, these are written as 1-based
-        ofe << '\n';
-
-        // Write element distribution
-        for (int i=0; i<inside_nodes.size(); ++i)
-        {
-            const Vector<Vector<int> >& inside_nodes_i = inside_nodes[i];
-
-            // Count the non-zero-length entries
-            int num_non_zero = 0;
-            for (int j=0; j<inside_nodes_i.size(); ++j)
-                if (inside_nodes_i[j].size() > 0)
-                    num_non_zero++;
-
-            ofe << num_non_zero << '\n';
-            for (int j=0; j<inside_nodes_i.size(); ++j)
-            {
-                const Vector<int>& inside_nodes_i_j = inside_nodes[i][j];
-                if (inside_nodes_i[j].size() > 0)
-                {
-                    ofe << j << " " << inside_nodes_i_j.size();
-                    for (int k=0; k<inside_nodes_i_j.size(); ++k)
-                        ofe << " " << inside_nodes_i_j[k];
-                    ofe << '\n';
-                }
-            }
-        }
-        ofe.close();
-    }
+      if (!UtilCreateDirectory(DataFile, 0755))
+        CreateDirectoryFailed(DataFile);
     //
-    // Force other processors to wait till directory is built and Header is written.
+    // Force other processors to wait till directory is built.
     //
     ParallelDescriptor::Barrier();
 
-    // Write data
-    for (int lev=0; lev<data.size(); ++lev)
-    {
-        char buf[64];
-        sprintf(buf, "Level_%d", lev);
-        std::string DataFile = outfile + "/" + std::string(buf);
-        
-        if (ParallelDescriptor::IOProcessor())
-            if (!UtilCreateDirectory(DataFile, 0755))
-                CreateDirectoryFailed(DataFile);
-        //
-        // Force other processors to wait till directory is built.
-        //
-        ParallelDescriptor::Barrier();
-        
-        std::string FabDataFile = DataFile + "/Str";
+    std::string FabDataFile = DataFile + "/Str";
 
-        if (names.size() == data[lev]->size())
-        {
-            VisMF::Write(*data[lev],FabDataFile);
-        }
-        else
-        {
-          const DistributionMapping dml(data[lev]->boxArray());
-          MultiFab tmp(data[lev]->boxArray(),dml,names.size(),data[lev]->nGrow());
-          MultiFab::Copy(tmp,*data[lev],sComp,0,names.size(),data[lev]->nGrow());
-          VisMF::Write(tmp,FabDataFile);
-        }
+    if (names.size() == data[lev]->size()) {
+      VisMF::Write(*data[lev], FabDataFile);
+    } else {
+      const DistributionMapping dml(data[lev]->boxArray());
+      MultiFab tmp(
+        data[lev]->boxArray(), dml, names.size(), data[lev]->nGrow());
+      MultiFab::Copy(
+        tmp, *data[lev], sComp, 0, names.size(), data[lev]->nGrow());
+      VisMF::Write(tmp, FabDataFile);
     }
+  }
 }
 
 const DistributionMapping&
-StreamData::DistributionMap (int level) const
+StreamData::DistributionMap(int level) const
 {
-    // All components will have the same distribution map, by assumption
-    AMREX_ASSERT(level<=finestLevel);
-    return dataGrids[level][0]->DistributionMap();
+  // All components will have the same distribution map, by assumption
+  AMREX_ASSERT(level <= finestLevel);
+  return dataGrids[level][0]->DistributionMap();
 }
 
 const std::vector<StreamData::MLloc>&
 StreamData::GlobalNodeMap() const
 {
-    if (global_node_map.size()==0) {
-        BuildGlobalNodeMap();
-    }
-    return global_node_map;
+  if (global_node_map.size() == 0) {
+    BuildGlobalNodeMap();
+  }
+  return global_node_map;
 }
 
 void
 StreamData::FlushGrids(int componentIndex)
 {
-    AmrData::FlushGrids(componentIndex);
-    if (boundaryNodes.size() > componentIndex && boundaryNodes[componentIndex]!=nullptr) {
-        delete boundaryNodes[componentIndex];
-        boundaryNodes[componentIndex] = new FArrayBox();
-    }
+  AmrData::FlushGrids(componentIndex);
+  if (
+    boundaryNodes.size() > componentIndex &&
+    boundaryNodes[componentIndex] != nullptr) {
+    delete boundaryNodes[componentIndex];
+    boundaryNodes[componentIndex] = new FArrayBox();
+  }
 }
 
 void
 StreamData::BuildGlobalNodeMap() const
 {
-    if (global_node_map.size() == 0) {
-        global_node_map.resize(NLines());
-        int myfinestLevel = FinestLevel();
-        
-        for (int iLev=0; iLev<=myfinestLevel; ++iLev)
-        {
-            int nBoxes = boxArray(iLev).size();
-            for (int iBox=0; iBox<nBoxes; ++iBox)
-            {
-                const Vector<int>& nodes_this_box = InsideNodes(iLev,iBox);
-                int num_nodes = nodes_this_box.size();
-                for (int iNode=0; iNode<num_nodes; ++iNode)
-                {
-                    // Remember that inside_nodes is 1-based
-                    global_node_map[nodes_this_box[iNode] - 1] = MLloc(iLev,iBox,iNode); 
-                }
-            }
+  if (global_node_map.size() == 0) {
+    global_node_map.resize(NLines());
+    int myfinestLevel = FinestLevel();
+
+    for (int iLev = 0; iLev <= myfinestLevel; ++iLev) {
+      int nBoxes = boxArray(iLev).size();
+      for (int iBox = 0; iBox < nBoxes; ++iBox) {
+        const Vector<int>& nodes_this_box = InsideNodes(iLev, iBox);
+        int num_nodes = nodes_this_box.size();
+        for (int iNode = 0; iNode < num_nodes; ++iNode) {
+          // Remember that inside_nodes is 1-based
+          global_node_map[nodes_this_box[iNode] - 1] = MLloc(iLev, iBox, iNode);
         }
+      }
+    }
 
-        // Get distribution on each level
-        Vector<DistributionMapping> dm(myfinestLevel+1);
-        for (int iLev = 0; iLev <= myfinestLevel; ++iLev) {
-            dm[iLev] = DistributionMap(iLev);
+    // Get distribution on each level
+    Vector<DistributionMapping> dm(myfinestLevel + 1);
+    for (int iLev = 0; iLev <= myfinestLevel; ++iLev) {
+      dm[iLev] = DistributionMap(iLev);
+    }
+
+    int mynodes_per_element = NodesPerElt();
+    int num_elements_global = NElts();
+
+    int my_proc = ParallelDescriptor::MyProc();
+
+    Vector<const MLloc*> n(mynodes_per_element);
+    for (int i = 0; i < num_elements_global; ++i) {
+      const int offset = i * mynodes_per_element;
+
+      for (int j = 0; j < mynodes_per_element; ++j) {
+        int global_node_id = global_element_node_ids[offset + j];
+        AMREX_ASSERT(global_node_map.size() > global_node_id);
+        n[j] = &(global_node_map[global_node_id]);
+      }
+
+      AMREX_ASSERT(n[0]->amr_lev <= myfinestLevel);
+      AMREX_ASSERT(
+        dm.size() > n[0]->amr_lev && dm[n[0]->amr_lev].size() > n[0]->box_idx);
+      int element_owner = dm[n[0]->amr_lev][n[0]->box_idx];
+
+      bool is_shared = false;
+      for (int j = 1; j < mynodes_per_element; ++j) {
+
+        AMREX_ASSERT(n[j]->amr_lev <= myfinestLevel);
+        AMREX_ASSERT(
+          dm.size() > n[j]->amr_lev &&
+          dm[n[j]->amr_lev].size() > n[j]->box_idx);
+        int node_owner = dm[n[j]->amr_lev][n[j]->box_idx];
+
+        if (element_owner != node_owner) {
+          element_owner = rand() > 0.5 ? element_owner : node_owner;
+          is_shared = true;
         }
-  
-        int mynodes_per_element = NodesPerElt();
-        int num_elements_global = NElts();
-  
-        int my_proc = ParallelDescriptor::MyProc();
-  
-        Vector<const MLloc*> n(mynodes_per_element);
-        for (int i=0; i<num_elements_global; ++i)
-        {
-            const int offset = i * mynodes_per_element;
-    
-            for (int j=0; j<mynodes_per_element; ++j) {
-                int global_node_id = global_element_node_ids[offset + j];
-                AMREX_ASSERT(global_node_map.size() > global_node_id);
-                n[j] = &(global_node_map[global_node_id]);
-            }
-    
-            AMREX_ASSERT(n[0]->amr_lev <= myfinestLevel);
-            AMREX_ASSERT(dm.size()>n[0]->amr_lev && dm[n[0]->amr_lev].size()>n[0]->box_idx);
-            int element_owner = dm[n[0]->amr_lev][n[0]->box_idx];
+      }
 
-            bool is_shared = false;
-            for (int j=1; j<mynodes_per_element; ++j) {
-      
-                AMREX_ASSERT(n[j]->amr_lev <= myfinestLevel);
-                AMREX_ASSERT(dm.size()>n[j]->amr_lev && dm[n[j]->amr_lev].size()>n[j]->box_idx);
-                int node_owner = dm[n[j]->amr_lev][n[j]->box_idx];
+      if (is_shared) {
+        for (int j = 0; j < mynodes_per_element; ++j) {
+          int node_owner = dm[n[j]->amr_lev][n[j]->box_idx];
+          int global_node_id = global_element_node_ids[offset + j];
 
-                if (element_owner != node_owner) {
-                    element_owner = rand() > 0.5  ?  element_owner :  node_owner;
-                    is_shared = true;
-                }
-            }
-    
-            if (is_shared) {
-                for (int j=0; j<mynodes_per_element; ++j) {
-                    int node_owner = dm[n[j]->amr_lev][n[j]->box_idx];
-                    int global_node_id = global_element_node_ids[offset + j];
-      
-                    if ( (element_owner==my_proc) && (element_owner!=node_owner)) {
-                        remote_nodes[node_owner][global_node_id] = n[j];
-                    }
-        
-                    if ( (node_owner==my_proc) && (element_owner!=my_proc) ) {
-                        tosend_nodes[element_owner][global_node_id] = n[j];
-                    }
-                }
-            }
+          if ((element_owner == my_proc) && (element_owner != node_owner)) {
+            remote_nodes[node_owner][global_node_id] = n[j];
+          }
 
-            if (element_owner == my_proc) {
-                local_element_ids.push_back(i);
-            }
+          if ((node_owner == my_proc) && (element_owner != my_proc)) {
+            tosend_nodes[element_owner][global_node_id] = n[j];
+          }
         }
+      }
 
-        // Build map to new nodes
-        int new_local_node_cnt = 0;
-        for (std::map<int,std::map<int,const MLloc*> >::const_iterator it=remote_nodes.begin(),
-                 End=remote_nodes.end(); it!=End ; ++it)
-        {
-            const std::map<int,const MLloc*>& nodes_recd = it->second;
-            for (std::map<int,const MLloc*>::const_iterator it1=nodes_recd.begin(),
-                     End1=nodes_recd.end(); it1!=End1; ++it1)
-            {
-                int global_node_id = it1->first;      
-                global_to_local_node_ids[global_node_id] = new_local_node_cnt; // Assign new node number
-                local_to_global_node_ids[new_local_node_cnt] = global_node_id; // Map new number back to global number
-                new_local_node_cnt++;
-            }
-        }
+      if (element_owner == my_proc) {
+        local_element_ids.push_back(i);
+      }
+    }
+
+    // Build map to new nodes
+    int new_local_node_cnt = 0;
+    for (std::map<int, std::map<int, const MLloc*>>::const_iterator
+           it = remote_nodes.begin(),
+           End = remote_nodes.end();
+         it != End; ++it) {
+      const std::map<int, const MLloc*>& nodes_recd = it->second;
+      for (std::map<int, const MLloc*>::const_iterator it1 = nodes_recd.begin(),
+                                                       End1 = nodes_recd.end();
+           it1 != End1; ++it1) {
+        int global_node_id = it1->first;
+        global_to_local_node_ids[global_node_id] =
+          new_local_node_cnt; // Assign new node number
+        local_to_global_node_ids[new_local_node_cnt] =
+          global_node_id; // Map new number back to global number
+        new_local_node_cnt++;
+      }
+    }
 
 #if 0
         for (int n=0; n<nprocs; ++n) {
@@ -551,49 +554,44 @@ StreamData::BuildGlobalNodeMap() const
         ParallelDescriptor::Barrier();
 #endif
 
-        // Build new set of local elements 
-        int num_local_elements = local_element_ids.size();
-        local_element_node_ids.resize(mynodes_per_element * num_local_elements);
-        int* ptr = local_element_node_ids.dataPtr();
-        
-        local_node_map.clear();
-        for (int i=0, End=local_element_ids.size(); i<End; ++i)
-        {
-            int global_element_id = local_element_ids[i];
-            const int offset_global = global_element_id * mynodes_per_element;
-            for (int j=0; j<mynodes_per_element; ++j)
-            {
-                int global_node_id = global_element_node_ids[offset_global + j];
-                int amr_lev, box_idx, pt_idx;
-                
-                // Local nodes are "ghost" nodes if they are in this map
-                //  ghost nodes are stored in the boundaryNodes fab
-                if (global_to_local_node_ids.count(global_node_id))
-                {
-                    amr_lev = -1;
-                    box_idx = -1;
-                    pt_idx = global_to_local_node_ids[global_node_id];
-                }
-                else
-                {
-                    // Otherwise, the node is in the usual data structure
-                    AMREX_ASSERT(global_node_map.size() > global_node_id);
-                    const MLloc& node = global_node_map[global_node_id];
-                    amr_lev = node.amr_lev;
-                    box_idx = node.box_idx;
-                    pt_idx = node.pt_idx;
-                    
-                    AMREX_ASSERT(DistributionMap(amr_lev)[box_idx] == my_proc);
-                }
-                
-                *ptr++ = global_node_id;
-                
-                // populate local node map
-                if (local_node_map.count(global_node_id)==0) {
-                    local_node_map[global_node_id] = MLloc(amr_lev,box_idx,pt_idx);
-                }
-            }
-        }        
+    // Build new set of local elements
+    int num_local_elements = local_element_ids.size();
+    local_element_node_ids.resize(mynodes_per_element * num_local_elements);
+    int* ptr = local_element_node_ids.dataPtr();
+
+    local_node_map.clear();
+    for (int i = 0, End = local_element_ids.size(); i < End; ++i) {
+      int global_element_id = local_element_ids[i];
+      const int offset_global = global_element_id * mynodes_per_element;
+      for (int j = 0; j < mynodes_per_element; ++j) {
+        int global_node_id = global_element_node_ids[offset_global + j];
+        int amr_lev, box_idx, pt_idx;
+
+        // Local nodes are "ghost" nodes if they are in this map
+        //  ghost nodes are stored in the boundaryNodes fab
+        if (global_to_local_node_ids.count(global_node_id)) {
+          amr_lev = -1;
+          box_idx = -1;
+          pt_idx = global_to_local_node_ids[global_node_id];
+        } else {
+          // Otherwise, the node is in the usual data structure
+          AMREX_ASSERT(global_node_map.size() > global_node_id);
+          const MLloc& node = global_node_map[global_node_id];
+          amr_lev = node.amr_lev;
+          box_idx = node.box_idx;
+          pt_idx = node.pt_idx;
+
+          AMREX_ASSERT(DistributionMap(amr_lev)[box_idx] == my_proc);
+        }
+
+        *ptr++ = global_node_id;
+
+        // populate local node map
+        if (local_node_map.count(global_node_id) == 0) {
+          local_node_map[global_node_id] = MLloc(amr_lev, box_idx, pt_idx);
+        }
+      }
+    }
 
 #if 0
         for (int n=0; n<nprocs; ++n) {
@@ -604,126 +602,132 @@ StreamData::BuildGlobalNodeMap() const
         }
         ParallelDescriptor::Barrier();
 #endif
-    }
+  }
 }
 
 const Vector<int>&
-StreamData::LocalElements ()
+StreamData::LocalElements()
 {
   return local_element_node_ids;
 }
 
 const Vector<int>&
-StreamData::LocalElementIDs ()
+StreamData::LocalElementIDs()
 {
   return local_element_ids;
 }
 
-const std::map<int,StreamData::MLloc>&
+const std::map<int, StreamData::MLloc>&
 StreamData::LocalNodeMap()
 {
   return local_node_map;
 }
 
 typedef StreamData::MLloc MLloc;
-static void DoIt(const Vector<int>& comps,
-                 Vector<int>& sendcnts,
-                 Vector<int>& recvcnts,
-                 Vector<int>& sdispls,
-                 Vector<int>& rdispls,
-                 Vector<Real>& senddata,
-                 Vector<Real>& recvdata,
-                 const std::map<int,std::map<int,const MLloc*> >& remote_nodes,
-                 const std::map<int,std::map<int,const MLloc*> >& tosend_nodes,
-                 Vector<FArrayBox*>& dest,
-                 StreamData& stream,
-                 std::map<int,int>& global_to_local_node_ids)
+static void
+DoIt(
+  const Vector<int>& comps,
+  Vector<int>& sendcnts,
+  Vector<int>& recvcnts,
+  Vector<int>& sdispls,
+  Vector<int>& rdispls,
+  Vector<Real>& senddata,
+  Vector<Real>& recvdata,
+  const std::map<int, std::map<int, const MLloc*>>& remote_nodes,
+  const std::map<int, std::map<int, const MLloc*>>& tosend_nodes,
+  Vector<FArrayBox*>& dest,
+  StreamData& stream,
+  std::map<int, int>& global_to_local_node_ids)
 {
   int num_procs = ParallelDescriptor::NProcs();
 
   // Build data structures for communicating node info
-  sendcnts.resize(num_procs,0);
-  recvcnts.resize(num_procs,0);
-  sdispls.resize(num_procs,0);
-  rdispls.resize(num_procs,0);
+  sendcnts.resize(num_procs, 0);
+  recvcnts.resize(num_procs, 0);
+  sdispls.resize(num_procs, 0);
+  rdispls.resize(num_procs, 0);
 
-  int points_on_line = stream.StreamIdxHi()-stream.StreamIdxLo()+1;
+  int points_on_line = stream.StreamIdxHi() - stream.StreamIdxLo() + 1;
   int nComp = comps.size();
   int chunk_size = points_on_line * nComp;
 
   int tot_num_to_send = 0;
-  for (std::map<int,std::map<int,const MLloc*> >::const_iterator it=tosend_nodes.begin(), 
-         End=tosend_nodes.end(); it!=End; ++it) 
-  {
+  for (std::map<int, std::map<int, const MLloc*>>::const_iterator
+         it = tosend_nodes.begin(),
+         End = tosend_nodes.end();
+       it != End; ++it) {
     sdispls[it->first] = tot_num_to_send;
     sendcnts[it->first] = it->second.size() * chunk_size;
     tot_num_to_send += sendcnts[it->first];
   }
-    
+
   int num_recv_nodes = 0;
   int tot_num_to_recv = 0;
-  for (std::map<int,std::map<int,const MLloc*> >::const_iterator it=remote_nodes.begin(), 
-         End=remote_nodes.end(); it!=End ; ++it) 
-  {
+  for (std::map<int, std::map<int, const MLloc*>>::const_iterator
+         it = remote_nodes.begin(),
+         End = remote_nodes.end();
+       it != End; ++it) {
     rdispls[it->first] = tot_num_to_recv;
     num_recv_nodes += it->second.size();
     recvcnts[it->first] = it->second.size() * chunk_size;
     tot_num_to_recv += recvcnts[it->first];
   }
-    
+
   // Load data to send, then communicate
   senddata.resize(tot_num_to_send);
   recvdata.resize(tot_num_to_recv);
 
-  StreamData& Cstream = const_cast<StreamData&>(stream); // A bit ugly, but for the greater good...
-    
+  StreamData& Cstream =
+    const_cast<StreamData&>(stream); // A bit ugly, but for the greater good...
+
   Vector<int> offsets = sdispls;
-  for (std::map<int,std::map<int,const MLloc*> >::const_iterator it=tosend_nodes.begin(), 
-         End=tosend_nodes.end(); it!=End; ++it) 
-  { 
+  for (std::map<int, std::map<int, const MLloc*>>::const_iterator
+         it = tosend_nodes.begin(),
+         End = tosend_nodes.end();
+       it != End; ++it) {
     int to_proc = it->first;
-    const std::map<int,const MLloc*>& proc_nodes = it->second;
-      
+    const std::map<int, const MLloc*>& proc_nodes = it->second;
+
     int icnt = 0;
-    for (std::map<int,const MLloc*>::const_iterator it1=proc_nodes.begin(), End1=proc_nodes.end(); 
-         it1!=End1; ++it1, ++icnt) 
-    {
+    for (std::map<int, const MLloc*>::const_iterator it1 = proc_nodes.begin(),
+                                                     End1 = proc_nodes.end();
+         it1 != End1; ++it1, ++icnt) {
       const MLloc* node = it1->second;
       int local_node_id = node->pt_idx;
-      for (int n=0; n<comps.size(); ++n) {
-        const FArrayBox& stream_fab = *(Cstream.getFab(node->amr_lev,node->box_idx,comps[n]));
-        for (int j=stream.StreamIdxLo(); j<=stream.StreamIdxHi(); ++j) {
-          IntVect iv(AMREX_D_DECL(local_node_id,j,0));
-          senddata[offsets[to_proc]++] = stream_fab(iv,0);
+      for (int n = 0; n < comps.size(); ++n) {
+        const FArrayBox& stream_fab =
+          *(Cstream.getFab(node->amr_lev, node->box_idx, comps[n]));
+        for (int j = stream.StreamIdxLo(); j <= stream.StreamIdxHi(); ++j) {
+          IntVect iv(AMREX_D_DECL(local_node_id, j, 0));
+          senddata[offsets[to_proc]++] = stream_fab(iv, 0);
         }
       }
     }
   }
 
 #if AMREX_USE_MPI
-  BL_MPI_REQUIRE( MPI_Alltoallv(tot_num_to_send == 0 ? 0 : senddata.dataPtr(),
-                                sendcnts.dataPtr(),
-                                sdispls.dataPtr(),
-                                ParallelDescriptor::Mpi_typemap<Real>::type(),
-                                tot_num_to_recv == 0 ? 0 : recvdata.dataPtr(),
-                                recvcnts.dataPtr(),
-                                rdispls.dataPtr(),
-                                ParallelDescriptor::Mpi_typemap<Real>::type(),
-                                ParallelDescriptor::Communicator()) );
-#endif    
+  BL_MPI_REQUIRE(MPI_Alltoallv(
+    tot_num_to_send == 0 ? 0 : senddata.dataPtr(), sendcnts.dataPtr(),
+    sdispls.dataPtr(), ParallelDescriptor::Mpi_typemap<Real>::type(),
+    tot_num_to_recv == 0 ? 0 : recvdata.dataPtr(), recvcnts.dataPtr(),
+    rdispls.dataPtr(), ParallelDescriptor::Mpi_typemap<Real>::type(),
+    ParallelDescriptor::Communicator()));
+#endif
 
-  if (num_recv_nodes>0) {
-      
-    Box d_box(IntVect(AMREX_D_DECL(0,stream.StreamIdxLo(),0)),
-              IntVect(AMREX_D_DECL(num_recv_nodes-1,stream.StreamIdxHi(),0)));
-      
-    for (int n=0; n<comps.size(); ++n) {
-        dest[comps[n]]->resize(d_box,1);
+  if (num_recv_nodes > 0) {
+
+    Box d_box(
+      IntVect(AMREX_D_DECL(0, stream.StreamIdxLo(), 0)),
+      IntVect(AMREX_D_DECL(num_recv_nodes - 1, stream.StreamIdxHi(), 0)));
+
+    for (int n = 0; n < comps.size(); ++n) {
+      dest[comps[n]]->resize(d_box, 1);
     }
 
-    for (std::map<int,std::map<int,const MLloc*> >::const_iterator it=remote_nodes.begin(), 
-           End=remote_nodes.end(); it!=End ; ++it)
-    {
+    for (std::map<int, std::map<int, const MLloc*>>::const_iterator
+           it = remote_nodes.begin(),
+           End = remote_nodes.end();
+         it != End; ++it) {
       int from_proc = it->first;
 
       if (rdispls[from_proc] + it->second.size() >= tot_num_to_recv) {
@@ -731,95 +735,95 @@ static void DoIt(const Vector<int>& comps,
       }
 
       Real* dest_loc = &recvdata[rdispls[from_proc]];
-        
-      for (std::map<int,const MLloc*>::const_iterator it1=it->second.begin(), 
-             End1=it->second.end(); it1!=End1; ++it1)
-      {
+
+      for (std::map<int, const MLloc*>::const_iterator it1 = it->second.begin(),
+                                                       End1 = it->second.end();
+           it1 != End1; ++it1) {
         int local_node_id = global_to_local_node_ids[it1->first];
-        for (int n=0; n<comps.size(); ++n) {
-          for (int j=d_box.smallEnd()[1]; j<=d_box.bigEnd()[1]; ++j) {
-            IntVect idx(AMREX_D_DECL(local_node_id,j,0));
-            (*dest[comps[n]])(idx,0) = *dest_loc++;
+        for (int n = 0; n < comps.size(); ++n) {
+          for (int j = d_box.smallEnd()[1]; j <= d_box.bigEnd()[1]; ++j) {
+            IntVect idx(AMREX_D_DECL(local_node_id, j, 0));
+            (*dest[comps[n]])(idx, 0) = *dest_loc++;
           }
         }
-      }        
+      }
     }
   }
 }
 
-
-
 void
-StreamData::PartitionElements (int nCompPass)
+StreamData::PartitionElements(int nCompPass)
 {
   Vector<int> comps(NComp());
-  for (int n=0; n<comps.size(); ++n) {
+  for (int n = 0; n < comps.size(); ++n) {
     comps[n] = n;
   }
   PartitionElements(nCompPass, comps);
 }
 
 void
-StreamData::PartitionElements (int nCompPass, const Vector<int>& comps)
+StreamData::PartitionElements(int nCompPass, const Vector<int>& comps)
 {
-  if (stream_verbose && ParallelDescriptor::IOProcessor() ) {
+  if (stream_verbose && ParallelDescriptor::IOProcessor()) {
     cout << "Partitioning elements..." << std::endl;
   }
 
-  for (int i=0; i<comps.size(); ++i) {
-    if (comps[i]<0 || comps[i]>NComp()) {
-        cout << "comp: " << comps[i] << endl;
+  for (int i = 0; i < comps.size(); ++i) {
+    if (comps[i] < 0 || comps[i] > NComp()) {
+      cout << "comp: " << comps[i] << endl;
       Error("desired component not on streamline");
     }
   }
 
   int num_comp = comps.size();
-  
-  // Build a structure that for each node points to where in the streamlines to get the data
+
+  // Build a structure that for each node points to where in the streamlines to
+  // get the data
   BuildGlobalNodeMap();
-  
+
   Vector<int> sendcnts;
   Vector<int> recvcnts;
   Vector<int> sdispls;
   Vector<int> rdispls;
   Vector<Real> senddata;
   Vector<Real> recvdata;
-  
+
   int num_tot = NComp();
   if (boundaryNodes.size() != num_tot) {
-      boundaryNodes.resize(num_tot,nullptr);
-      for (int i=0; i<num_tot; ++i) {
-          boundaryNodes[i] = new FArrayBox();
-      }
+    boundaryNodes.resize(num_tot, nullptr);
+    for (int i = 0; i < num_tot; ++i) {
+      boundaryNodes[i] = new FArrayBox();
+    }
   }
-  
-  bool isio = ParallelDescriptor::IOProcessor();  
+
+  bool isio = ParallelDescriptor::IOProcessor();
   int src_comp = 0;
-  while (src_comp < num_comp) 
-  {
+  while (src_comp < num_comp) {
     int nCompPassLoc = std::min(src_comp + nCompPass, num_comp) - src_comp;
     Vector<int> loc_comps(nCompPassLoc);
-    for (int n=0; n<loc_comps.size(); ++n) {
+    for (int n = 0; n < loc_comps.size(); ++n) {
       loc_comps[n] = comps[src_comp + n];
     }
-    
+
     if (stream_verbose && isio) {
-      std::cout << "Reading " << loc_comps.size() << " components of stream data ";
-      if (1 || stream_verbose>1) {
+      std::cout << "Reading " << loc_comps.size()
+                << " components of stream data ";
+      if (1 || stream_verbose > 1) {
         std::cout << ": ";
-        for (int j=0; j<loc_comps.size(); ++j) {
+        for (int j = 0; j < loc_comps.size(); ++j) {
           std::cout << PlotVarNames()[loc_comps[j]] << " ";
         }
       }
       std::cout << std::endl;
     }
-    DoIt(loc_comps, sendcnts, recvcnts, sdispls, rdispls, senddata, recvdata,
-         remote_nodes, tosend_nodes, boundaryNodes, *this, global_to_local_node_ids);
-    
+    DoIt(
+      loc_comps, sendcnts, recvcnts, sdispls, rdispls, senddata, recvdata,
+      remote_nodes, tosend_nodes, boundaryNodes, *this,
+      global_to_local_node_ids);
+
     src_comp += nCompPassLoc;
   }
   if (stream_verbose && ParallelDescriptor::IOProcessor()) {
     cout << "Finished partitioning" << endl;
   }
 }
-

--- a/Src/StreamPC.H
+++ b/Src/StreamPC.H
@@ -3,59 +3,64 @@
 
 #include <AMReX_Particles.H>
 
-typedef amrex::Array<amrex::Real,AMREX_SPACEDIM> dim3;
-typedef amrex::Array<int,AMREX_SPACEDIM> int3;
+typedef amrex::Array<amrex::Real, AMREX_SPACEDIM> dim3;
+typedef amrex::Array<int, AMREX_SPACEDIM> int3;
 
 struct RealData
 {
   enum {
-    AMREX_D_DECL(xloc = 0,
-                 yloc,
-                 zloc),
+    AMREX_D_DECL(xloc = 0, yloc, zloc),
   };
 };
 
-class StreamParticleContainer
-  : public amrex::ParticleContainer<0, 3, 0, 0>
+class StreamParticleContainer : public amrex::ParticleContainer<0, 3, 0, 0>
 {
 public:
-
   using MyParIter = amrex::ParIter<0, 3, 0, 0>;
 
-  StreamParticleContainer (int                                               a_nPtsOnStrm,
-                           const amrex::Vector<amrex::Geometry>            & a_geoms,
-                           const amrex::Vector<amrex::DistributionMapping> & a_dmaps,
-                           const amrex::Vector<amrex::BoxArray>            & a_bas,
-                           const amrex::Vector<int>                        & a_rrs,
-			   const int                                       a_nVar,
-			   const amrex::IntVect                            a_is_per,
-			   const amrex::Vector<std::string>                & a_outVarNames);
+  StreamParticleContainer(
+    int a_nPtsOnStrm,
+    const amrex::Vector<amrex::Geometry>& a_geoms,
+    const amrex::Vector<amrex::DistributionMapping>& a_dmaps,
+    const amrex::Vector<amrex::BoxArray>& a_bas,
+    const amrex::Vector<int>& a_rrs,
+    const int a_nVar,
+    const amrex::IntVect a_is_per,
+    const amrex::Vector<std::string>& a_outVarNames);
 
   void InitParticles(const amrex::Vector<amrex::Vector<amrex::Real>>& a_locs);
 
   void SetParticleLocation(int a_streamPos);
 
-  void ComputeNextLocation(int                                    a_fromLoc,
-                           const amrex::Real                            a_hRK,
-                           const amrex::Vector<amrex::MultiFab> & a_vectorField,
-			   const int                                    a_cSpace);
+  void ComputeNextLocation(
+    int a_fromLoc,
+    const amrex::Real a_hRK,
+    const amrex::Vector<amrex::MultiFab>& a_vectorField,
+    const int a_cSpace);
 
-  void InterpDataAtLocation(int                                    a_fromLoc,
-			    const amrex::Vector<amrex::MultiFab> & a_vectorField);
-  
-  
-  void WriteStreamAsBinary(const std::string& outfile,
-			   amrex::Vector<int>& faceData);
+  void InterpDataAtLocation(
+    int a_fromLoc, const amrex::Vector<amrex::MultiFab>& a_vectorField);
 
-  
+  void
+  WriteStreamAsBinary(const std::string& outfile, amrex::Vector<int>& faceData);
+
   void WriteStreamAsTecplot(const std::string& outfile);
 
-  bool RK4(dim3 & x,amrex::Real hrk,const amrex::FArrayBox& v,const amrex::Real* dx,const amrex::Real* plo,const amrex::Real* phi,int dir, int cSpace, amrex::Real dxFine);
+  bool RK4(
+    dim3& x,
+    amrex::Real hrk,
+    const amrex::FArrayBox& v,
+    const amrex::Real* dx,
+    const amrex::Real* plo,
+    const amrex::Real* phi,
+    int dir,
+    int cSpace,
+    amrex::Real dxFine);
 
-#if AMREX_DEBUG //AJA inspect function 
+#if AMREX_DEBUG // AJA inspect function
   void InspectParticles(const int nStreamPairs);
 #endif
-  
+
 protected:
   int Nlev;
   int nPtsOnStrm;
@@ -64,8 +69,8 @@ protected:
   int fcomp;
   amrex::IntVect is_per;
   amrex::Vector<std::string> outVarNames;
-private:
 
+private:
 };
 
 #endif

--- a/Src/StreamPC.cpp
+++ b/Src/StreamPC.cpp
@@ -8,16 +8,16 @@
 
 using namespace amrex;
 
-StreamParticleContainer::
-StreamParticleContainer(int                                 a_nPtsOnStrm,
-                        const Vector<Geometry>            & a_geoms,
-                        const Vector<DistributionMapping> & a_dmaps,
-                        const Vector<BoxArray>            & a_bas,
-                        const Vector<int>                 & a_rrs,
-			const int                         a_nVar,
-			const IntVect                     a_is_per,
-			const Vector<std::string>         & a_outVarNames)
-  : ParticleContainer<0, 3, 0, 0> (a_geoms, a_dmaps, a_bas, a_rrs)
+StreamParticleContainer::StreamParticleContainer(
+  int a_nPtsOnStrm,
+  const Vector<Geometry>& a_geoms,
+  const Vector<DistributionMapping>& a_dmaps,
+  const Vector<BoxArray>& a_bas,
+  const Vector<int>& a_rrs,
+  const int a_nVar,
+  const IntVect a_is_per,
+  const Vector<std::string>& a_outVarNames)
+  : ParticleContainer<0, 3, 0, 0>(a_geoms, a_dmaps, a_bas, a_rrs)
 {
   Nlev = a_geoms.size();
   nPtsOnStrm = a_nPtsOnStrm;
@@ -26,87 +26,87 @@ StreamParticleContainer(int                                 a_nPtsOnStrm,
   sizeOfRealStreamData = nPtsOnStrm * pcomp;
   is_per = a_is_per;
   outVarNames = a_outVarNames;
-  ResizeRuntimeRealComp(sizeOfRealStreamData,true);
+  ResizeRuntimeRealComp(sizeOfRealStreamData, true);
 }
 
 void
-StreamParticleContainer::
-InitParticles (const Vector<Vector<Real>>& locs)
+StreamParticleContainer::InitParticles(const Vector<Vector<Real>>& locs)
 {
   BL_PROFILE("StreamParticleContainer::InitParticles");
 
   const int nProc = ParallelDescriptor::NProcs();
   const int myProc = ParallelDescriptor::MyProc();
   int nLocs = locs.size();
-  auto& particle_tile = DefineAndReturnParticleTile(Nlev-1, myProc, 0);
+  auto& particle_tile = DefineAndReturnParticleTile(Nlev - 1, myProc, 0);
   for (int n = 0; n < nLocs; n++) {
-    //lets just initialise on a random processor and redistribute afterwards 
-    //trying to find the right processor here doesn't work well with particles near boundaries
-    if (n%nProc == myProc) {
-      //Create IDs for the two particles, NextID only works process-locally, so lets manually assign instead
-      const int p1_id = 2*n+1; 
-      const int p2_id = 2*n+2; 
-      //create a pair of particles
-      std::pair<ParticleType,ParticleType> ppair;
-      //Give them the two IDs
+    // lets just initialise on a random processor and redistribute afterwards
+    // trying to find the right processor here doesn't work well with particles
+    // near boundaries
+    if (n % nProc == myProc) {
+      // Create IDs for the two particles, NextID only works process-locally, so
+      // lets manually assign instead
+      const int p1_id = 2 * n + 1;
+      const int p2_id = 2 * n + 2;
+      // create a pair of particles
+      std::pair<ParticleType, ParticleType> ppair;
+      // Give them the two IDs
       ppair.first.id() = p1_id;
       ppair.second.id() = p2_id;
-      //Initialise on same process
+      // Initialise on same process
       ppair.first.cpu() = myProc;
       ppair.second.cpu() = myProc;
-      //Initialise at same position
-      AMREX_D_EXPR(ppair.first.pos(0) = locs[n][0],ppair.first.pos(1) = locs[n][1],ppair.first.pos(2) = locs[n][2]);
-      AMREX_D_EXPR(ppair.second.pos(0) = locs[n][0],ppair.second.pos(1) = locs[n][1],ppair.second.pos(2) = locs[n][2]);
-      //Initialise position at 0
+      // Initialise at same position
+      AMREX_D_EXPR(
+        ppair.first.pos(0) = locs[n][0], ppair.first.pos(1) = locs[n][1],
+        ppair.first.pos(2) = locs[n][2]);
+      AMREX_D_EXPR(
+        ppair.second.pos(0) = locs[n][0], ppair.second.pos(1) = locs[n][1],
+        ppair.second.pos(2) = locs[n][2]);
+      // Initialise position at 0
       ppair.first.idata(0) = 0;
       ppair.second.idata(0) = 0;
-      //First particle going forwards, second going backwards
+      // First particle going forwards, second going backwards
       ppair.first.idata(1) = 1;
       ppair.second.idata(1) = -1;
-      //Each particle needs to know the other one's ID
+      // Each particle needs to know the other one's ID
       ppair.first.idata(2) = p2_id;
       ppair.second.idata(2) = p1_id;
-      //Add each particle to the tile and allocate real space in order
+      // Add each particle to the tile and allocate real space in order
       particle_tile.push_back(ppair.first);
-      for (int i = 0; i<NumRuntimeRealComps(); i++) {
-	particle_tile.push_back_real(i, i < AMREX_SPACEDIM ? locs[n][i] : 0);
+      for (int i = 0; i < NumRuntimeRealComps(); i++) {
+        particle_tile.push_back_real(i, i < AMREX_SPACEDIM ? locs[n][i] : 0);
       }
       particle_tile.push_back(ppair.second);
-      for (int i = 0; i<NumRuntimeRealComps(); i++) {
-	particle_tile.push_back_real(i, i < AMREX_SPACEDIM ? locs[n][i] : 0);
+      for (int i = 0; i < NumRuntimeRealComps(); i++) {
+        particle_tile.push_back_real(i, i < AMREX_SPACEDIM ? locs[n][i] : 0);
       }
     }
   }
   Redistribute();
 }
 
-
 void
-StreamParticleContainer::
-SetParticleLocation(const int a_streamLoc)
+StreamParticleContainer::SetParticleLocation(const int a_streamLoc)
 {
   BL_PROFILE("StreamParticleContainer::SetParticleLocation");
-  //offset to find coordinates 
+  // offset to find coordinates
   int offset = pcomp * a_streamLoc;
   dim3 newpos;
-  for (int lev = 0; lev < Nlev; ++lev)
-  {
-    for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
-    {
+  for (int lev = 0; lev < Nlev; ++lev) {
+    for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
       auto& aos = pti.GetArrayOfStructs();
       auto& soa = pti.GetStructOfArrays();
 
-      for (size_t pindex=0; pindex<aos.size(); ++pindex)
-      {
+      for (size_t pindex = 0; pindex < aos.size(); ++pindex) {
         ParticleType& p = aos[pindex];
-        if (p.id() > 0)
-        {
-          newpos = {AMREX_D_DECL(soa.GetRealData(offset + RealData::xloc)[pindex],
-                                 soa.GetRealData(offset + RealData::yloc)[pindex],
-                                 soa.GetRealData(offset + RealData::zloc)[pindex])};
+        if (p.id() > 0) {
+          newpos = {AMREX_D_DECL(
+            soa.GetRealData(offset + RealData::xloc)[pindex],
+            soa.GetRealData(offset + RealData::yloc)[pindex],
+            soa.GetRealData(offset + RealData::zloc)[pindex])};
 
-          AMREX_D_EXPR(p.pos(0) = newpos[0], p.pos(1) = newpos[1], p.pos(2) = newpos[2]);
-	  
+          AMREX_D_EXPR(
+            p.pos(0) = newpos[0], p.pos(1) = newpos[1], p.pos(2) = newpos[2]);
         }
       }
     }
@@ -114,207 +114,236 @@ SetParticleLocation(const int a_streamLoc)
   Redistribute();
 }
 
-static void vnrml(Vector<Real>& vec, int dir)
+static void
+vnrml(Vector<Real>& vec, int dir)
 {
   static Real eps = 1.e24;
-  Real mag = std::sqrt(AMREX_D_TERM(vec[0] * vec[0],
-				    + vec[1] * vec[1],
-				    + vec[2] * vec[2]));
+  Real mag = std::sqrt(
+    AMREX_D_TERM(vec[0] * vec[0], +vec[1] * vec[1], +vec[2] * vec[2]));
   if (mag < eps) {
-    for (int i=0; i<AMREX_SPACEDIM; ++i) vec[i] *= dir / mag;
-  }
-  else {
+    for (int i = 0; i < AMREX_SPACEDIM; ++i)
+      vec[i] *= dir / mag;
+  } else {
     vec = {AMREX_D_DECL(0, 0, 0)};
   }
 }
 
-static bool ntrpv(const dim3 x,const FArrayBox& gfab,
-                  const Real* dx,const Real* plo,const Real* phi,Vector<Real>& u, int nComp)
+static bool
+ntrpv(
+  const dim3 x,
+  const FArrayBox& gfab,
+  const Real* dx,
+  const Real* plo,
+  const Real* phi,
+  Vector<Real>& u,
+  int nComp)
 {
   int3 b;
   dim3 n;
 
-  for (int d=0; d<AMREX_SPACEDIM; ++d) {
-    b[d] = (int)std::floor( (x[d] - plo[d]) / dx[d] - 0.5 );
-    n[d] = ( x[d] - ( (b[d] + 0.5 ) * dx[d] + plo[d] ) )/dx[d];
-    n[d] = std::max(0., std::min(1.,n[d]));
+  for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+    b[d] = (int)std::floor((x[d] - plo[d]) / dx[d] - 0.5);
+    n[d] = (x[d] - ((b[d] + 0.5) * dx[d] + plo[d])) / dx[d];
+    n[d] = std::max(0., std::min(1., n[d]));
   }
 
   const auto& gbx = gfab.box();
   const auto& glo = gbx.smallEnd();
   const auto& ghi = gbx.bigEnd();
-  for (int d=0; d<AMREX_SPACEDIM; ++d) {
-    if (b[d] < glo[d] ||  b[d] > ghi[d]-1) {
+  for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+    if (b[d] < glo[d] || b[d] > ghi[d] - 1) {
       std::cout << "dir: " << d << std::endl;
-      std::cout << "d,b,glo,ghi: " << d << " " << b[d] << " " << glo[d] << " " << ghi[d] << std::endl;
-      std::cout << "x,plo,phi " << x[d] << " " << plo[d] << " " << phi[d] << std::endl;
-      std::cout << "boxlo,boxhi " << plo[d]+glo[d]*dx[d] << " " << plo[d]+(ghi[d]+1)*dx[d] << std::endl;
+      std::cout << "d,b,glo,ghi: " << d << " " << b[d] << " " << glo[d] << " "
+                << ghi[d] << std::endl;
+      std::cout << "x,plo,phi " << x[d] << " " << plo[d] << " " << phi[d]
+                << std::endl;
+      std::cout << "boxlo,boxhi " << plo[d] + glo[d] * dx[d] << " "
+                << plo[d] + (ghi[d] + 1) * dx[d] << std::endl;
       return false;
     }
   }
   const auto& g = gfab.array();
-  for (int i=0; i<nComp; ++i) {
+  for (int i = 0; i < nComp; ++i) {
 #if AMREX_SPACEDIM == 2
-    u[i] =
-      +   n[0]   *   n[1]   * g(b[0]+1,b[1]+1,0,i)
-      +   n[0]   * (1-n[1]) * g(b[0]+1,b[1]  ,0,i)
-      + (1-n[0]) *   n[1]   * g(b[0]  ,b[1]+1,0,i)
-      + (1-n[0]) * (1-n[1]) * g(b[0]  ,b[1]  ,0,i);
+    u[i] = +n[0] * n[1] * g(b[0] + 1, b[1] + 1, 0, i) +
+           n[0] * (1 - n[1]) * g(b[0] + 1, b[1], 0, i) +
+           (1 - n[0]) * n[1] * g(b[0], b[1] + 1, 0, i) +
+           (1 - n[0]) * (1 - n[1]) * g(b[0], b[1], 0, i);
 #else
-    u[i] =
-      +    n[0]   *    n[1]  *    n[2]  * g(b[0]+1,b[1]+1,b[2]+1,i)
-      +    n[0]   * (1-n[1]) *    n[2]  * g(b[0]+1,b[1]  ,b[2]+1,i)
-      +    n[0]   *    n[1]  * (1-n[2]) * g(b[0]+1,b[1]+1,b[2]  ,i)
-      +    n[0]   * (1-n[1]) * (1-n[2]) * g(b[0]+1,b[1]  ,b[2]  ,i)
-      +  (1-n[0]) *    n[1]  *    n[2]  * g(b[0]  ,b[1]+1,b[2]+1,i)
-      +  (1-n[0]) * (1-n[1]) *    n[2]  * g(b[0]  ,b[1]  ,b[2]+1,i)
-      +  (1-n[0]) *    n[1]  * (1-n[2]) * g(b[0]  ,b[1]+1,b[2]  ,i)
-      +  (1-n[0]) * (1-n[1]) * (1-n[2]) * g(b[0]  ,b[1]  ,b[2]  ,i);
+    u[i] = +n[0] * n[1] * n[2] * g(b[0] + 1, b[1] + 1, b[2] + 1, i) +
+           n[0] * (1 - n[1]) * n[2] * g(b[0] + 1, b[1], b[2] + 1, i) +
+           n[0] * n[1] * (1 - n[2]) * g(b[0] + 1, b[1] + 1, b[2], i) +
+           n[0] * (1 - n[1]) * (1 - n[2]) * g(b[0] + 1, b[1], b[2], i) +
+           (1 - n[0]) * n[1] * n[2] * g(b[0], b[1] + 1, b[2] + 1, i) +
+           (1 - n[0]) * (1 - n[1]) * n[2] * g(b[0], b[1], b[2] + 1, i) +
+           (1 - n[0]) * n[1] * (1 - n[2]) * g(b[0], b[1] + 1, b[2], i) +
+           (1 - n[0]) * (1 - n[1]) * (1 - n[2]) * g(b[0], b[1], b[2], i);
 #endif
   }
   return true;
 }
 
 bool
-StreamParticleContainer::
-RK4(dim3 & x, Real hrk,const FArrayBox& v,const Real* dx,const Real* plo,const Real* phi,int dir, int cSpace, Real dxFine)
+StreamParticleContainer::RK4(
+  dim3& x,
+  Real hrk,
+  const FArrayBox& v,
+  const Real* dx,
+  const Real* plo,
+  const Real* phi,
+  int dir,
+  int cSpace,
+  Real dxFine)
 {
   Vector<Real> vec(AMREX_SPACEDIM);
   dim3 k1, k2, k3, k4;
   dim3 xx = x;
-  if (!ntrpv(xx,v,dx,plo,phi,vec,AMREX_SPACEDIM)) return false;
-  //before normalising vec, lets grab |grad vec|
+  if (!ntrpv(xx, v, dx, plo, phi, vec, AMREX_SPACEDIM))
+    return false;
+  // before normalising vec, lets grab |grad vec|
 
-  //in physical space, dt = hrk * dxFine (hrk <= 0.5)
-  //in cspace, dt = min(0.95*dxLev,hrk/|gradC|) - min stops going too far in one step and breaking things
+  // in physical space, dt = hrk * dxFine (hrk <= 0.5)
+  // in cspace, dt = min(0.95*dxLev,hrk/|gradC|) - min stops going too far in
+  // one step and breaking things
 
-  Real dt = (cSpace == 0) ? hrk*dxFine : min(0.95*dx[0],hrk/std::sqrt(AMREX_D_TERM(vec[0] * vec[0],
-										   + vec[1] * vec[1],
-										   + vec[2] * vec[2])));
-  
-  //convert gradC to gradC / |gradC| (will also clip to zero if barely any gradient)
-  vnrml(vec,dir);
+  Real dt =
+    (cSpace == 0)
+      ? hrk * dxFine
+      : min(
+          0.95 * dx[0],
+          hrk / std::sqrt(AMREX_D_TERM(
+                  vec[0] * vec[0], +vec[1] * vec[1], +vec[2] * vec[2])));
 
-  for (int d=0; d<AMREX_SPACEDIM; ++d) {
+  // convert gradC to gradC / |gradC| (will also clip to zero if barely any
+  // gradient)
+  vnrml(vec, dir);
+
+  for (int d = 0; d < AMREX_SPACEDIM; ++d) {
     k1[d] = vec[d] * dt;
     xx[d] = x[d] + k1[d] * 0.5;
   }
-  if (!ntrpv(xx,v,dx,plo,phi,vec,AMREX_SPACEDIM)) return false;
-  //update dt if using cspace
+  if (!ntrpv(xx, v, dx, plo, phi, vec, AMREX_SPACEDIM))
+    return false;
+  // update dt if using cspace
   if (cSpace != 0) {
-    dt = min(0.95*dx[0],hrk/std::sqrt(AMREX_D_TERM(vec[0] * vec[0],
-						   + vec[1] * vec[1],
-						   + vec[2] * vec[2])));
+    dt = min(
+      0.95 * dx[0],
+      hrk / std::sqrt(AMREX_D_TERM(
+              vec[0] * vec[0], +vec[1] * vec[1], +vec[2] * vec[2])));
   }
-  vnrml(vec,dir);
+  vnrml(vec, dir);
 
-  for (int d=0; d<AMREX_SPACEDIM; ++d) {
+  for (int d = 0; d < AMREX_SPACEDIM; ++d) {
     k2[d] = vec[d] * dt;
     xx[d] = x[d] + k2[d] * 0.5;
   }
-  if (!ntrpv(xx,v,dx,plo,phi,vec,AMREX_SPACEDIM)) return false;
+  if (!ntrpv(xx, v, dx, plo, phi, vec, AMREX_SPACEDIM))
+    return false;
   if (cSpace != 0) {
-    dt = min(0.95*dx[0],hrk/std::sqrt(AMREX_D_TERM(vec[0] * vec[0],
-						   + vec[1] * vec[1],
-						   + vec[2] * vec[2])));
+    dt = min(
+      0.95 * dx[0],
+      hrk / std::sqrt(AMREX_D_TERM(
+              vec[0] * vec[0], +vec[1] * vec[1], +vec[2] * vec[2])));
   }
-  vnrml(vec,dir);
+  vnrml(vec, dir);
 
-  for (int d=0; d<AMREX_SPACEDIM; ++d) {
+  for (int d = 0; d < AMREX_SPACEDIM; ++d) {
     k3[d] = vec[d] * dt;
     xx[d] = x[d] + k3[d];
   }
-  if (!ntrpv(xx,v,dx,plo,phi,vec,AMREX_SPACEDIM)) return false;
+  if (!ntrpv(xx, v, dx, plo, phi, vec, AMREX_SPACEDIM))
+    return false;
 
   if (cSpace != 0) {
-    dt = min(0.95*dx[0],hrk/std::sqrt(AMREX_D_TERM(vec[0] * vec[0],
-						   + vec[1] * vec[1],
-						   + vec[2] * vec[2])));
-  } 
-  vnrml(vec,dir);
+    dt = min(
+      0.95 * dx[0],
+      hrk / std::sqrt(AMREX_D_TERM(
+              vec[0] * vec[0], +vec[1] * vec[1], +vec[2] * vec[2])));
+  }
+  vnrml(vec, dir);
 
-  const Real third = 1./3.;
-  const Real sixth = 1./6.;
+  const Real third = 1. / 3.;
+  const Real sixth = 1. / 6.;
   dim3 delta;
-  for (int d=0; d<AMREX_SPACEDIM; ++d) {
+  for (int d = 0; d < AMREX_SPACEDIM; ++d) {
     k4[d] = vec[d] * dt;
-    delta[d] = (k1[d] + k4[d])*sixth + (k2[d] + k3[d])*third;
+    delta[d] = (k1[d] + k4[d]) * sixth + (k2[d] + k3[d]) * third;
   }
 
-  // cut step length to keep in domain (FIXME: Deal with periodic - hopefully fixed?)
+  // cut step length to keep in domain (FIXME: Deal with periodic - hopefully
+  // fixed?)
   Real scale = 1;
-  for (int d=0; d<AMREX_SPACEDIM; ++d) {
-    if ((x[d]+delta[d] <= plo[d] + dx[d]) && (is_per[d] == 0)) {
-      //std::cout << "Too low, clipping path: x=" << x[d] << ", delta = " << delta[d] << std::endl;
-      scale = 0.0; //stop moving
-      //scale = std::min(scale, std::abs((x[d] - (plo[d]+dx[d]))/delta[d]));
+  for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+    if ((x[d] + delta[d] <= plo[d] + dx[d]) && (is_per[d] == 0)) {
+      // std::cout << "Too low, clipping path: x=" << x[d] << ", delta = " <<
+      // delta[d] << std::endl;
+      scale = 0.0; // stop moving
+      // scale = std::min(scale, std::abs((x[d] - (plo[d]+dx[d]))/delta[d]));
     }
-    if ((x[d]+delta[d] >= phi[d] - dx[d]) && (is_per[d] == 0)) {
-      //std::cout << "Too high, clipping path: x=" << x[d] << ", delta = " << delta[d] << std::endl; 
-      scale = 0.0; //just stop
-      //scale = std::min(scale, std::abs(((phi[d]-dx[d]) - x[d])/delta[d]));
+    if ((x[d] + delta[d] >= phi[d] - dx[d]) && (is_per[d] == 0)) {
+      // std::cout << "Too high, clipping path: x=" << x[d] << ", delta = " <<
+      // delta[d] << std::endl;
+      scale = 0.0; // just stop
+      // scale = std::min(scale, std::abs(((phi[d]-dx[d]) - x[d])/delta[d]));
     }
   }
-  for (int d=0; d<AMREX_SPACEDIM; ++d) {
+  for (int d = 0; d < AMREX_SPACEDIM; ++d) {
     x[d] += scale * delta[d];
-    x[d] = std::min(phi[d]-1.e-10, std::max(plo[d]+1.e-10, x[d]) ); // Deal with precision issues
+    x[d] = std::min(
+      phi[d] - 1.e-10,
+      std::max(plo[d] + 1.e-10, x[d])); // Deal with precision issues
   }
   return true;
 }
 
 void
-StreamParticleContainer::
-ComputeNextLocation(int                      a_fromLoc,
-                    const Real                     a_hRK,
-                    const Vector<MultiFab> & a_vectorField,
-		    const int                      a_cSpace)
+StreamParticleContainer::ComputeNextLocation(
+  int a_fromLoc,
+  const Real a_hRK,
+  const Vector<MultiFab>& a_vectorField,
+  const int a_cSpace)
 {
   BL_PROFILE("StreamParticleContainer::ComputeNextLocation");
 
   SetParticleLocation(a_fromLoc);
-  //Real dt = a_hRK;
+  // Real dt = a_hRK;
   Real dxFine = Geom(Nlev - 1).CellSize()[0];
 
   const int new_loc_id = a_fromLoc + 1;
   int offset = pcomp * new_loc_id;
 
-  for (int lev = 0; lev < Nlev; ++lev)
-  {
+  for (int lev = 0; lev < Nlev; ++lev) {
     const auto& geom = Geom(lev);
     const auto& dx = geom.CellSize();
-    const auto& plo = geom.ProbLo(); 
-    const auto& phi = geom.ProbHi(); 
+    const auto& plo = geom.ProbLo();
+    const auto& phi = geom.ProbHi();
 
-    for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
-    {
+    for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
       auto& aos = pti.GetArrayOfStructs();
       auto& soa = pti.GetStructOfArrays();
       const FArrayBox& v = a_vectorField[lev][pti];
-      
-      for (size_t pindex=0; pindex<aos.size(); ++pindex)
-      {
+
+      for (size_t pindex = 0; pindex < aos.size(); ++pindex) {
         ParticleType& p = aos[pindex];
         const int dir = p.idata(1);
         dim3 x = {AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))};
-        if (p.id() > 0)
-        {
-          if (!RK4(x, a_hRK,v,dx,plo,phi,dir,a_cSpace,dxFine))
-          {
+        if (p.id() > 0) {
+          if (!RK4(x, a_hRK, v, dx, plo, phi, dir, a_cSpace, dxFine)) {
             Abort("bad RK");
           }
         }
-        AMREX_D_EXPR(soa.GetRealData(offset + RealData::xloc)[pindex] = x[0],
-                     soa.GetRealData(offset + RealData::yloc)[pindex] = x[1],
-                     soa.GetRealData(offset + RealData::zloc)[pindex] = x[2]);
+        AMREX_D_EXPR(
+          soa.GetRealData(offset + RealData::xloc)[pindex] = x[0],
+          soa.GetRealData(offset + RealData::yloc)[pindex] = x[1],
+          soa.GetRealData(offset + RealData::zloc)[pindex] = x[2]);
       }
     }
   }
 }
 
 void
-StreamParticleContainer::
-InterpDataAtLocation(int                      a_fromLoc,
-		     const Vector<MultiFab> & a_vectorField)
+StreamParticleContainer::InterpDataAtLocation(
+  int a_fromLoc, const Vector<MultiFab>& a_vectorField)
 {
   BL_PROFILE("StreamParticleContainer::InterpDataAtLocation");
 
@@ -322,87 +351,88 @@ InterpDataAtLocation(int                      a_fromLoc,
 
   int offset = pcomp * a_fromLoc; // components on particle
 
-  for (int lev = 0; lev < Nlev; ++lev)
-  {
+  for (int lev = 0; lev < Nlev; ++lev) {
     const auto& geom = Geom(lev);
     const auto& dx = geom.CellSize();
     const auto& plo = geom.ProbLo();
     const auto& phi = geom.ProbHi();
 
     dim3 Lx;
-    for (int iComp=0; iComp<AMREX_SPACEDIM; iComp++)
-      Lx[iComp] = phi[iComp]-plo[iComp];
+    for (int iComp = 0; iComp < AMREX_SPACEDIM; iComp++)
+      Lx[iComp] = phi[iComp] - plo[iComp];
 
-    for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
-    {
+    for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
       auto& aos = pti.GetArrayOfStructs();
       auto& soa = pti.GetStructOfArrays();
       const FArrayBox& v = a_vectorField[lev][pti];
 
-      for (size_t pindex=0; pindex<aos.size(); ++pindex)
-      {
+      for (size_t pindex = 0; pindex < aos.size(); ++pindex) {
         ParticleType& p = aos[pindex];
-	if (p.id()>0) {
-	  // where's the particle?
-	  dim3 x = {AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))};
-	  Vector<Real> ntrpvOut(fcomp); // components in infile
+        if (p.id() > 0) {
+          // where's the particle?
+          dim3 x = {AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))};
+          Vector<Real> ntrpvOut(fcomp); // components in infile
 
-	  // interpolate all data to particle location
-	  ntrpv(x,v,dx,plo,phi,ntrpvOut,fcomp); // components in infile
+          // interpolate all data to particle location
+          ntrpv(x, v, dx, plo, phi, ntrpvOut, fcomp); // components in infile
 
-	  // copy the interpolated data to the particle
-	  // first DIM components are particle location
-	  // next DIM components are stream location w/o adjusting for periodicity
-	  // then we have the interpolated data we want
-	  for (int iComp=AMREX_SPACEDIM; iComp<fcomp; ++iComp) {
-	    int idxOnPart = offset + iComp + AMREX_SPACEDIM;
-	    soa.GetRealData(idxOnPart)[pindex] = ntrpvOut[iComp];
-	  }
-	  // let's figure out the location on the stream w/o adjusting for periodicity
-	  if (a_fromLoc==0) { // nothing to do on the surface; just take a copy of the location
-	    for (int d=0; d<AMREX_SPACEDIM; ++d) {
-	      int idx = offset + d;
-	      soa.GetRealData(idx+AMREX_SPACEDIM)[pindex] = soa.GetRealData(idx)[pindex];
-	    }
-	  } else { // set new location adjusting for periodicity
-	    // calculate the change in position delta
-	    // add to the old position
-	    // adjust delta if it's affected by periodicity (i.e. delta too big)
-	    for (int d=0; d<AMREX_SPACEDIM; ++d) {
-	      int  idx    = offset + d;
-	      int  idxOld = idx - pcomp;
-	      Real xnew   = soa.GetRealData(idx   )[pindex];
-	      Real xold   = soa.GetRealData(idxOld)[pindex];
-	      Real delta  = xnew-xold;
-	      if (fabs(delta)>dx[d]) { // has been adjusted for periodicity
-		//printf("%i %i %e %e %e",pindex,d,xnew,xold,delta);
-		if (delta<0.) delta+=Lx[d];
-		else          delta-=Lx[d];
-		//printf(" --> %e\n",delta);
-	      }
-	      // store periodicity-adjusted copy of location at idx+SPACEDIM
-	      Real sold   = soa.GetRealData(idxOld+AMREX_SPACEDIM)[pindex];
-	      Real snew   = sold+delta;
-	      soa.GetRealData(idx+AMREX_SPACEDIM)[pindex] = snew;
-	    }
-	  }
-	  //hack last component to AMR level for debugging
-	  //soa.GetRealData(offset + DEF_FCOMP-1)[pindex] = (Real)lev;
-	}
+          // copy the interpolated data to the particle
+          // first DIM components are particle location
+          // next DIM components are stream location w/o adjusting for
+          // periodicity then we have the interpolated data we want
+          for (int iComp = AMREX_SPACEDIM; iComp < fcomp; ++iComp) {
+            int idxOnPart = offset + iComp + AMREX_SPACEDIM;
+            soa.GetRealData(idxOnPart)[pindex] = ntrpvOut[iComp];
+          }
+          // let's figure out the location on the stream w/o adjusting for
+          // periodicity
+          if (a_fromLoc == 0) { // nothing to do on the surface; just take a
+                                // copy of the location
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+              int idx = offset + d;
+              soa.GetRealData(idx + AMREX_SPACEDIM)[pindex] =
+                soa.GetRealData(idx)[pindex];
+            }
+          } else { // set new location adjusting for periodicity
+            // calculate the change in position delta
+            // add to the old position
+            // adjust delta if it's affected by periodicity (i.e. delta too big)
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+              int idx = offset + d;
+              int idxOld = idx - pcomp;
+              Real xnew = soa.GetRealData(idx)[pindex];
+              Real xold = soa.GetRealData(idxOld)[pindex];
+              Real delta = xnew - xold;
+              if (fabs(delta) > dx[d]) { // has been adjusted for periodicity
+                // printf("%i %i %e %e %e",pindex,d,xnew,xold,delta);
+                if (delta < 0.)
+                  delta += Lx[d];
+                else
+                  delta -= Lx[d];
+                // printf(" --> %e\n",delta);
+              }
+              // store periodicity-adjusted copy of location at idx+SPACEDIM
+              Real sold = soa.GetRealData(idxOld + AMREX_SPACEDIM)[pindex];
+              Real snew = sold + delta;
+              soa.GetRealData(idx + AMREX_SPACEDIM)[pindex] = snew;
+            }
+          }
+          // hack last component to AMR level for debugging
+          // soa.GetRealData(offset + DEF_FCOMP-1)[pindex] = (Real)lev;
+        }
       }
     }
   }
 }
 
-
 void
-StreamParticleContainer::
-WriteStreamAsTecplot(const std::string& outFile)
+StreamParticleContainer::WriteStreamAsTecplot(const std::string& outFile)
 {
   // Set location to first point on stream to guarantee partner line is local
   SetParticleLocation(0);
-  
-  // Create a folder and have each processor write their own data, one file per streamline
+
+  // Create a folder and have each processor write their own data, one file per
+  // streamline
   auto myProc = ParallelDescriptor::MyProc();
 
   if (!amrex::UtilCreateDirectory(outFile, 0755))
@@ -410,51 +440,43 @@ WriteStreamAsTecplot(const std::string& outFile)
   ParallelDescriptor::Barrier();
 
   bool will_write = false;
-  for (int lev = 0; lev < Nlev && !will_write; ++lev)
-  {
-    for (MyParIter pti(*this, lev); pti.isValid() && !will_write; ++pti)
-    {
+  for (int lev = 0; lev < Nlev && !will_write; ++lev) {
+    for (MyParIter pti(*this, lev); pti.isValid() && !will_write; ++pti) {
       auto& aos = pti.GetArrayOfStructs();
 
-      for (size_t pindex=0; pindex<aos.size() && !will_write; ++pindex)
-      {
+      for (size_t pindex = 0; pindex < aos.size() && !will_write; ++pindex) {
         ParticleType& p = aos[pindex];
         will_write |= (p.id() > 0);
       }
     }
   }
 
-  if (will_write)
-  {
+  if (will_write) {
     std::string fileName = outFile + "/str_";
-    fileName = Concatenate(fileName,myProc) + ".dat";
+    fileName = Concatenate(fileName, myProc) + ".dat";
     std::ofstream ofs(fileName.c_str());
     ofs << "VARIABLES = \"";
-    for (int iComp=0; iComp<fcomp-1; ++iComp)
+    for (int iComp = 0; iComp < fcomp - 1; ++iComp)
       ofs << outVarNames[iComp] << "\" \"";
     ofs << outVarNames[fcomp - 1] << "\"\n";
-    
-    for (int lev = 0; lev < Nlev; ++lev)
-    {
-      for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
-      {
+
+    for (int lev = 0; lev < Nlev; ++lev) {
+      for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
         auto& aos = pti.GetArrayOfStructs();
         auto& soa = pti.GetStructOfArrays();
 
-        for (size_t pindex=0; pindex<aos.size(); ++pindex)
-        {
+        for (size_t pindex = 0; pindex < aos.size(); ++pindex) {
           ofs << "ZONE I=1 J=" << nPtsOnStrm << " K=1 FORMAT=POINT\n";
-	  for (int j=0; j<nPtsOnStrm; ++j)
-	    {
-	      // by including the spacedim offset, we use locations w/o periodicity adjustments
-	      int offset = j*pcomp + AMREX_SPACEDIM;
-	      //std::cout << offset << std::endl;
-	      for (int iComp=0; iComp<fcomp; ++iComp) {
-		ofs << soa.GetRealData(offset + iComp)[pindex] << " ";
-	      }
-	      ofs << '\n';
-	      
-	    }
+          for (int j = 0; j < nPtsOnStrm; ++j) {
+            // by including the spacedim offset, we use locations w/o
+            // periodicity adjustments
+            int offset = j * pcomp + AMREX_SPACEDIM;
+            // std::cout << offset << std::endl;
+            for (int iComp = 0; iComp < fcomp; ++iComp) {
+              ofs << soa.GetRealData(offset + iComp)[pindex] << " ";
+            }
+            ofs << '\n';
+          }
         }
       }
     }
@@ -462,156 +484,148 @@ WriteStreamAsTecplot(const std::string& outFile)
   }
 }
 
-
-#if AMREX_DEBUG //AJA inspect function
+#if AMREX_DEBUG // AJA inspect function
 void
-StreamParticleContainer::
-InspectParticles (const int nStreamPairs)
+StreamParticleContainer::InspectParticles(const int nStreamPairs)
 {
   BL_PROFILE("StreamParticleContainer::InspectParticles");
 
   SetParticleLocation(0);
-  
+
   int myProc = ParallelDescriptor::MyProc();
   int nProcs = ParallelDescriptor::NProcs();
 
   Vector<Vector<int>> partIndexing(nProcs);
   Vector<Vector<int>> ptiIndexing(nProcs);
 
-  for (int iProc = 0; iProc<nProcs; iProc++) {
-    partIndexing[iProc].resize(2*nStreamPairs+1);
-    ptiIndexing[iProc].resize(2*nStreamPairs+1);
-    for (int iStream=0; iStream<=2*nStreamPairs; iStream++) {
+  for (int iProc = 0; iProc < nProcs; iProc++) {
+    partIndexing[iProc].resize(2 * nStreamPairs + 1);
+    ptiIndexing[iProc].resize(2 * nStreamPairs + 1);
+    for (int iStream = 0; iStream <= 2 * nStreamPairs; iStream++) {
       partIndexing[iProc][iStream] = -1;
-      ptiIndexing[iProc][iStream]  = -1;
+      ptiIndexing[iProc][iStream] = -1;
     }
   }
 
   int ptiCounter;
-  
-  int minId=100000000;
-  int maxId=-minId;
+
+  int minId = 100000000;
+  int maxId = -minId;
 
   for (int lev = 0; lev < Nlev; ++lev) {
-    ptiCounter=0;
+    ptiCounter = 0;
 
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti, ++ptiCounter) {
 
       auto& aos = pti.GetArrayOfStructs();
 
-      for (size_t pindex=0; pindex<aos.size(); ++pindex) {
+      for (size_t pindex = 0; pindex < aos.size(); ++pindex) {
         ParticleType& p = aos[pindex];
 
         if (p.id() > 0) {
-	  int pId = p.id();
-	  minId=min(minId,pId);
-	  maxId=max(maxId,pId);
-	  if (pId>2*nStreamPairs) {
-	    std::cout << "pId > 2*nStreamPairs " << pId << " > "
-		      << (2*nStreamPairs) << std::endl;
-	  }
-	  partIndexing[myProc][pId] = pindex;
-	  ptiIndexing[myProc][pId] = ptiCounter;
-	} else {
-	  Print() << "p.id() = " << p.id() << " !> 0" <<std::endl;
-	} // p.id
+          int pId = p.id();
+          minId = min(minId, pId);
+          maxId = max(maxId, pId);
+          if (pId > 2 * nStreamPairs) {
+            std::cout << "pId > 2*nStreamPairs " << pId << " > "
+                      << (2 * nStreamPairs) << std::endl;
+          }
+          partIndexing[myProc][pId] = pindex;
+          ptiIndexing[myProc][pId] = ptiCounter;
+        } else {
+          Print() << "p.id() = " << p.id() << " !> 0" << std::endl;
+        } // p.id
 
       } // pindex
     } // pti
 
     // Now let's see if the pair is on the same processor and pti
 
-    ptiCounter=0; // reset
-    
+    ptiCounter = 0; // reset
+
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti, ++ptiCounter) {
       auto& aos = pti.GetArrayOfStructs();
-      int goodCount=0;
-      for (int iStream=1; iStream<=2*nStreamPairs; iStream++) {
-	int pindex1 = partIndexing[myProc][iStream];
-	int ptiindex1 = ptiIndexing[myProc][iStream];
-	//if ( (pindex1>-1) && (pindex1<aos.size()) ) {
-	if ( (pindex1>-1) && (ptiindex1==ptiCounter) ) {
-	  ParticleType& p1 = aos[pindex1];
-	  int myId1   = p1.id();
-	  int pairId1 = p1.idata(2);
-	  int pindex2 = partIndexing[myProc][pairId1];
-	  ParticleType& p2 = aos[pindex2];
-	  int myId2   = p2.id();
-	  int pairId2 = p2.idata(2);
-	  if ( (myId1!=pairId2) || (pairId1!=myId2) ) {
-	    std::cout << "myProc / pindex1 / myId1 / pairId1 = " 
-		      << myProc << " / "
-		      << pindex1 << " / "
-		      << myId1 << " / "
-		      << pairId1 << " / " << std::endl;
-	    std::cout << "myProc / pindex2 / myId2 / pairId2 = "
-		      << myProc << " / "
-		      << pindex2 << " / "
-		      << myId2 << " / "
-		      << pairId2 << " / " << std::endl;
-	  } else {
-	    // looks good
-	    goodCount+=2;
-	  }
-	}
+      int goodCount = 0;
+      for (int iStream = 1; iStream <= 2 * nStreamPairs; iStream++) {
+        int pindex1 = partIndexing[myProc][iStream];
+        int ptiindex1 = ptiIndexing[myProc][iStream];
+        // if ( (pindex1>-1) && (pindex1<aos.size()) ) {
+        if ((pindex1 > -1) && (ptiindex1 == ptiCounter)) {
+          ParticleType& p1 = aos[pindex1];
+          int myId1 = p1.id();
+          int pairId1 = p1.idata(2);
+          int pindex2 = partIndexing[myProc][pairId1];
+          ParticleType& p2 = aos[pindex2];
+          int myId2 = p2.id();
+          int pairId2 = p2.idata(2);
+          if ((myId1 != pairId2) || (pairId1 != myId2)) {
+            std::cout << "myProc / pindex1 / myId1 / pairId1 = " << myProc
+                      << " / " << pindex1 << " / " << myId1 << " / " << pairId1
+                      << " / " << std::endl;
+            std::cout << "myProc / pindex2 / myId2 / pairId2 = " << myProc
+                      << " / " << pindex2 << " / " << myId2 << " / " << pairId2
+                      << " / " << std::endl;
+          } else {
+            // looks good
+            goodCount += 2;
+          }
+        }
       }
-      if (goodCount!=(int)aos.size()) {
-	std::cout << "aos.size() != goodCount : "
-		  << aos.size() << " != " 
-		  << goodCount << std::endl;
+      if (goodCount != (int)aos.size()) {
+        std::cout << "aos.size() != goodCount : " << aos.size()
+                  << " != " << goodCount << std::endl;
       }
     }
-    
+
   } // lev
 
   ParallelDescriptor::ReduceIntMin(minId);
   ParallelDescriptor::ReduceIntMax(maxId);
   if (ParallelDescriptor::IOProcessor())
-    printf("InspectParticles: minId / maxId = %i / %i\n",minId,maxId);
-  
+    printf("InspectParticles: minId / maxId = %i / %i\n", minId, maxId);
+
   int duplicate(0);
   int missing(0);
-  for (int iStream=1; iStream<=2*nStreamPairs; iStream++) {
-    int pIdx   = partIndexing[myProc][iStream];
+  for (int iStream = 1; iStream <= 2 * nStreamPairs; iStream++) {
+    int pIdx = partIndexing[myProc][iStream];
     int ptiIdx = ptiIndexing[myProc][iStream];
-    int gotcha=0;
-    if ( (pIdx!=-1) && (ptiIdx!=-1) ) {
+    int gotcha = 0;
+    if ((pIdx != -1) && (ptiIdx != -1)) {
       gotcha++;
     }
     ParallelDescriptor::ReduceIntSum(gotcha);
-    if (gotcha==0) {
+    if (gotcha == 0) {
       Print() << "iStream(" << iStream << ") == 0" << std::endl;
       missing++;
     }
-    if (gotcha>1) {
+    if (gotcha > 1) {
       Print() << "iStream(" << iStream << ") > 1" << std::endl;
       duplicate++;
     }
   }
-  if (missing>0)
+  if (missing > 0)
     Print() << "Missing " << missing << " particles !!!" << std::endl;
   else {
     Print() << "No particles missing :-)" << std::endl;
-  }    
-  if (duplicate>0)
+  }
+  if (duplicate > 0)
     Print() << "There are " << duplicate << " duplicates !!!" << std::endl;
   else {
     Print() << "No duplicate particles :-)" << std::endl;
   }
-  
 }
 
 #endif
 
 void
-StreamParticleContainer::
-WriteStreamAsBinary(const std::string& outFile,
-		    Vector<int>& faceData)
+StreamParticleContainer::WriteStreamAsBinary(
+  const std::string& outFile, Vector<int>& faceData)
 {
   // Set location to first point on stream to guarantee partner line is local
   SetParticleLocation(0);
 
-  // Create a folder and have each processor write their own data, one file per streamline
+  // Create a folder and have each processor write their own data, one file per
+  // streamline
   auto myProc = ParallelDescriptor::MyProc();
   auto nProcs = ParallelDescriptor::NProcs();
 
@@ -620,145 +634,144 @@ WriteStreamAsBinary(const std::string& outFile,
   ParallelDescriptor::Barrier();
 
   bool will_write = false;
-  for (int lev = 0; lev < Nlev && !will_write; ++lev)
-  {
-    for (MyParIter pti(*this, lev); pti.isValid() && !will_write; ++pti)
-    {
+  for (int lev = 0; lev < Nlev && !will_write; ++lev) {
+    for (MyParIter pti(*this, lev); pti.isValid() && !will_write; ++pti) {
       auto& aos = pti.GetArrayOfStructs();
 
-      for (size_t pindex=0; pindex<aos.size() && !will_write; ++pindex)
-      {
+      for (size_t pindex = 0; pindex < aos.size() && !will_write; ++pindex) {
         ParticleType& p = aos[pindex];
         will_write |= (p.id() > 0);
       }
-
     }
   }
-  
+
   // Need to count the total number of streams to be written
   // by all ptiters on all levels on this processor
   int nStreams = 0;
   int nStreamsCheck = 0;
-    
+
   for (int lev = 0; lev < Nlev; ++lev) {
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
       auto& aos = pti.GetArrayOfStructs();
-      for (size_t pindex=0; pindex<aos.size(); ++pindex) {
-	ParticleType& p = aos[pindex];
-	if ( (p.id()>0) && (p.idata(1)==1) ) {
-	  nStreams++;
-	}
+      for (size_t pindex = 0; pindex < aos.size(); ++pindex) {
+        ParticleType& p = aos[pindex];
+        if ((p.id() > 0) && (p.idata(1) == 1)) {
+          nStreams++;
+        }
       }
     }
   }
-  
+
   // write to a binary file
   std::string rootName = outFile + "/str_";
-  std::string fileName = Concatenate(rootName,myProc) + ".bin";
-  //std::string headName = Concatenate(rootName,myProc) + ".head";
-  FILE *file=fopen(fileName.c_str(),"w");
-  //FILE *head=fopen(headName.c_str(),"w");
-  // total number of streams in file
-  fwrite(&(nStreams),sizeof(int),1,file);
-  
-  int minId=100000000;
-  int maxId=-minId;
+  std::string fileName = Concatenate(rootName, myProc) + ".bin";
+  // std::string headName = Concatenate(rootName,myProc) + ".head";
+  FILE* file = fopen(fileName.c_str(), "w");
+  // FILE *head=fopen(headName.c_str(),"w");
+  //  total number of streams in file
+  fwrite(&(nStreams), sizeof(int), 1, file);
+
+  int minId = 100000000;
+  int maxId = -minId;
   for (int lev = 0; lev < Nlev; ++lev) {
 
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
       auto& aos = pti.GetArrayOfStructs();
       auto& soa = pti.GetStructOfArrays();
-      
+
       int aosSize = aos.size();
-      
+
       // construct the pair mapping for this pti
-      //Vector<int> pIdMap(2*nStreamPairs+1);
-      std::map<int,int> pid_to_pindex;
-      for (int pindex=0; pindex<aosSize; ++pindex) {
-	ParticleType& p = aos[pindex];
-	int pId = p.id();
-	if (pId>0) {
-	  pid_to_pindex[pId]=pindex;
-	}
+      // Vector<int> pIdMap(2*nStreamPairs+1);
+      std::map<int, int> pid_to_pindex;
+      for (int pindex = 0; pindex < aosSize; ++pindex) {
+        ParticleType& p = aos[pindex];
+        int pId = p.id();
+        if (pId > 0) {
+          pid_to_pindex[pId] = pindex;
+        }
       }
-      
-      for (int pindex=0; pindex<aosSize; ++pindex) {
-	ParticleType& p = aos[pindex];	  
-	int pId         = p.id();
-	int dir         = p.idata(1);
-	int pairId      = p.idata(2);
-	
-	if ( (pId>0) && (dir==1) ) {
-	  // write info about this stream and its pair
-	  int pindexPair      = pid_to_pindex[pairId];
-	  ParticleType& pPair = aos[pindexPair];
-	  int pIdPair         = pPair.id();
-	  int pairIdPair      = pPair.idata(2);
-	  
-	  // sanity check
-	  if ( ( pIdPair != pairId ) || ( pId != pairIdPair ) ) {
-	    std::cout << pIdPair << std::endl; 
-	    std::cout << pairId << std::endl; 
-	    std::cout << pId << std::endl;
-	    std::cout << pairIdPair << std::endl;
-	    Abort("Bad pair mapping");
-	  }
-	  // back out the original id from the surface (both count from 1)
-	  int pIdInv = (pId+1)/2;
-	  fwrite(&(pIdInv),sizeof(int),1,file); // pair id
-	  
-	  //fprintf(head,"%i %i %i\n",pId,dir,pairId);
-	  
-	  minId=min(minId,pId);
-	  maxId=max(maxId,pId);
-	  
-	  // if we write in the order paricle->component->position on surface,
-	  // then end up with a single-component stream together in memory
-	  // by including spacedim in offset, we use locations w/o periodicity adjustments
-	  
-	  for (int iComp=0; iComp<fcomp; iComp++) {
-	    // first write pair (dir=-1) backwards (without double writing surface)
-	    for (int j=nPtsOnStrm-1; j>0; j--) {
-	      int offset = j*pcomp + iComp + AMREX_SPACEDIM;
-	      fwrite(&(soa.GetRealData(offset)[pindexPair]),sizeof(Real),1,file);
-	    }
-	    // now write this particle's (dir=1) data (with surface)
-	    for (int j=0; j<nPtsOnStrm; j++) {
-	      int offset = j*pcomp + iComp + AMREX_SPACEDIM;
-	      fwrite(&(soa.GetRealData(offset)[pindex]),sizeof(Real),1,file);
-	    }
-	  }
-	  
-	  nStreamsCheck++; // sanity check to make sure we wrote number of streams anticipated
-	  
-	}
+
+      for (int pindex = 0; pindex < aosSize; ++pindex) {
+        ParticleType& p = aos[pindex];
+        int pId = p.id();
+        int dir = p.idata(1);
+        int pairId = p.idata(2);
+
+        if ((pId > 0) && (dir == 1)) {
+          // write info about this stream and its pair
+          int pindexPair = pid_to_pindex[pairId];
+          ParticleType& pPair = aos[pindexPair];
+          int pIdPair = pPair.id();
+          int pairIdPair = pPair.idata(2);
+
+          // sanity check
+          if ((pIdPair != pairId) || (pId != pairIdPair)) {
+            std::cout << pIdPair << std::endl;
+            std::cout << pairId << std::endl;
+            std::cout << pId << std::endl;
+            std::cout << pairIdPair << std::endl;
+            Abort("Bad pair mapping");
+          }
+          // back out the original id from the surface (both count from 1)
+          int pIdInv = (pId + 1) / 2;
+          fwrite(&(pIdInv), sizeof(int), 1, file); // pair id
+
+          // fprintf(head,"%i %i %i\n",pId,dir,pairId);
+
+          minId = min(minId, pId);
+          maxId = max(maxId, pId);
+
+          // if we write in the order paricle->component->position on surface,
+          // then end up with a single-component stream together in memory
+          // by including spacedim in offset, we use locations w/o periodicity
+          // adjustments
+
+          for (int iComp = 0; iComp < fcomp; iComp++) {
+            // first write pair (dir=-1) backwards (without double writing
+            // surface)
+            for (int j = nPtsOnStrm - 1; j > 0; j--) {
+              int offset = j * pcomp + iComp + AMREX_SPACEDIM;
+              fwrite(
+                &(soa.GetRealData(offset)[pindexPair]), sizeof(Real), 1, file);
+            }
+            // now write this particle's (dir=1) data (with surface)
+            for (int j = 0; j < nPtsOnStrm; j++) {
+              int offset = j * pcomp + iComp + AMREX_SPACEDIM;
+              fwrite(&(soa.GetRealData(offset)[pindex]), sizeof(Real), 1, file);
+            }
+          }
+
+          nStreamsCheck++; // sanity check to make sure we wrote number of
+                           // streams anticipated
+        }
       }
     }
   }
   ParallelDescriptor::ReduceIntMin(minId);
   ParallelDescriptor::ReduceIntMax(maxId);
-  
-  if (nStreams!=nStreamsCheck)
-    std::cout << "(nStreams!=nStreamsCheck) : "
-	      << nStreams << " != "  << nStreamsCheck << std::endl;
-  
+
+  if (nStreams != nStreamsCheck)
+    std::cout << "(nStreams!=nStreamsCheck) : " << nStreams
+              << " != " << nStreamsCheck << std::endl;
+
   fclose(file);
-  
+
   // Write header file with everything consistent across all processors
   ParallelDescriptor::ReduceIntSum(nStreams);
   if (ParallelDescriptor::IOProcessor()) {
     fileName = outFile + "/Header";
     std::ofstream ofs(fileName.c_str());
     ofs << "Even odder-ball replacement for sampled streams" << std::endl;
-    ofs << nProcs << std::endl;         // translates to number of files to read
-    ofs << nStreams << std::endl;       // total number of streams
-    ofs << 2*nPtsOnStrm-1 << std::endl; // number of points
-    ofs << fcomp << std::endl;      // number of variables
-    for (int iComp=0; iComp<fcomp; ++iComp)
+    ofs << nProcs << std::endl;   // translates to number of files to read
+    ofs << nStreams << std::endl; // total number of streams
+    ofs << 2 * nPtsOnStrm - 1 << std::endl; // number of points
+    ofs << fcomp << std::endl;              // number of variables
+    for (int iComp = 0; iComp < fcomp; ++iComp)
       ofs << outVarNames[iComp] << " ";
     ofs << std::endl;
     ofs << faceData.size() << std::endl;
-    ofs.write((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
+    ofs.write((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
     ofs << '\n';
     ofs.close();
   }

--- a/Src/amrToFE.cpp
+++ b/Src/amrToFE.cpp
@@ -11,641 +11,638 @@
 #include <AMReX_DataServices.H>
 
 using namespace amrex;
-using std::cout;
 using std::cerr;
+using std::cout;
 using std::endl;
 
 struct Node
 {
-    enum typeEnum{INIT=0, COVERED=1, VALID=2};
-    Node()
-        : level(-1), iv(IntVect(AMREX_D_DECL(-1,-1,-1))), grid(-1), type(Node::INIT) {}
-    Node(const IntVect& idx, int lev, int grd, typeEnum typ = INIT)
-      : level(lev), iv(idx), grid(grd), type(typ) {}
-    inline bool operator< (const Node& rhs) const
-        {
-            if (level < rhs.level) return true;
-            if ((level == rhs.level) && (iv<rhs.iv)) return true;
-            return false;
-        }
-    inline bool operator!= (const Node& rhs) const
-        {
-            return ((*this) < rhs || rhs < (*this));
-        }
-    int level;
-    IntVect iv;
-    int grid;
-    typeEnum type;
+  enum typeEnum { INIT = 0, COVERED = 1, VALID = 2 };
+  Node()
+    : level(-1),
+      iv(IntVect(AMREX_D_DECL(-1, -1, -1))),
+      grid(-1),
+      type(Node::INIT)
+  {
+  }
+  Node(const IntVect& idx, int lev, int grd, typeEnum typ = INIT)
+    : level(lev), iv(idx), grid(grd), type(typ)
+  {
+  }
+  inline bool operator<(const Node& rhs) const
+  {
+    if (level < rhs.level)
+      return true;
+    if ((level == rhs.level) && (iv < rhs.iv))
+      return true;
+    return false;
+  }
+  inline bool operator!=(const Node& rhs) const
+  {
+    return ((*this) < rhs || rhs < (*this));
+  }
+  int level;
+  IntVect iv;
+  int grid;
+  typeEnum type;
 };
 
-std::ostream& operator<< (std::ostream&  os, const Node& node)
+std::ostream&
+operator<<(std::ostream& os, const Node& node)
 {
-    os << "Node: IntVect=" << node.iv << ", level=" << node.level << ", grid=" << node.grid << ", type="; 
-    if (node.type==Node::INIT)
-        os << "INIT";
-    else if (node.type==Node::COVERED)
-        os << "COVERED";
-    else
-        os << "VALID";
-    if (os.fail())
-        Error("operator<<(std::ostream&,Node&) failed");
-    return os;
+  os << "Node: IntVect=" << node.iv << ", level=" << node.level
+     << ", grid=" << node.grid << ", type=";
+  if (node.type == Node::INIT)
+    os << "INIT";
+  else if (node.type == Node::COVERED)
+    os << "COVERED";
+  else
+    os << "VALID";
+  if (os.fail())
+    Error("operator<<(std::ostream&,Node&) failed");
+  return os;
 }
 
 struct Element
 {
-#if (AMREX_SPACEDIM==2)
+#if (AMREX_SPACEDIM == 2)
 #define MYLEN 4
-    Element(const Node& a, const Node& b, const Node& c, const Node& d)
-        {  n[0]=&a; n[1]=&b; n[2]=&c; n[3]=&d; }
+  Element(const Node& a, const Node& b, const Node& c, const Node& d)
+  {
+    n[0] = &a;
+    n[1] = &b;
+    n[2] = &c;
+    n[3] = &d;
+  }
 #else
 #define MYLEN 8
-    Element(const Node& a, const Node& b, const Node& c, const Node& d,
-            const Node& e, const Node& f, const Node& g, const Node& h)
-        {  n[0]=&a; n[1]=&b; n[2]=&c; n[3]=&d; n[4]=&e; n[5]=&f; n[6]=&g; n[7]=&h; }
+  Element(
+    const Node& a,
+    const Node& b,
+    const Node& c,
+    const Node& d,
+    const Node& e,
+    const Node& f,
+    const Node& g,
+    const Node& h)
+  {
+    n[0] = &a;
+    n[1] = &b;
+    n[2] = &c;
+    n[3] = &d;
+    n[4] = &e;
+    n[5] = &f;
+    n[6] = &g;
+    n[7] = &h;
+  }
 #endif
-    const Node* n[MYLEN];
-    inline bool operator< (const Element& rhs) const
-        {
-            for (int i=0; i<MYLEN; ++i)
-                if (*n[i] != *rhs.n[i])
-                    return *n[i] < *rhs.n[i];
-            return false;
-        }
+  const Node* n[MYLEN];
+  inline bool operator<(const Element& rhs) const
+  {
+    for (int i = 0; i < MYLEN; ++i)
+      if (*n[i] != *rhs.n[i])
+        return *n[i] < *rhs.n[i];
+    return false;
+  }
 };
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
-    std::cerr 
-	<< endl
-	<< " usage:" << endl
-	<< endl
-	<< "    " << argv[0] << " [ParmParse input file] [additional keyword=input]" << endl
-	<< endl
-	<< "       The first argument is a file name unless it contains an =." << endl
-	<< "       With no arguments prints this help." << endl
-        << endl
-	<< " keywords:" << endl
-	<< endl
-	<< "    box = int list of two subbox coords, LL and UR  (default all)" << endl
-	<< "    comps = integer comp list  (overrides sComp and nComp)" << endl
-	<< "    finestLevel = <#> finest level to use  (default all)" << endl
-	<< "    help = <anything> prints this help" << endl
-	<< "    infile = <plotfile>  (required)" << endl
-	<< "    nComp = <#> number of comps  (default all)" << endl
-	<< "    nGrowPer = <#> number of lev-0 cells by which to" << endl
-	<< "               extend periodic boundaries  (default 0)" << endl
-	<< "    outType = tec (default) or flt" << endl
-	<< "    sComp = start comp  (default 0)" << endl
-	<< "    connect_cc = Generate flattened structure by connecting cells centers,"
-        << "                 otherwise, generate node at all cell corners and copy cc"
-        << "                 value out (default 1)" << endl
-	<< endl
-	<< " if nGrowPer > 1 then these additional keywords are needed:" << endl
-	<< endl	
-	<< "    geometry.coord_sys = <0 Cartesion, 1 rz>" << endl
-	<< "    geometry.is_periodic = <0, false or 1, true for each axis>" << endl
-	<< "    geometry.prob_lo = <lower limits for the axes>" << endl
-	<< "    geometry.prob_hi = <upper limits for the axes>" << endl
-	<< endl;
-    Finalize();
-    exit(1);
+  std::cerr
+    << endl
+    << " usage:" << endl
+    << endl
+    << "    " << argv[0] << " [ParmParse input file] [additional keyword=input]"
+    << endl
+    << endl
+    << "       The first argument is a file name unless it contains an =."
+    << endl
+    << "       With no arguments prints this help." << endl
+    << endl
+    << " keywords:" << endl
+    << endl
+    << "    box = int list of two subbox coords, LL and UR  (default all)"
+    << endl
+    << "    comps = integer comp list  (overrides sComp and nComp)" << endl
+    << "    finestLevel = <#> finest level to use  (default all)" << endl
+    << "    help = <anything> prints this help" << endl
+    << "    infile = <plotfile>  (required)" << endl
+    << "    nComp = <#> number of comps  (default all)" << endl
+    << "    nGrowPer = <#> number of lev-0 cells by which to" << endl
+    << "               extend periodic boundaries  (default 0)" << endl
+    << "    outType = tec (default) or flt" << endl
+    << "    sComp = start comp  (default 0)" << endl
+    << "    connect_cc = Generate flattened structure by connecting cells "
+       "centers,"
+    << "                 otherwise, generate node at all cell corners and copy "
+       "cc"
+    << "                 value out (default 1)" << endl
+    << endl
+    << " if nGrowPer > 1 then these additional keywords are needed:" << endl
+    << endl
+    << "    geometry.coord_sys = <0 Cartesion, 1 rz>" << endl
+    << "    geometry.is_periodic = <0, false or 1, true for each axis>" << endl
+    << "    geometry.prob_lo = <lower limits for the axes>" << endl
+    << "    geometry.prob_hi = <upper limits for the axes>" << endl
+    << endl;
+  Finalize();
+  exit(1);
 }
 
-static
-BoxArray
-GetBndryCells (const BoxArray& ba,
-               int             ngrow,
-               const Geometry& geom)
+static BoxArray
+GetBndryCells(const BoxArray& ba, int ngrow, const Geometry& geom)
 {
-    //
-    // First get list of all ghost cells.
-    //
-    BoxList gcells, bcells;
+  //
+  // First get list of all ghost cells.
+  //
+  BoxList gcells, bcells;
 
-    for (int i = 0; i < ba.size(); ++i)
-	gcells.join(boxDiff(grow(ba[i],ngrow),ba[i]));
-    //
-    // Now strip out intersections with original BoxArray.
-    //
-    for (BoxList::const_iterator it = gcells.begin(); it != gcells.end(); ++it)
-    {
-        std::vector< std::pair<int,Box> > isects = ba.intersections(*it);
+  for (int i = 0; i < ba.size(); ++i)
+    gcells.join(boxDiff(grow(ba[i], ngrow), ba[i]));
+  //
+  // Now strip out intersections with original BoxArray.
+  //
+  for (BoxList::const_iterator it = gcells.begin(); it != gcells.end(); ++it) {
+    std::vector<std::pair<int, Box>> isects = ba.intersections(*it);
 
-        if (isects.empty())
-            bcells.push_back(*it);
-        else
-        {
-            //
-            // Collect all the intersection pieces.
-            //
-            BoxList pieces;
-            for (int i = 0; i < isects.size(); i++)
-                pieces.push_back(isects[i].second);
-            BoxList leftover = complementIn(*it,pieces);
-            bcells.catenate(leftover);
-        }
+    if (isects.empty())
+      bcells.push_back(*it);
+    else {
+      //
+      // Collect all the intersection pieces.
+      //
+      BoxList pieces;
+      for (int i = 0; i < isects.size(); i++)
+        pieces.push_back(isects[i].second);
+      BoxList leftover = complementIn(*it, pieces);
+      bcells.catenate(leftover);
     }
-    //
-    // Now strip out overlaps.
-    //
-    gcells.clear();
-    gcells = removeOverlap(bcells);
-    bcells.clear();
+  }
+  //
+  // Now strip out overlaps.
+  //
+  gcells.clear();
+  gcells = removeOverlap(bcells);
+  bcells.clear();
 
-    if (geom.isAnyPeriodic())
-    {
-        Vector<IntVect> pshifts(27);
+  if (geom.isAnyPeriodic()) {
+    Vector<IntVect> pshifts(27);
 
-        const Box domain = geom.Domain();
+    const Box domain = geom.Domain();
 
-        for (BoxList::const_iterator it = gcells.begin(); it != gcells.end(); ++it)
-        {
-            if (!domain.contains(*it))
-            {
-                //
-                // Add in periodic ghost cells shifted to valid region.
-                //
-                geom.periodicShift(domain, *it, pshifts);
+    for (BoxList::const_iterator it = gcells.begin(); it != gcells.end();
+         ++it) {
+      if (!domain.contains(*it)) {
+        //
+        // Add in periodic ghost cells shifted to valid region.
+        //
+        geom.periodicShift(domain, *it, pshifts);
 
-                for (int i = 0; i < pshifts.size(); i++)
-                {
-                    const Box shftbox = *it + pshifts[i];
+        for (int i = 0; i < pshifts.size(); i++) {
+          const Box shftbox = *it + pshifts[i];
 
-                    const Box ovlp = domain & shftbox;
-                    BoxList bl = complementIn(ovlp,BoxList(ba));
-                    bcells.catenate(bl);
-                }
-            }
+          const Box ovlp = domain & shftbox;
+          BoxList bl = complementIn(ovlp, BoxList(ba));
+          bcells.catenate(bl);
         }
-
-        gcells.catenate(bcells);
+      }
     }
 
-    return BoxArray(gcells);
+    gcells.catenate(bcells);
+  }
+
+  return BoxArray(gcells);
 }
 
 class FABdata
 {
 public:
-    FABdata(int i, int n)
-        {fab.resize(Box(IntVect::TheZeroVector(),
-                        IntVect(AMREX_D_DECL(i-1,0,0))),n);}
-    Real& operator[](int i) {return fab.dataPtr()[i];}
-    Real* dataPtr (int N = 0) {return fab.dataPtr(N);}
-    const Real* dataPtr (int N = 0) const {return fab.dataPtr(N);}
-    FArrayBox fab;
-    int boxSize;
+  FABdata(int i, int n)
+  {
+    fab.resize(
+      Box(IntVect::TheZeroVector(), IntVect(AMREX_D_DECL(i - 1, 0, 0))), n);
+  }
+  Real& operator[](int i) { return fab.dataPtr()[i]; }
+  Real* dataPtr(int N = 0) { return fab.dataPtr(N); }
+  const Real* dataPtr(int N = 0) const { return fab.dataPtr(N); }
+  FArrayBox fab;
+  int boxSize;
 };
 
 void
-Collate(Vector<Real>& NodeRaw,
-        Vector<int>&  EltRaw,
-        int          nCompPerNode)
+Collate(Vector<Real>& NodeRaw, Vector<int>& EltRaw, int nCompPerNode)
 {
 
 #if BL_USE_MPI
-    const int IOProc = ParallelDescriptor::IOProcessorNumber();
-    AMREX_ASSERT(IOProc==0);
-    const int nProcs = ParallelDescriptor::NProcs(); 
-    Vector<int> nmdataR(nProcs,0);
-    Vector<int> offsetR(nProcs,0);
-    //
-    // Tell root CPU how many Real data elements each CPU will be sending.
-    //
-    int countR = NodeRaw.size();
-    MPI_Gather(&countR,
-               1,
-               ParallelDescriptor::Mpi_typemap<int>::type(),
-               nmdataR.dataPtr(),
-               1,
-               ParallelDescriptor::Mpi_typemap<int>::type(),
-               IOProc,
-               ParallelDescriptor::Communicator());
+  const int IOProc = ParallelDescriptor::IOProcessorNumber();
+  AMREX_ASSERT(IOProc == 0);
+  const int nProcs = ParallelDescriptor::NProcs();
+  Vector<int> nmdataR(nProcs, 0);
+  Vector<int> offsetR(nProcs, 0);
+  //
+  // Tell root CPU how many Real data elements each CPU will be sending.
+  //
+  int countR = NodeRaw.size();
+  MPI_Gather(
+    &countR, 1, ParallelDescriptor::Mpi_typemap<int>::type(), nmdataR.dataPtr(),
+    1, ParallelDescriptor::Mpi_typemap<int>::type(), IOProc,
+    ParallelDescriptor::Communicator());
 
-    if (ParallelDescriptor::IOProcessor())
-    {
-        for (int i = 1; i < nProcs; i++)
-            offsetR[i] = offsetR[i-1] + nmdataR[i-1];
+  if (ParallelDescriptor::IOProcessor()) {
+    for (int i = 1; i < nProcs; i++)
+      offsetR[i] = offsetR[i - 1] + nmdataR[i - 1];
 
-        NodeRaw.resize(offsetR[nProcs-1] + nmdataR[nProcs-1]);
+    NodeRaw.resize(offsetR[nProcs - 1] + nmdataR[nProcs - 1]);
+  }
+  //
+  // Gather all the Real data to IOProc into NodeRaw.
+  //
+  MPI_Gatherv(
+    NodeRaw.dataPtr(), countR, ParallelDescriptor::Mpi_typemap<Real>::type(),
+    NodeRaw.dataPtr(), nmdataR.dataPtr(), offsetR.dataPtr(),
+    ParallelDescriptor::Mpi_typemap<Real>::type(), IOProc,
+    ParallelDescriptor::Communicator());
+
+  // Now communicate the element info
+  Vector<int> nmdataI(nProcs, 0);
+  Vector<int> offsetI(nProcs, 0);
+  int countI = EltRaw.size();
+  MPI_Gather(
+    &countI, 1, ParallelDescriptor::Mpi_typemap<int>::type(), nmdataI.dataPtr(),
+    1, ParallelDescriptor::Mpi_typemap<int>::type(), IOProc,
+    ParallelDescriptor::Communicator());
+
+  if (ParallelDescriptor::IOProcessor()) {
+    for (int i = 1; i < nProcs; i++)
+      offsetI[i] = offsetI[i - 1] + nmdataI[i - 1];
+
+    EltRaw.resize(offsetI[nProcs - 1] + nmdataI[nProcs - 1]);
+  }
+  //
+  // Gather all the data to IOProc into EltRaw
+  //
+  MPI_Gatherv(
+    EltRaw.dataPtr(), countI, ParallelDescriptor::Mpi_typemap<int>::type(),
+    EltRaw.dataPtr(), nmdataI.dataPtr(), offsetI.dataPtr(),
+    ParallelDescriptor::Mpi_typemap<int>::type(), IOProc,
+    ParallelDescriptor::Communicator());
+  //
+  // Shift nodeIDs in element definitions
+  //
+  if (ParallelDescriptor::IOProcessor()) {
+    for (int i = 1; i < nProcs; i++) {
+      const int nodeOffset = offsetR[i] / nCompPerNode;
+      for (int j = 0; j < nmdataI[i]; j++)
+        EltRaw[offsetI[i] + j] += nodeOffset;
     }
-    //
-    // Gather all the Real data to IOProc into NodeRaw.
-    //
-    MPI_Gatherv(NodeRaw.dataPtr(),
-                countR,
-                ParallelDescriptor::Mpi_typemap<Real>::type(),
-                NodeRaw.dataPtr(),
-                nmdataR.dataPtr(),
-                offsetR.dataPtr(),
-                ParallelDescriptor::Mpi_typemap<Real>::type(),
-                IOProc,
-                ParallelDescriptor::Communicator());
-
-    // Now communicate the element info
-    Vector<int> nmdataI(nProcs,0);
-    Vector<int> offsetI(nProcs,0);
-    int countI = EltRaw.size();
-    MPI_Gather(&countI,
-               1,
-               ParallelDescriptor::Mpi_typemap<int>::type(),
-               nmdataI.dataPtr(),
-               1,
-               ParallelDescriptor::Mpi_typemap<int>::type(),
-               IOProc,
-               ParallelDescriptor::Communicator());
-
-    if (ParallelDescriptor::IOProcessor())
-    {
-        for (int i = 1; i < nProcs; i++)
-            offsetI[i] = offsetI[i-1] + nmdataI[i-1];
-
-        EltRaw.resize(offsetI[nProcs-1] + nmdataI[nProcs-1]);
-    }
-    //
-    // Gather all the data to IOProc into EltRaw
-    //
-    MPI_Gatherv(EltRaw.dataPtr(),
-                countI,
-                ParallelDescriptor::Mpi_typemap<int>::type(),
-                EltRaw.dataPtr(),
-                nmdataI.dataPtr(),
-                offsetI.dataPtr(),
-                ParallelDescriptor::Mpi_typemap<int>::type(),
-                IOProc,
-                ParallelDescriptor::Communicator());
-    //
-    // Shift nodeIDs in element definitions
-    //
-    if (ParallelDescriptor::IOProcessor())
-    {
-        for (int i = 1; i < nProcs; i++)
-        {
-            const int nodeOffset = offsetR[i]/nCompPerNode;
-            for (int j = 0; j < nmdataI[i]; j++)                
-                EltRaw[offsetI[i]+j] += nodeOffset;
-        }
-    }
+  }
 #endif
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    Initialize(argc,argv);
-    {
+  Initialize(argc, argv);
+  {
     if (argc < 2)
-        print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-        print_usage(argc,argv);
+      print_usage(argc, argv);
 
     bool verbose = false;
-    pp.query("verbose",verbose);
+    pp.query("verbose", verbose);
 
     if (verbose)
-        AmrData::SetVerbose(true);
+      AmrData::SetVerbose(true);
 
-    std::string infile; pp.get("infile",infile);
+    std::string infile;
+    pp.get("infile", infile);
     std::string outfile_DEF;
 
-    bool doBin=false;
-    std::string outType = "tec"; pp.query("outType",outType);
-    if (outType=="flt")
-    {
-        outfile_DEF = infile+".flt";
-    }
-    else if (outType=="tec")
-    {
+    bool doBin = false;
+    std::string outType = "tec";
+    pp.query("outType", outType);
+    if (outType == "flt") {
+      outfile_DEF = infile + ".flt";
+    } else if (outType == "tec") {
 #ifdef USE_TEC_BIN_IO
-        bool doBin = true;
-        pp.query("doBin",doBin);
-        outfile_DEF = infile+(doBin ? ".plt" : ".dat" );
+      bool doBin = true;
+      pp.query("doBin", doBin);
+      outfile_DEF = infile + (doBin ? ".plt" : ".dat");
 #else
-        outfile_DEF = infile+".dat";
+      outfile_DEF = infile + ".dat";
 #endif
-    }
-    else
-    {
-        print_usage(argc,argv);
+    } else {
+      print_usage(argc, argv);
     }
 
-    // 
-    bool connect_cc = true; pp.query("connect_cc",connect_cc);
+    //
+    bool connect_cc = true;
+    pp.query("connect_cc", connect_cc);
 
-    std::string outfile(outfile_DEF); pp.query("outfile",outfile);
+    std::string outfile(outfile_DEF);
+    pp.query("outfile", outfile);
     Print() << "outfile: " << outfile << std::endl;
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(infile, fileType);
 
     if (!dataServices.AmrDataOk())
-        DataServices::Dispatch(DataServices::ExitRequest, NULL);
+      DataServices::Dispatch(DataServices::ExitRequest, NULL);
 
     AmrData& amrData = dataServices.AmrDataRef();
 
     const Vector<std::string>& names = amrData.PlotVarNames();
 
     Vector<int> comps;
-    if (int nc = pp.countval("comps"))
-    {
-        comps.resize(nc);
-        pp.getarr("comps",comps,0,nc);
-    }
-    else
-    {
-        int sComp = 0;
-        pp.query("sComp",sComp);
-        int nComp = amrData.NComp();
-        pp.query("nComp",nComp);
-        AMREX_ASSERT(sComp+nComp <= amrData.NComp());
-        comps.resize(nComp);
-        for (int i=0; i<nComp; ++i)
-            comps[i] = sComp + i;
+    if (int nc = pp.countval("comps")) {
+      comps.resize(nc);
+      pp.getarr("comps", comps, 0, nc);
+    } else {
+      int sComp = 0;
+      pp.query("sComp", sComp);
+      int nComp = amrData.NComp();
+      pp.query("nComp", nComp);
+      AMREX_ASSERT(sComp + nComp <= amrData.NComp());
+      comps.resize(nComp);
+      for (int i = 0; i < nComp; ++i)
+        comps[i] = sComp + i;
     }
 
     Box subbox;
-    if (int nx=pp.countval("box"))
-    {
-        Vector<int> barr;
-        pp.getarr("box",barr,0,nx);
-        int d=AMREX_SPACEDIM;
-        AMREX_ASSERT(barr.size()==2*d);
-        subbox=Box(IntVect(AMREX_D_DECL(barr[0],barr[1],barr[2])),
-                   IntVect(AMREX_D_DECL(barr[d],barr[d+1],barr[d+2]))) & amrData.ProbDomain()[0];
+    if (int nx = pp.countval("box")) {
+      Vector<int> barr;
+      pp.getarr("box", barr, 0, nx);
+      int d = AMREX_SPACEDIM;
+      AMREX_ASSERT(barr.size() == 2 * d);
+      subbox = Box(
+                 IntVect(AMREX_D_DECL(barr[0], barr[1], barr[2])),
+                 IntVect(AMREX_D_DECL(barr[d], barr[d + 1], barr[d + 2]))) &
+               amrData.ProbDomain()[0];
 
     } else {
 
-        subbox = amrData.ProbDomain()[0];
+      subbox = amrData.ProbDomain()[0];
     }
 
-    int finestLevel = amrData.FinestLevel(); pp.query("finestLevel",finestLevel);
+    int finestLevel = amrData.FinestLevel();
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
     Vector<BoxArray> gridArray(Nlev);
     Vector<Box> subboxArray(Nlev);
 
-    int nGrowPer = 0; pp.query("nGrowPer",nGrowPer);
+    int nGrowPer = 0;
+    pp.query("nGrowPer", nGrowPer);
     Vector<std::unique_ptr<Geometry>> geom(Nlev);
 
     RealBox rb(amrData.ProbLo().data(), amrData.ProbHi().data());
-    
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-        subboxArray[lev]
-            = (lev==0 ? subbox
-               : Box(subboxArray[lev-1]).refine(amrData.RefRatio()[lev-1]));
 
-        geom[lev].reset(new Geometry(amrData.ProbDomain()[lev], &rb));
+    for (int lev = 0; lev < Nlev; ++lev) {
+      subboxArray[lev] =
+        (lev == 0
+           ? subbox
+           : Box(subboxArray[lev - 1]).refine(amrData.RefRatio()[lev - 1]));
 
-        if (nGrowPer>0 && lev==0)
-        {
-            for (int i=0; i<AMREX_SPACEDIM; ++i)
-            {
-                if (geom[lev]->isPeriodic(i))
-                {
-                    if (subboxArray[lev].smallEnd()[i] == amrData.ProbDomain()[lev].smallEnd()[i])
-                        subboxArray[lev].growLo(i,nGrowPer);
-                    if (subboxArray[lev].bigEnd()[i] == amrData.ProbDomain()[lev].bigEnd()[i])
-                        subboxArray[lev].growHi(i,nGrowPer);
-                }
-            }
+      geom[lev].reset(new Geometry(amrData.ProbDomain()[lev], &rb));
+
+      if (nGrowPer > 0 && lev == 0) {
+        for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+          if (geom[lev]->isPeriodic(i)) {
+            if (
+              subboxArray[lev].smallEnd()[i] ==
+              amrData.ProbDomain()[lev].smallEnd()[i])
+              subboxArray[lev].growLo(i, nGrowPer);
+            if (
+              subboxArray[lev].bigEnd()[i] ==
+              amrData.ProbDomain()[lev].bigEnd()[i])
+              subboxArray[lev].growHi(i, nGrowPer);
+          }
         }
+      }
 
-        gridArray[lev] = intersect(amrData.boxArray(lev), subboxArray[lev]);
+      gridArray[lev] = intersect(amrData.boxArray(lev), subboxArray[lev]);
 
-        if (nGrowPer>0 && geom[lev]->isAnyPeriodic() && gridArray[lev].size()>0)
-        {
-	  //const Box& probDomain = amrData.ProbDomain()[lev];
-            const BoxArray& ba = amrData.boxArray(lev);
-            BoxList bladd;
-            Vector<IntVect> shifts;
-            for (int i=0; i<ba.size(); ++i)
-            {
-                geom[lev]->periodicShift(subboxArray[lev],ba[i],shifts);
-                for (int j=0; j<shifts.size(); ++j)
-                {
-                    Box ovlp = Box(ba[i]).shift(shifts[j]) & subboxArray[lev];
-                    if (ovlp.ok())
-                        bladd.push_back(ovlp);
-                }
-            }
-            bladd.simplify();
-            BoxList blnew(gridArray[lev]);
-            blnew.join(bladd);
-            gridArray[lev] = BoxArray(blnew);
+      if (
+        nGrowPer > 0 && geom[lev]->isAnyPeriodic() &&
+        gridArray[lev].size() > 0) {
+        // const Box& probDomain = amrData.ProbDomain()[lev];
+        const BoxArray& ba = amrData.boxArray(lev);
+        BoxList bladd;
+        Vector<IntVect> shifts;
+        for (int i = 0; i < ba.size(); ++i) {
+          geom[lev]->periodicShift(subboxArray[lev], ba[i], shifts);
+          for (int j = 0; j < shifts.size(); ++j) {
+            Box ovlp = Box(ba[i]).shift(shifts[j]) & subboxArray[lev];
+            if (ovlp.ok())
+              bladd.push_back(ovlp);
+          }
         }
+        bladd.simplify();
+        BoxList blnew(gridArray[lev]);
+        blnew.join(bladd);
+        gridArray[lev] = BoxArray(blnew);
+      }
 
-        if (!gridArray[lev].size())
-        {
-            Nlev = lev;
-            finestLevel = Nlev-1;
-            gridArray.resize(Nlev);
-            subboxArray.resize(Nlev);
-        }
+      if (!gridArray[lev].size()) {
+        Nlev = lev;
+        finestLevel = Nlev - 1;
+        gridArray.resize(Nlev);
+        subboxArray.resize(Nlev);
+      }
     }
 
     const int nGrow = 1;
     typedef BaseFab<Node> NodeFab;
-    typedef FabArray<NodeFab> MultiNodeFab; 
+    typedef FabArray<NodeFab> MultiNodeFab;
     Vector<std::unique_ptr<MultiNodeFab>> nodes(Nlev);
 
     std::cerr << "Before nodes allocated" << endl;
-    for (int lev=0; lev<Nlev; ++lev)
-         nodes[lev].reset(new MultiNodeFab(gridArray[lev],DistributionMapping(gridArray[lev]),1,nGrow));
+    for (int lev = 0; lev < Nlev; ++lev)
+      nodes[lev].reset(new MultiNodeFab(
+        gridArray[lev], DistributionMapping(gridArray[lev]), 1, nGrow));
     std::cerr << "After nodes allocated" << endl;
 
     int cnt = 0;
-    typedef std::map<Node,int> NodeMap;
+    typedef std::map<Node, int> NodeMap;
     NodeMap nodeMap;
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-        for (MFIter fai(*nodes[lev]); fai.isValid(); ++fai)
-        {
-            NodeFab& ifab = (*nodes[lev])[fai];
-            const Box box = ifab.box() & subboxArray[lev];
-            for (IntVect iv=box.smallEnd(); iv<=box.bigEnd(); box.next(iv))
-                ifab(iv,0) = Node(iv,lev,fai.index(),Node::VALID);
-        }
-            
-        if (lev != 0)
-        {
-            const int ref = amrData.RefRatio()[lev-1];
-            const Box rangeBox = Box(IntVect::TheZeroVector(),
-                                     (ref-1)*IntVect::TheUnitVector());
+    for (int lev = 0; lev < Nlev; ++lev) {
+      for (MFIter fai(*nodes[lev]); fai.isValid(); ++fai) {
+        NodeFab& ifab = (*nodes[lev])[fai];
+        const Box box = ifab.box() & subboxArray[lev];
+        for (IntVect iv = box.smallEnd(); iv <= box.bigEnd(); box.next(iv))
+          ifab(iv, 0) = Node(iv, lev, fai.index(), Node::VALID);
+      }
 
-            BoxArray bndryCells = GetBndryCells(nodes[lev]->boxArray(),ref,*geom[lev]);
+      if (lev != 0) {
+        const int ref = amrData.RefRatio()[lev - 1];
+        const Box rangeBox =
+          Box(IntVect::TheZeroVector(), (ref - 1) * IntVect::TheUnitVector());
 
-            for (MFIter fai(*nodes[lev]); fai.isValid(); ++fai)
-            {
-                const Box box = Box(fai.validbox()).grow(ref) & subboxArray[lev];
-                NodeFab& ifab = (*nodes[lev])[fai];
-                std::vector< std::pair<int,Box> > isects = bndryCells.intersections(box);
-                for (int i = 0; i < isects.size(); i++)
-                {
-                    Box co = isects[i].second & fai.validbox();
-                    if (co.ok())
-                        Print() << "BAD ISECTS: " << co << std::endl;
+        BoxArray bndryCells =
+          GetBndryCells(nodes[lev]->boxArray(), ref, *geom[lev]);
 
-                    const Box& dstBox = isects[i].second;
-                    const Box& srcBox = coarsen(dstBox,ref);
+        for (MFIter fai(*nodes[lev]); fai.isValid(); ++fai) {
+          const Box box = Box(fai.validbox()).grow(ref) & subboxArray[lev];
+          NodeFab& ifab = (*nodes[lev])[fai];
+          std::vector<std::pair<int, Box>> isects =
+            bndryCells.intersections(box);
+          for (int i = 0; i < isects.size(); i++) {
+            Box co = isects[i].second & fai.validbox();
+            if (co.ok())
+              Print() << "BAD ISECTS: " << co << std::endl;
 
-                    NodeFab dst(dstBox,1);
-                    for (IntVect iv(srcBox.smallEnd());
-                         iv<=srcBox.bigEnd();
-                         srcBox.next(iv))
-                    {
-                        const IntVect baseIV = ref*iv;
-                        for (IntVect ivt(rangeBox.smallEnd());ivt<=rangeBox.bigEnd();rangeBox.next(ivt))
-                            dst(baseIV + ivt,0) = Node(iv,lev-1,-1,Node::VALID);
-                    }
-                    const Box ovlp = dstBox & ifab.box();
+            const Box& dstBox = isects[i].second;
+            const Box& srcBox = coarsen(dstBox, ref);
 
-                    Box mo = ovlp & fai.validbox();
-                    if (mo.ok())
-                    {
-                        Print() << "BAD OVERLAP: " << mo << std::endl;
-                        Print() << "         vb: " << fai.validbox() << std::endl;
-                    }
-                    if (ovlp.ok())
-                        ifab.copy(dst,ovlp,0,ovlp,0,1);
-                }
+            NodeFab dst(dstBox, 1);
+            for (IntVect iv(srcBox.smallEnd()); iv <= srcBox.bigEnd();
+                 srcBox.next(iv)) {
+              const IntVect baseIV = ref * iv;
+              for (IntVect ivt(rangeBox.smallEnd()); ivt <= rangeBox.bigEnd();
+                   rangeBox.next(ivt))
+                dst(baseIV + ivt, 0) = Node(iv, lev - 1, -1, Node::VALID);
             }
-        }
+            const Box ovlp = dstBox & ifab.box();
 
-        // Block out cells covered by finer grid
-        if (lev < finestLevel)
-        {
-            const BoxArray coarsenedFineBoxes =
-                BoxArray(gridArray[lev+1]).coarsen(amrData.RefRatio()[lev]);
-                
-            for (MFIter fai(*nodes[lev]); fai.isValid(); ++fai)
-            {
-                NodeFab& ifab = (*nodes[lev])[fai];
-                const Box& box = ifab.box();
-                std::vector< std::pair<int,Box> > isects = coarsenedFineBoxes.intersections(box);
-                for (int i = 0; i < isects.size(); i++)
-                {
-                    const Box& ovlp = isects[i].second;
-                    for (IntVect iv=ovlp.smallEnd(); iv<=ovlp.bigEnd(); ovlp.next(iv))
-                        ifab(iv,0) = Node(iv,lev,fai.index(),Node::COVERED);
-                }
+            Box mo = ovlp & fai.validbox();
+            if (mo.ok()) {
+              Print() << "BAD OVERLAP: " << mo << std::endl;
+              Print() << "         vb: " << fai.validbox() << std::endl;
             }
+            if (ovlp.ok())
+              ifab.copy(dst, ovlp, 0, ovlp, 0, 1);
+          }
         }
+      }
 
-        // Add the unique nodes from this level to the list
-        for (MFIter fai(*nodes[lev]); fai.isValid(); ++fai)
-        {
-            NodeFab& ifab = (*nodes[lev])[fai];
-            const Box& box = fai.validbox() & subboxArray[lev];
-            for (IntVect iv(box.smallEnd()); iv<=box.bigEnd(); box.next(iv))
-            {
-                if (ifab(iv,0).type == Node::VALID)
-                {
-                    if (ifab(iv,0).level != lev) 
-                        Print() << "bad level: " << ifab(iv,0) << std::endl;
-                    nodeMap[ifab(iv,0)] = cnt++;
-                }
-            }
+      // Block out cells covered by finer grid
+      if (lev < finestLevel) {
+        const BoxArray coarsenedFineBoxes =
+          BoxArray(gridArray[lev + 1]).coarsen(amrData.RefRatio()[lev]);
+
+        for (MFIter fai(*nodes[lev]); fai.isValid(); ++fai) {
+          NodeFab& ifab = (*nodes[lev])[fai];
+          const Box& box = ifab.box();
+          std::vector<std::pair<int, Box>> isects =
+            coarsenedFineBoxes.intersections(box);
+          for (int i = 0; i < isects.size(); i++) {
+            const Box& ovlp = isects[i].second;
+            for (IntVect iv = ovlp.smallEnd(); iv <= ovlp.bigEnd();
+                 ovlp.next(iv))
+              ifab(iv, 0) = Node(iv, lev, fai.index(), Node::COVERED);
+          }
         }
+      }
+
+      // Add the unique nodes from this level to the list
+      for (MFIter fai(*nodes[lev]); fai.isValid(); ++fai) {
+        NodeFab& ifab = (*nodes[lev])[fai];
+        const Box& box = fai.validbox() & subboxArray[lev];
+        for (IntVect iv(box.smallEnd()); iv <= box.bigEnd(); box.next(iv)) {
+          if (ifab(iv, 0).type == Node::VALID) {
+            if (ifab(iv, 0).level != lev)
+              Print() << "bad level: " << ifab(iv, 0) << std::endl;
+            nodeMap[ifab(iv, 0)] = cnt++;
+          }
+        }
+      }
     }
 
     std::cerr << "After nodeMap built, size=" << nodeMap.size() << endl;
 
     typedef std::set<Element> EltSet;
     EltSet elements;
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-        for (MFIter fai(*nodes[lev]); fai.isValid(); ++fai)
-        {
-            NodeFab& ifab = (*nodes[lev])[fai];                        
-            Box box = ifab.box() & subboxArray[lev];
+    for (int lev = 0; lev < Nlev; ++lev) {
+      for (MFIter fai(*nodes[lev]); fai.isValid(); ++fai) {
+        NodeFab& ifab = (*nodes[lev])[fai];
+        Box box = ifab.box() & subboxArray[lev];
 
-            for (int dir=0; dir<AMREX_SPACEDIM; ++dir)
-                box.growHi(dir,-1);
+        for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
+          box.growHi(dir, -1);
 
-            for (IntVect iv(box.smallEnd()); iv<=box.bigEnd(); box.next(iv))
-            {
+        for (IntVect iv(box.smallEnd()); iv <= box.bigEnd(); box.next(iv)) {
 #if (AMREX_SPACEDIM == 2)
-                const Node& n1 = ifab(iv,0);
-                const Node& n2 = ifab(IntVect(iv).shift(BASISV(0)),0);
-                const Node& n3 = ifab(IntVect(iv).shift(IntVect::TheUnitVector()),0);
-                const Node& n4 = ifab(IntVect(iv).shift(BASISV(1)),0);
-                if (n1.type==Node::VALID && n2.type==Node::VALID &&
-                    n3.type==Node::VALID && n4.type==Node::VALID )
-                    elements.insert(Element(n1,n2,n3,n4));
+          const Node& n1 = ifab(iv, 0);
+          const Node& n2 = ifab(IntVect(iv).shift(BASISV(0)), 0);
+          const Node& n3 = ifab(IntVect(iv).shift(IntVect::TheUnitVector()), 0);
+          const Node& n4 = ifab(IntVect(iv).shift(BASISV(1)), 0);
+          if (
+            n1.type == Node::VALID && n2.type == Node::VALID &&
+            n3.type == Node::VALID && n4.type == Node::VALID)
+            elements.insert(Element(n1, n2, n3, n4));
 #else
-                const IntVect ivu = IntVect(iv).shift(BASISV(2));
-                const Node& n1 = ifab(iv ,0);
-                const Node& n2 = ifab(IntVect(iv ).shift(BASISV(0)),0);
-                const Node& n3 = ifab(IntVect(iv ).shift(BASISV(0)).shift(BASISV(1)),0);
-                const Node& n4 = ifab(IntVect(iv ).shift(BASISV(1)),0);
-                const Node& n5 = ifab(ivu,0);
-                const Node& n6 = ifab(IntVect(ivu).shift(BASISV(0)),0);
-                const Node& n7 = ifab(IntVect(ivu).shift(BASISV(0)).shift(BASISV(1)),0);
-                const Node& n8 = ifab(IntVect(ivu).shift(BASISV(1)),0);
-                if (n1.type==Node::VALID && n2.type==Node::VALID &&
-                    n3.type==Node::VALID && n4.type==Node::VALID &&
-                    n5.type==Node::VALID && n6.type==Node::VALID &&
-                    n7.type==Node::VALID && n8.type==Node::VALID )
-                    elements.insert(Element(n1,n2,n3,n4,n5,n6,n7,n8));
+          const IntVect ivu = IntVect(iv).shift(BASISV(2));
+          const Node& n1 = ifab(iv, 0);
+          const Node& n2 = ifab(IntVect(iv).shift(BASISV(0)), 0);
+          const Node& n3 =
+            ifab(IntVect(iv).shift(BASISV(0)).shift(BASISV(1)), 0);
+          const Node& n4 = ifab(IntVect(iv).shift(BASISV(1)), 0);
+          const Node& n5 = ifab(ivu, 0);
+          const Node& n6 = ifab(IntVect(ivu).shift(BASISV(0)), 0);
+          const Node& n7 =
+            ifab(IntVect(ivu).shift(BASISV(0)).shift(BASISV(1)), 0);
+          const Node& n8 = ifab(IntVect(ivu).shift(BASISV(1)), 0);
+          if (
+            n1.type == Node::VALID && n2.type == Node::VALID &&
+            n3.type == Node::VALID && n4.type == Node::VALID &&
+            n5.type == Node::VALID && n6.type == Node::VALID &&
+            n7.type == Node::VALID && n8.type == Node::VALID)
+            elements.insert(Element(n1, n2, n3, n4, n5, n6, n7, n8));
 #endif
-            }
         }
+      }
     }
 
     int nElts = (connect_cc ? elements.size() : nodeMap.size());
-    std::cerr << "Before connData allocated " << elements.size() << " elements"  << endl;
-    Vector<int> connData(MYLEN*nElts);
-    std::cerr << "After connData allocated " << elements.size() << " elements" << endl;
+    std::cerr << "Before connData allocated " << elements.size() << " elements"
+              << endl;
+    Vector<int> connData(MYLEN * nElts);
+    std::cerr << "After connData allocated " << elements.size() << " elements"
+              << endl;
 
     if (connect_cc) {
-        cnt = 0;
-        for (EltSet::const_iterator it = elements.begin(); it!=elements.end(); ++it)
-        {
-            for (int j=0; j<MYLEN; ++j)
-            {
-                const NodeMap::const_iterator noit = nodeMap.find(*((*it).n[j]));
-                if (noit == nodeMap.end())
-                {
-                    Print() << "Node not found in node map" << std::endl;
-                    Print() << *((*it).n[j]) << std::endl;
-                }
-                else
-                {
-                    connData[cnt++] = noit->second+1;
-                }
-            }
+      cnt = 0;
+      for (EltSet::const_iterator it = elements.begin(); it != elements.end();
+           ++it) {
+        for (int j = 0; j < MYLEN; ++j) {
+          const NodeMap::const_iterator noit = nodeMap.find(*((*it).n[j]));
+          if (noit == nodeMap.end()) {
+            Print() << "Node not found in node map" << std::endl;
+            Print() << *((*it).n[j]) << std::endl;
+          } else {
+            connData[cnt++] = noit->second + 1;
+          }
         }
+      }
     } else {
-        cnt = 1;
-        for (int i=0; i<nElts; ++i) {
-            for (int j=0; j<MYLEN; ++j) {
-                connData[i*MYLEN+j] = cnt++;
-            }
+      cnt = 1;
+      for (int i = 0; i < nElts; ++i) {
+        for (int j = 0; j < MYLEN; ++j) {
+          connData[i * MYLEN + j] = cnt++;
         }
+      }
     }
 
     std::cerr << "Final elements built" << endl;
 
     // Invert the map
     std::vector<Node> nodeVect(nodeMap.size());
-    for (NodeMap::const_iterator it=nodeMap.begin(); it!=nodeMap.end(); ++it)
-    {
-        if (it->second>=nodeVect.size() || it->second<0)
-            Print() << "Bad id: " << it->second << "  bad node: " << it->first << std::endl;
-        AMREX_ASSERT(it->second>=0);
-        AMREX_ASSERT(it->second<nodeVect.size());
-        nodeVect[it->second] = (*it).first;
+    for (NodeMap::const_iterator it = nodeMap.begin(); it != nodeMap.end();
+         ++it) {
+      if (it->second >= nodeVect.size() || it->second < 0)
+        Print() << "Bad id: " << it->second << "  bad node: " << it->first
+                << std::endl;
+      AMREX_ASSERT(it->second >= 0);
+      AMREX_ASSERT(it->second < nodeVect.size());
+      nodeVect[it->second] = (*it).first;
     }
-    std::cerr << "Final nodeVect built (" << nodeVect.size() << " nodes)" << endl;
-		
+    std::cerr << "Final nodeVect built (" << nodeVect.size() << " nodes)"
+              << endl;
+
     nodeMap.clear();
     elements.clear();
     nodes.clear();
@@ -654,247 +651,240 @@ main (int   argc,
 
     Vector<std::unique_ptr<MultiFab>> fileData(Nlev);
     int ng = nGrowPer;
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-        if (lev!=0)
-            ng *= amrData.RefRatio()[lev-1];
-        const BoxArray& ba = gridArray[lev];
-        fileData[lev].reset(new MultiFab(ba,DistributionMapping(ba),comps.size(),0));
-        fileData[lev]->setVal(1.e30);
-        std::cerr << "My data set alloc'd at lev=" << lev << endl;
+    for (int lev = 0; lev < Nlev; ++lev) {
+      if (lev != 0)
+        ng *= amrData.RefRatio()[lev - 1];
+      const BoxArray& ba = gridArray[lev];
+      fileData[lev].reset(
+        new MultiFab(ba, DistributionMapping(ba), comps.size(), 0));
+      fileData[lev]->setVal(1.e30);
+      std::cerr << "My data set alloc'd at lev=" << lev << endl;
 
-        MultiFab pData, pDataNG;
-        if (ng>0 && geom[lev]->isAnyPeriodic())
-        {
-            const Box& pd = amrData.ProbDomain()[lev];
-            //const BoxArray& vba = amrData.boxArray(lev);
-            Box shrunkenDomain = pd;
-            for (int i=0; i<AMREX_SPACEDIM; ++i)
-                if (geom[lev]->isPeriodic(i))
-                    shrunkenDomain.grow(i,-ng);
+      MultiFab pData, pDataNG;
+      if (ng > 0 && geom[lev]->isAnyPeriodic()) {
+        const Box& pd = amrData.ProbDomain()[lev];
+        // const BoxArray& vba = amrData.boxArray(lev);
+        Box shrunkenDomain = pd;
+        for (int i = 0; i < AMREX_SPACEDIM; ++i)
+          if (geom[lev]->isPeriodic(i))
+            shrunkenDomain.grow(i, -ng);
 
-            const BoxArray edgeVBoxes = boxComplement(pd,shrunkenDomain);
-            pData.define(edgeVBoxes,DistributionMapping(edgeVBoxes),1,ng);
-            pDataNG.define(BoxArray(edgeVBoxes).grow(ng),DistributionMapping(edgeVBoxes),1,0);
+        const BoxArray edgeVBoxes = boxComplement(pd, shrunkenDomain);
+        pData.define(edgeVBoxes, DistributionMapping(edgeVBoxes), 1, ng);
+        pDataNG.define(
+          BoxArray(edgeVBoxes).grow(ng), DistributionMapping(edgeVBoxes), 1, 0);
+      }
+
+      for (int i = 0; i < comps.size(); ++i) {
+        BoxArray tmpBA =
+          intersect(fileData[lev]->boxArray(), amrData.ProbDomain()[lev]);
+        MultiFab tmpMF(tmpBA, DistributionMapping(tmpBA), 1, 0);
+        tmpMF.setVal(2.e30);
+        amrData.FillVar(tmpMF, lev, names[comps[i]], 0);
+        fileData[lev]->ParallelCopy(tmpMF, 0, i, 1);
+        if (ng > 0 && geom[lev]->isAnyPeriodic()) {
+          pData.setVal(3.e30);
+          pDataNG.ParallelCopy(tmpMF);
+          for (MFIter mfi(pData); mfi.isValid(); ++mfi)
+            pData[mfi].copy(pDataNG[mfi]);
+          amrData.FillVar(pData, lev, names[comps[i]], 0);
+          pData.FillBoundary(geom[lev]->periodicity());
+          for (MFIter mfi(pData); mfi.isValid(); ++mfi)
+            pDataNG[mfi].copy(pData[mfi]);
+          fileData[lev]->ParallelCopy(pDataNG, 0, i, 1);
         }
+      }
 
-        for (int i=0; i<comps.size(); ++i)
-        {
-            BoxArray tmpBA = intersect(fileData[lev]->boxArray(),amrData.ProbDomain()[lev]);
-            MultiFab tmpMF(tmpBA,DistributionMapping(tmpBA),1,0);
-            tmpMF.setVal(2.e30);
-            amrData.FillVar(tmpMF,lev,names[comps[i]],0);
-            fileData[lev]->ParallelCopy(tmpMF,0,i,1);
-            if (ng>0 && geom[lev]->isAnyPeriodic())
-            {
-                pData.setVal(3.e30);
-                pDataNG.ParallelCopy(tmpMF);
-                for (MFIter mfi(pData); mfi.isValid(); ++mfi)
-                    pData[mfi].copy(pDataNG[mfi]);
-                amrData.FillVar(pData,lev,names[comps[i]],0);
-                pData.FillBoundary(geom[lev]->periodicity());
-                for (MFIter mfi(pData); mfi.isValid(); ++mfi)
-                    pDataNG[mfi].copy(pData[mfi]);
-                fileData[lev]->ParallelCopy(pDataNG,0,i,1);
-            }            
-        }
-
-        if (fileData[lev]->max(0) > 1.e29)
-        {
-            std::cerr << "Bad mf data" << std::endl;
-            VisMF::Write(*fileData[lev],"out.mfab");
-            Abort();
-        }
+      if (fileData[lev]->max(0) > 1.e29) {
+        std::cerr << "Bad mf data" << std::endl;
+        VisMF::Write(*fileData[lev], "out.mfab");
+        Abort();
+      }
     }
     std::cerr << "File data loaded" << endl;
 
-    int nNodesFINAL = (connect_cc  ?  nodeVect.size() : nElts*MYLEN );
-    int nCompsFINAL = AMREX_SPACEDIM+comps.size();
-    FABdata tmpData(nNodesFINAL,nCompsFINAL);
-    int tmpDatLen = nCompsFINAL*nNodesFINAL;
+    int nNodesFINAL = (connect_cc ? nodeVect.size() : nElts * MYLEN);
+    int nCompsFINAL = AMREX_SPACEDIM + comps.size();
+    FABdata tmpData(nNodesFINAL, nCompsFINAL);
+    int tmpDatLen = nCompsFINAL * nNodesFINAL;
     std::cerr << "Final node data allocated (size=" << tmpDatLen << ")" << endl;
 
-    //const Vector<Vector<Real> >& dxLevel = amrData.DxLevel();  // Do not trust dx from file...compute our own
-    Vector<Vector<Real> > dxLevel(Nlev);
-    for (int i=0; i<Nlev; ++i)
-    {
-        dxLevel[i].resize(AMREX_SPACEDIM);
-        for (int j=0; j<AMREX_SPACEDIM; ++j)
-            dxLevel[i][j] = amrData.ProbSize()[j]/amrData.ProbDomain()[i].length(j);
+    // const Vector<Vector<Real> >& dxLevel = amrData.DxLevel();  // Do not
+    // trust dx from file...compute our own
+    Vector<Vector<Real>> dxLevel(Nlev);
+    for (int i = 0; i < Nlev; ++i) {
+      dxLevel[i].resize(AMREX_SPACEDIM);
+      for (int j = 0; j < AMREX_SPACEDIM; ++j)
+        dxLevel[i][j] =
+          amrData.ProbSize()[j] / amrData.ProbDomain()[i].length(j);
     }
     const Vector<Real>& plo = amrData.ProbLo();
 
-    // Handy structures for loading data in usual fab ordering (transpose of mef/flt ordering)
+    // Handy structures for loading data in usual fab ordering (transpose of
+    // mef/flt ordering)
 #define BIN_POINT
 #undef BIN_POINT
 #ifdef BIN_POINT
     Real* data = tmpData.dataPtr();
 #else /* BLOCK ordering */
-    Vector<Real*> fdat(comps.size()+AMREX_SPACEDIM);
-    for (int i=0; i<fdat.size(); ++i)
-        fdat[i] = tmpData.dataPtr(i);
+    Vector<Real*> fdat(comps.size() + AMREX_SPACEDIM);
+    for (int i = 0; i < fdat.size(); ++i)
+      fdat[i] = tmpData.dataPtr(i);
 #endif
 
     cnt = 0;
     int Nnodes = nodeVect.size();
     int jGridPrev = 0;
     int levPrev = -1;
-    for (int i=0; i<Nnodes; ++i)
-    {
-        const Node& node = nodeVect[i];
+    for (int i = 0; i < Nnodes; ++i) {
+      const Node& node = nodeVect[i];
 
-        const Vector<Real>& dx = dxLevel[node.level];
-        const IntVect& iv = node.iv;
+      const Vector<Real>& dx = dxLevel[node.level];
+      const IntVect& iv = node.iv;
 
-        const BoxArray& grids = fileData[node.level]->boxArray();
-        int jGrid = node.grid;
-        if (jGrid<0)
-        {
-            bool found_it = false;
-            
-            // Try same grid as last time, otherwise search list
-            if (node.level==levPrev && grids[jGridPrev].contains(iv))
-            {
-                found_it = true;
-                jGrid = jGridPrev;
-            }
-            for (int j=0; j<grids.size() && !found_it; ++j)
-            {
-                if (grids[j].contains(iv))
-                {
-                    found_it = true;
-                    jGrid = j;
-                }
-            }
-            AMREX_ASSERT(found_it);
+      const BoxArray& grids = fileData[node.level]->boxArray();
+      int jGrid = node.grid;
+      if (jGrid < 0) {
+        bool found_it = false;
+
+        // Try same grid as last time, otherwise search list
+        if (node.level == levPrev && grids[jGridPrev].contains(iv)) {
+          found_it = true;
+          jGrid = jGridPrev;
         }
-	// Remember these for next time
-	levPrev = node.level;
-	jGridPrev = jGrid;
+        for (int j = 0; j < grids.size() && !found_it; ++j) {
+          if (grids[j].contains(iv)) {
+            found_it = true;
+            jGrid = j;
+          }
+        }
+        AMREX_ASSERT(found_it);
+      }
+      // Remember these for next time
+      levPrev = node.level;
+      jGridPrev = jGrid;
 
-	Vector<IntVect> ivt;
-        if (connect_cc) {
-            ivt.resize(1,iv);
-        } else {
-	  ivt.resize(AMREX_D_PICK(1,4,8),iv);
-            ivt[1] += BASISV(0);
-            ivt[2] = ivt[1] + BASISV(1);
-            ivt[3] += BASISV(1);
-#if BLSPACEDIM==3
-            for (int n=0; n<4; ++n) {
-                ivt[4+n] = iv[n] + BASISV(2);
-            }
+      Vector<IntVect> ivt;
+      if (connect_cc) {
+        ivt.resize(1, iv);
+      } else {
+        ivt.resize(AMREX_D_PICK(1, 4, 8), iv);
+        ivt[1] += BASISV(0);
+        ivt[2] = ivt[1] + BASISV(1);
+        ivt[3] += BASISV(1);
+#if BLSPACEDIM == 3
+        for (int n = 0; n < 4; ++n) {
+          ivt[4 + n] = iv[n] + BASISV(2);
+        }
 #endif
+      }
+
+      for (int j = 0; j < ivt.size(); ++j) {
+
+        Real offset = (connect_cc ? 0.5 : 0);
+
+#ifdef BIN_POINT
+        for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
+          data[cnt++] = plo[dir] + (ivt[j][dir] + offset) * dx[dir];
+#else  /* BLOCK ordering */
+        for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
+          fdat[dir][cnt] = plo[dir] + (ivt[j][dir] + offset) * dx[dir];
+#endif /* BIN_POINT */
+
+#ifdef BIN_POINT
+        for (int n = 0; n < comps.size(); ++n) {
+          data[cnt++] = (*fileData[node.level])[jGrid](iv, n);
         }
-
-	for (int j=0; j<ivt.size(); ++j) {
-
-            Real offset = (connect_cc ? 0.5 : 0);
-
-#ifdef BIN_POINT
-	  for (int dir=0; dir<AMREX_SPACEDIM; ++dir)
-            data[cnt++] = plo[dir] + (ivt[j][dir] + offset) * dx[dir];
-#else /* BLOCK ordering */
-	  for (int dir=0; dir<AMREX_SPACEDIM; ++dir)
-            fdat[dir][cnt] = plo[dir] + (ivt[j][dir] + offset) * dx[dir];
+#else  /* BLOCK ordering */
+        for (int n = 0; n < comps.size(); ++n) {
+          fdat[n + AMREX_SPACEDIM][cnt] = (*fileData[node.level])[jGrid](iv, n);
+        }
+        cnt++;
 #endif /* BIN_POINT */
-
-
-#ifdef BIN_POINT
-	  for (int n=0; n<comps.size(); ++n) {
-              data[cnt++] = (*fileData[node.level])[jGrid](iv,n);
-          }
-#else /* BLOCK ordering */
-	  for (int n=0; n<comps.size(); ++n) {
-              fdat[n+AMREX_SPACEDIM][cnt] = (*fileData[node.level])[jGrid](iv,n);
-          }
-	  cnt++;
-#endif /* BIN_POINT */
-	}
+      }
     }
 
-    //Collate(tmpData,connData,MYLEN);
+    // Collate(tmpData,connData,MYLEN);
 
     //
     // Write output
     //
     const int nState = AMREX_SPACEDIM + comps.size();
-    std::string vars = AMREX_D_TERM("X"," Y"," Z");
-    for (int j=0; j<comps.size(); ++j)
-        vars += " " + amrData.PlotVarNames()[comps[j]];
+    std::string vars = AMREX_D_TERM("X", " Y", " Z");
+    for (int j = 0; j < comps.size(); ++j)
+      vars += " " + amrData.PlotVarNames()[comps[j]];
 
-    if (outType == "tec")
-    {
+    if (outType == "tec") {
 
 #ifdef BIN_POINT
-        std::string block_or_point = "FEPOINT";
+      std::string block_or_point = "FEPOINT";
 #else /* BLOCK ordering */
-        std::string block_or_point = "FEBLOCK";
+      std::string block_or_point = "FEBLOCK";
 #endif
 
-
-        if (doBin)
-        {
+      if (doBin) {
 #ifdef USE_TEC_BIN_IO
-            INTEGER4 Debug = 0;
-            INTEGER4 VIsDouble = 1;
-            INTEGER4 EltID = AMREX_D_PICK(0,1,3);
-            TECINI((char*)"Pltfile data", (char*)vars.c_str(), (char*)outfile.c_str(), (char*)".", &Debug, &VIsDouble);
-            INTEGER4 nPts = nNodesFINAL;
-            TECZNE((char*)infile.c_str(), &nPts, &nElts, &EltID, (char*)block_or_point.c_str(), NULL);
-            TECDAT(&tmpDatLen,tmpData.fab.dataPtr(),&VIsDouble);
-            TECNOD(connData.dataPtr());
-            TECEND();
+        INTEGER4 Debug = 0;
+        INTEGER4 VIsDouble = 1;
+        INTEGER4 EltID = AMREX_D_PICK(0, 1, 3);
+        TECINI(
+          (char*)"Pltfile data", (char*)vars.c_str(), (char*)outfile.c_str(),
+          (char*)".", &Debug, &VIsDouble);
+        INTEGER4 nPts = nNodesFINAL;
+        TECZNE(
+          (char*)infile.c_str(), &nPts, &nElts, &EltID,
+          (char*)block_or_point.c_str(), NULL);
+        TECDAT(&tmpDatLen, tmpData.fab.dataPtr(), &VIsDouble);
+        TECNOD(connData.dataPtr());
+        TECEND();
 #else
-            Abort("Need to recompile with USE_TEC_BIN_IO defined");
+        Abort("Need to recompile with USE_TEC_BIN_IO defined");
 #endif
+      } else {
+        std::ofstream osf(outfile.c_str(), std::ios::out);
+        osf << AMREX_D_TERM("VARIABLES= \"X\"", " \"Y\"", " \"Z\"");
+        for (int j = 0; j < comps.size(); ++j)
+          osf << " \"" << amrData.PlotVarNames()[comps[j]] << "\"";
+        // int nPts = nodeVect.size();
+        char buf[100];
+        sprintf(buf, "%g", amrData.Time());
+        osf << endl
+            << "ZONE T=\"" << infile << " time = " << buf
+            << "\", N=" << nNodesFINAL << ", E=" << nElts << ", F=" << "FEPOINT"
+            << " ET="
+            //<< "\", N=" << nPts << ", E=" << nElts << ", F=" << block_or_point
+            //<< " ET="
+            << AMREX_D_PICK("POINT", "QUADRILATERAL", "BRICK") << endl;
+
+        for (int i = 0; i < nNodesFINAL; ++i) {
+          for (int j = 0; j < nState; ++j)
+            osf << tmpData.dataPtr(j)[i] << " ";
+          osf << endl;
         }
-        else
-        {
-            std::ofstream osf(outfile.c_str(),std::ios::out);
-            osf << AMREX_D_TERM("VARIABLES= \"X\"", " \"Y\"", " \"Z\"");
-            for (int j=0; j<comps.size(); ++j)
-                osf << " \""  << amrData.PlotVarNames()[comps[j]] << "\"";
-            //int nPts = nodeVect.size();
-            char buf[100];
-            sprintf(buf,"%g",amrData.Time());
-            osf << endl << "ZONE T=\"" << infile << " time = " << buf
-                << "\", N=" << nNodesFINAL << ", E=" << nElts << ", F=" << "FEPOINT" << " ET="
-                //<< "\", N=" << nPts << ", E=" << nElts << ", F=" << block_or_point << " ET="
-                << AMREX_D_PICK("POINT","QUADRILATERAL","BRICK") << endl;
-            
-            for (int i=0; i<nNodesFINAL; ++i)
-            {
-                for (int j=0; j<nState; ++j)
-                    osf << tmpData.dataPtr(j)[i] << " ";
-                osf << endl;
-            }
-            for (int i=0; i<nElts; ++i)
-            {
-                for (int j=0; j<MYLEN; ++j)
-                    osf << connData[i*MYLEN+j] << " ";
-                osf << endl;
-            }
-            osf << endl;
-            osf.close();
+        for (int i = 0; i < nElts; ++i) {
+          for (int j = 0; j < MYLEN; ++j)
+            osf << connData[i * MYLEN + j] << " ";
+          osf << endl;
         }
+        osf << endl;
+        osf.close();
+      }
+    } else {
+      std::ofstream ofs;
+      std::ostream* os =
+        (outfile == "-" ? (std::ostream*)(&std::cout) : (std::ostream*)(&ofs));
+      if (outfile != "-")
+        ofs.open(
+          outfile.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
+      (*os) << infile << " time = " << amrData.Time() << endl;
+      (*os) << vars << endl;
+      (*os) << nElts << " " << MYLEN << endl;
+      tmpData.fab.writeOn(*os);
+      (*os).write((char*)connData.dataPtr(), sizeof(int) * connData.size());
+      if (outfile != "-")
+        ofs.close();
     }
-    else
-    {
-        std::ofstream ofs;
-        std::ostream* os =
-            (outfile=="-" ? (std::ostream*)(&std::cout) : (std::ostream*)(&ofs) );
-        if (outfile!="-")
-            ofs.open(outfile.c_str(),std::ios::out|std::ios::trunc|std::ios::binary);
-        (*os) << infile << " time = " << amrData.Time() << endl;
-        (*os) << vars << endl;
-        (*os) << nElts << " " << MYLEN << endl;
-        tmpData.fab.writeOn(*os);
-        (*os).write((char*)connData.dataPtr(),sizeof(int)*connData.size());
-        if (outfile!="-")
-            ofs.close();
-    }
-    }
-    Finalize();
-    return 0;
+  }
+  Finalize();
+  return 0;
 }

--- a/Src/avgPlotfiles.cpp
+++ b/Src/avgPlotfiles.cpp
@@ -5,201 +5,230 @@
 
 using namespace amrex;
 
-static
-void
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
-  std::cerr << "Utility to average pltfiles on same domain but with non-matching AMR";
+  std::cerr
+    << "Utility to average pltfiles on same domain but with non-matching AMR";
   std::cerr << "usage:\n";
   std::cerr << argv[0] << "infiles=<s1 s2 s3> [options] \n\tOptions:\n";
-  std::cerr << "\t     infiles=<s1 s2 s3> where <s1> <s2> amnd <s3> are pltfiles\n";
+  std::cerr
+    << "\t     infiles=<s1 s2 s3> where <s1> <s2> amnd <s3> are pltfiles\n";
   std::cerr << "\t     outfile=<s> where <s> is the output pltfile\n";
-  std::cerr << "\t     variables=<s1 s2 s3> where <s1> <s2> and <s3> are variable names to select for combined pltfile [DEF-> all possible]\n";
-  std::cerr << "\t     output_max_level=<s> where <s> is the max refinement level to combine, zero-indexed [DEF->1000]\n";
-  std::cerr << "\t     output_max_grid_size=<s> where <s> is the output max_grid_size. If all BoxArrays are the same, this is ignored. [DEF->32]\n";
-  std::cerr << "\t     interp_type=<int> where this determines the type of interpolation when FillPatching: 0 -> piecewise constant, 1 -> cell cons linear [DEF->1]\n";
-exit(1);
+  std::cerr
+    << "\t     variables=<s1 s2 s3> where <s1> <s2> and <s3> are variable "
+       "names to select for combined pltfile [DEF-> all possible]\n";
+  std::cerr << "\t     output_max_level=<s> where <s> is the max refinement "
+               "level to combine, zero-indexed [DEF->1000]\n";
+  std::cerr
+    << "\t     output_max_grid_size=<s> where <s> is the output max_grid_size. "
+       "If all BoxArrays are the same, this is ignored. [DEF->32]\n";
+  std::cerr << "\t     interp_type=<int> where this determines the type of "
+               "interpolation when FillPatching: 0 -> piecewise constant, 1 -> "
+               "cell cons linear [DEF->1]\n";
+  exit(1);
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-   amrex::Initialize(argc,argv);
-   {
-     if (argc < 2) {
-       print_usage(argc,argv);
-     }
-     // ---------------------------------------------------------------------
-     // ParmParse
-     // ---------------------------------------------------------------------
-     ParmParse pp;
+  amrex::Initialize(argc, argv);
+  {
+    if (argc < 2) {
+      print_usage(argc, argv);
+    }
+    // ---------------------------------------------------------------------
+    // ParmParse
+    // ---------------------------------------------------------------------
+    ParmParse pp;
 
-     if (pp.contains("help")) {
-       print_usage(argc,argv);
-     }
+    if (pp.contains("help")) {
+      print_usage(argc, argv);
+    }
 
-     // Arbitrary number of input files will be combined and averaged
-     int nf = pp.countval("infiles");
-     AMREX_ALWAYS_ASSERT(nf>0);
-     Vector<std::string> plotFileNames; pp.getarr("infiles",plotFileNames,0,nf);
+    // Arbitrary number of input files will be combined and averaged
+    int nf = pp.countval("infiles");
+    AMREX_ALWAYS_ASSERT(nf > 0);
+    Vector<std::string> plotFileNames;
+    pp.getarr("infiles", plotFileNames, 0, nf);
 
-     // into a single output file
-     std::string outfile("plt_averaged");
-     pp.query("outfile",outfile);
+    // into a single output file
+    std::string outfile("plt_averaged");
+    pp.query("outfile", outfile);
 
-     // Vairables to keep - will keep all if not specified
-     int nvar = pp.countval("variables");
-     Vector<std::string> variableNames;
-     pp.queryarr("variables",variableNames,0,nvar);
-     bool all_vars = nvar > 0 ? false : true;
-     Vector<Vector<int>> var_idxs;
+    // Vairables to keep - will keep all if not specified
+    int nvar = pp.countval("variables");
+    Vector<std::string> variableNames;
+    pp.queryarr("variables", variableNames, 0, nvar);
+    bool all_vars = nvar > 0 ? false : true;
+    Vector<Vector<int>> var_idxs;
 
-     // Maximum number of levels to keep
-     int output_max_level = 1000;
-     pp.query("output_max_level", output_max_level);
-     output_max_level +=1; // account for base level
+    // Maximum number of levels to keep
+    int output_max_level = 1000;
+    pp.query("output_max_level", output_max_level);
+    output_max_level += 1; // account for base level
 
-     // Max grid size in output data
-     int output_max_grid_size = 32;
-     pp.query("output_max_grid_size", output_max_grid_size);
+    // Max grid size in output data
+    int output_max_grid_size = 32;
+    pp.query("output_max_grid_size", output_max_grid_size);
 
-     // Type of interpolation to do
-     int interp_type = 1;
-     pp.query("interp_type",interp_type);
+    // Type of interpolation to do
+    int interp_type = 1;
+    pp.query("interp_type", interp_type);
 
+    // ---------------------------------------------------------------------
+    // Execute
+    // ---------------------------------------------------------------------
 
-     // ---------------------------------------------------------------------
-     // Execute
-     // ---------------------------------------------------------------------
+    // First load the metadata of each input plt file
+    Print() << "Loading plt file metadata..." << std::endl;
+    Vector<pele::physics::pltfilemanager::PltFileManager*> plt_file_data(nf);
+    int nlevels = 0;
+    for (int i = 0; i < plt_file_data.size(); ++i) {
+      plt_file_data[i] =
+        new pele::physics::pltfilemanager::PltFileManager(plotFileNames[i]);
+      nlevels = max(nlevels, plt_file_data[i]->getNlev());
+      // Verify we have the right vairables
+      if (all_vars) {
+        if (i == 0) {
+          variableNames = plt_file_data[i]->getVariableList();
+          nvar = variableNames.size();
+        } else {
+          Vector<std::string> variableNamesTest =
+            plt_file_data[i]->getVariableList();
+          if (variableNamesTest.size() != nvar) {
+            amrex::Abort(
+              "All plt files must have same number of variables unless "
+              "variable list is specified. File: " +
+              plotFileNames[i]);
+          }
+          for (int var = 0; var < nvar; ++var) {
+            if (variableNames[var] != variableNamesTest[var]) {
+              amrex::Abort(
+                "All plt files must have same variables unless variable list "
+                "is specified. File: " +
+                plotFileNames[i]);
+            }
+          }
+        }
+      } else {
+        Vector<int> var_idx_loc;
+        Vector<std::string> variableNamesPlt =
+          plt_file_data[i]->getVariableList();
+        for (int var = 0; var < nvar; ++var) {
+          int pvar;
+          for (pvar = 0; pvar < variableNamesPlt.size(); ++pvar) {
+            if (variableNames[var] == variableNamesPlt[pvar]) {
+              var_idx_loc.push_back(pvar);
+              break;
+            }
+          }
+          if (pvar == variableNamesPlt.size()) {
+            amrex::Abort(
+              "Variable '" + variableNames[var] +
+              "' not found in file: " + plotFileNames[i]);
+          }
+        }
+        var_idxs.push_back(var_idx_loc);
+      }
+    }
+    nlevels = min(nlevels, output_max_level);
+    Print() << " -> Combining " << nf << " files across " << nlevels
+            << " levels" << std::endl;
 
-     // First load the metadata of each input plt file
-     Print() << "Loading plt file metadata..." << std::endl;
-     Vector<pele::physics::pltfilemanager::PltFileManager*> plt_file_data(nf);
-     int nlevels = 0;
-     for (int i = 0; i < plt_file_data.size(); ++i) {
-       plt_file_data[i] = new pele::physics::pltfilemanager::PltFileManager(plotFileNames[i]);
-       nlevels = max(nlevels, plt_file_data[i]->getNlev());
-       // Verify we have the right vairables
-       if (all_vars) {
-         if (i==0) {
-           variableNames = plt_file_data[i]->getVariableList();
-           nvar = variableNames.size();
-         } else {
-           Vector<std::string> variableNamesTest = plt_file_data[i]->getVariableList();
-           if (variableNamesTest.size() != nvar) {
-             amrex::Abort("All plt files must have same number of variables unless variable list is specified. File: " + plotFileNames[i]);
-           }
-           for (int var = 0; var < nvar; ++var) {
-             if (variableNames[var] != variableNamesTest[var]) {
-               amrex::Abort("All plt files must have same variables unless variable list is specified. File: " + plotFileNames[i]);
-             }
-           }
-         }
-       } else {
-         Vector<int> var_idx_loc;
-         Vector<std::string> variableNamesPlt = plt_file_data[i]->getVariableList();
-         for (int var = 0; var < nvar; ++var) {
-           int pvar;
-           for (pvar = 0; pvar < variableNamesPlt.size(); ++pvar) {
-             if (variableNames[var] == variableNamesPlt[pvar]) {
-               var_idx_loc.push_back(pvar);
-               break;
-             }
-           }
-           if (pvar == variableNamesPlt.size()) {
-             amrex::Abort("Variable '" + variableNames[var] + "' not found in file: " + plotFileNames[i]);
-           }
-         }
-         var_idxs.push_back(var_idx_loc);
-       }
-     }
-     nlevels = min(nlevels, output_max_level);
-     Print() << " -> Combining " << nf << " files across " << nlevels << " levels" << std::endl;
+    // Loop over each input file to get union of boxes on each level
+    // On any level with all same BoxArray, we use that without modification
+    Print() << "Finding the combined grids..." << std::endl;
+    Vector<BoxArray> combined_boxes;
+    Vector<Geometry> level_geometries;
+    Vector<int> boxarray_all_same(nlevels, 1);
+    for (int i = 0; i < plt_file_data.size(); ++i) {
+      int nlevels_file = min(nlevels, plt_file_data[i]->getNlev());
+      for (int lev = 0; lev < nlevels_file; ++lev) {
+        // Verify we have the same geometry
+        if (level_geometries.size() <= lev) {
+          level_geometries.push_back(plt_file_data[i]->getGeom(lev));
+        } else {
+          bool same_domain = AlmostEqual(
+            plt_file_data[i]->getGeom(lev).ProbDomain(),
+            level_geometries[lev].ProbDomain());
+          bool same_box = plt_file_data[i]->getGeom(lev).Domain() ==
+                          level_geometries[lev].Domain();
+          if (!(same_domain and same_box)) {
+            amrex::Abort("All plt files must have the same geometry");
+          }
+        }
+        // Now combine the boxes - if not the same
+        if (combined_boxes.size() <= lev) {
+          combined_boxes.push_back(BoxArray(plt_file_data[i]->getGrid(lev)));
+        } else {
+          BoxList boxlist_file{plt_file_data[i]->getGrid(lev)};
+          BoxList boxlist_combined{combined_boxes[lev]};
+          if (boxlist_combined != boxlist_file) {
+            boxlist_combined.catenate(boxlist_file);
+            combined_boxes[lev] = BoxArray(boxlist_combined);
+            combined_boxes[lev].removeOverlap();
+            boxarray_all_same[lev] = 0;
+          }
+        }
+      }
+    }
 
-     // Loop over each input file to get union of boxes on each level
-     // On any level with all same BoxArray, we use that without modification
-     Print() << "Finding the combined grids..." << std::endl;
-     Vector<BoxArray> combined_boxes;
-     Vector<Geometry> level_geometries;
-     Vector<int> boxarray_all_same(nlevels, 1);
-     for (int i = 0; i < plt_file_data.size(); ++i) {
-       int nlevels_file = min(nlevels, plt_file_data[i]->getNlev());
-       for (int lev = 0; lev < nlevels_file; ++lev) {
-         // Verify we have the same geometry
-         if (level_geometries.size() <= lev) {
-           level_geometries.push_back(plt_file_data[i]->getGeom(lev));
-         } else {
-           bool same_domain = AlmostEqual(plt_file_data[i]->getGeom(lev).ProbDomain(), level_geometries[lev].ProbDomain());
-           bool same_box = plt_file_data[i]->getGeom(lev).Domain() == level_geometries[lev].Domain();
-           if (!(same_domain and same_box)) {
-             amrex::Abort("All plt files must have the same geometry");
-           }
-         }
-         // Now combine the boxes - if not the same
-         if (combined_boxes.size() <= lev) {
-           combined_boxes.push_back(BoxArray(plt_file_data[i]->getGrid(lev)));
-         } else {
-           BoxList boxlist_file{plt_file_data[i]->getGrid(lev)};
-           BoxList boxlist_combined{combined_boxes[lev]};
-           if (boxlist_combined != boxlist_file) {
-             boxlist_combined.catenate(boxlist_file);
-             combined_boxes[lev] = BoxArray(boxlist_combined);
-             combined_boxes[lev].removeOverlap();
-             boxarray_all_same[lev] = 0;
-           }
-         }
-       }
-     }
+    // Create the data structures to read in the data and keep running sums
+    Vector<MultiFab> running_data(nlevels);
+    Vector<MultiFab> tmp_data(nlevels);
+    Vector<IntVect> refRatios(nlevels - 1);
+    for (int lev = 0; lev < nlevels; ++lev) {
+      if (!boxarray_all_same[lev]) {
+        combined_boxes[lev].maxSize(output_max_grid_size);
+      }
+      DistributionMapping dmap = DistributionMapping(combined_boxes[lev]);
+      tmp_data[lev].define(combined_boxes[lev], dmap, nvar, 0);
+      running_data[lev].define(combined_boxes[lev], dmap, nvar, 0);
+      running_data[lev].setVal(0.0);
+      if (lev > 0) {
+        int rr = int(
+          level_geometries[lev - 1].CellSize(0) /
+          level_geometries[lev].CellSize(0));
+        refRatios[lev - 1] = {AMREX_D_DECL(rr, rr, rr)};
+      }
+    }
 
-     // Create the data structures to read in the data and keep running sums
-     Vector<MultiFab> running_data(nlevels);
-     Vector<MultiFab> tmp_data(nlevels);
-     Vector<IntVect> refRatios(nlevels-1);
-     for (int lev = 0; lev < nlevels; ++lev) {
-       if (!boxarray_all_same[lev]) {
-         combined_boxes[lev].maxSize(output_max_grid_size);
-       }
-       DistributionMapping dmap = DistributionMapping(combined_boxes[lev]);
-       tmp_data[lev].define(combined_boxes[lev], dmap, nvar, 0);
-       running_data[lev].define(combined_boxes[lev], dmap, nvar, 0);
-       running_data[lev].setVal(0.0);
-       if (lev > 0) {
-         int rr = int(level_geometries[lev-1].CellSize(0) / level_geometries[lev].CellSize(0));
-         refRatios[lev-1] = {AMREX_D_DECL(rr,rr,rr)};
-       }
-     }
+    // Fillpatch tmp_data from each pltfile and add to running data
+    Print() << "Fillpatching and combining..." << std::endl;
+    for (int i = 0; i < plt_file_data.size(); ++i) {
+      Print() << "   working on file " << plotFileNames[i] << " (" << i + 1
+              << "/" << plt_file_data.size() << ")" << std::endl;
+      for (int lev = 0; lev < nlevels; ++lev) {
+        if (all_vars) {
+          plt_file_data[i]->fillPatchFromPlt(
+            lev, level_geometries[lev], 0, 0, nvar, tmp_data[lev], interp_type);
+        } else {
+          for (int var = 0; var < nvar; ++var) {
+            plt_file_data[i]->fillPatchFromPlt(
+              lev, level_geometries[lev], var_idxs[i][var], var, 1,
+              tmp_data[lev], interp_type);
+          }
+        }
+        MultiFab::Add(running_data[lev], tmp_data[lev], 0, 0, nvar, 0);
+      }
+      delete plt_file_data[i];
+    }
 
-     // Fillpatch tmp_data from each pltfile and add to running data
-     Print() << "Fillpatching and combining..." << std::endl;
-     for (int i = 0; i < plt_file_data.size(); ++i) {
-       Print() << "   working on file " << plotFileNames[i] << " (" << i+1 << "/" << plt_file_data.size() << ")" << std::endl;
-       for (int lev = 0; lev < nlevels; ++lev) {
-         if (all_vars) {
-           plt_file_data[i]->fillPatchFromPlt(lev, level_geometries[lev], 0, 0, nvar, tmp_data[lev], interp_type);
-         } else {
-           for (int var = 0; var < nvar; ++var) {
-             plt_file_data[i]->fillPatchFromPlt(lev, level_geometries[lev], var_idxs[i][var], var, 1, tmp_data[lev], interp_type);
-           }
-         }
-         MultiFab::Add(running_data[lev], tmp_data[lev], 0, 0, nvar, 0);
-       }
-       delete plt_file_data[i];
-     }
+    // Divide by number of files to get average
+    Real factor = 1.0 / Real(nf);
+    for (int lev = 0; lev < nlevels; ++lev) {
+      running_data[lev].mult(factor);
+    }
 
-     // Divide by number of files to get average
-     Real factor = 1.0 / Real(nf);
-     for (int lev = 0; lev < nlevels; ++lev) {
-       running_data[lev].mult(factor);
-     }
-
-     // Save the final plt file
-     Print() << "Saving final plt file..." << std::endl;
-     Vector<int> stepidx(nlevels,0);
-     WriteMultiLevelPlotfile(outfile,nlevels, GetVecOfConstPtrs(running_data),variableNames,level_geometries,0.0,stepidx,refRatios);
-     Print() << "Done." << std::endl;
-   }
-   amrex::Finalize();
-   return 0;
+    // Save the final plt file
+    Print() << "Saving final plt file..." << std::endl;
+    Vector<int> stepidx(nlevels, 0);
+    WriteMultiLevelPlotfile(
+      outfile, nlevels, GetVecOfConstPtrs(running_data), variableNames,
+      level_geometries, 0.0, stepidx, refRatios);
+    Print() << "Done." << std::endl;
+  }
+  amrex::Finalize();
+  return 0;
 }

--- a/Src/avgToPlane.cpp
+++ b/Src/avgToPlane.cpp
@@ -5,24 +5,34 @@
 
 using namespace amrex;
 
-void STORE_PPM_STR (const std::string& file,
-                    int width, int height, int iimage[],
-                    const int r[], const int g[], const int b[]);
-void STORE_PGM_STR (const std::string& file,
-                    int width, int height, int iimage[]);
-void LOAD_PALETTE_STR (const std::string& file, int r[], int g[], int b[], int a[]);
-void pixelizeData(const FArrayBox& data, int slicedir, int sliceloc,
-                  BaseFab<int>& image, Real data_min, Real data_max, int nVals);
+void STORE_PPM_STR(
+  const std::string& file,
+  int width,
+  int height,
+  int iimage[],
+  const int r[],
+  const int g[],
+  const int b[]);
+void
+STORE_PGM_STR(const std::string& file, int width, int height, int iimage[]);
+void
+LOAD_PALETTE_STR(const std::string& file, int r[], int g[], int b[], int a[]);
+void pixelizeData(
+  const FArrayBox& data,
+  int slicedir,
+  int sliceloc,
+  BaseFab<int>& image,
+  Real data_min,
+  Real data_max,
+  int nVals);
 
 static std::string AND("_");
 static std::string PPM(".ppm");
 static std::string PGM(".pgm");
 static std::string FABF(".fab");
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile=f1 [options] \n\tOptions:\n";
@@ -32,241 +42,250 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
-Box ProjectBox(const Box& srcBox,
-               int        dir,
-               int        loc)
+Box
+ProjectBox(const Box& srcBox, int dir, int loc)
 {
   Box dstBox = srcBox;
-  dstBox.setSmall(dir,loc);
-  dstBox.setBig(dir,loc);
+  dstBox.setSmall(dir, loc);
+  dstBox.setBig(dir, loc);
   return dstBox;
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     // Open plotfile header and create an amrData object pointing into it
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     Vector<int> comps;
-    if (int nc = pp.countval("comps"))
-    {
+    if (int nc = pp.countval("comps")) {
       comps.resize(nc);
-      pp.getarr("comps",comps,0,nc);
-    }
-    else
-    {
+      pp.getarr("comps", comps, 0, nc);
+    } else {
       int sComp = 0;
-      pp.query("sComp",sComp);
+      pp.query("sComp", sComp);
       int nComp = amrData.NComp();
-      pp.query("nComp",nComp);
-      AMREX_ASSERT(sComp+nComp <= amrData.NComp());
+      pp.query("nComp", nComp);
+      AMREX_ASSERT(sComp + nComp <= amrData.NComp());
       comps.resize(nComp);
-      for (int i=0; i<nComp; ++i)
+      for (int i = 0; i < nComp; ++i)
         comps[i] = sComp + i;
     }
 
-    int finestLevel = amrData.FinestLevel(); pp.query("finestLevel",finestLevel);
-    AMREX_ALWAYS_ASSERT(finestLevel >= 0 && finestLevel<=amrData.FinestLevel());
+    int finestLevel = amrData.FinestLevel();
+    pp.query("finestLevel", finestLevel);
+    AMREX_ALWAYS_ASSERT(
+      finestLevel >= 0 && finestLevel <= amrData.FinestLevel());
     Box subbox = amrData.ProbDomain()[finestLevel];
 
-    if (int nx=pp.countval("box"))
-    {
+    if (int nx = pp.countval("box")) {
       Vector<int> inBox;
-      pp.getarr("box",inBox,0,nx);
-      int d=AMREX_SPACEDIM;
-      AMREX_ASSERT(inBox.size()==2*d);
-      subbox=Box(IntVect(AMREX_D_DECL(inBox[0],inBox[1],inBox[2])),
-                 IntVect(AMREX_D_DECL(inBox[d],inBox[d+1],inBox[d+2])),
-                 IndexType::TheCellType());
+      pp.getarr("box", inBox, 0, nx);
+      int d = AMREX_SPACEDIM;
+      AMREX_ASSERT(inBox.size() == 2 * d);
+      subbox = Box(
+        IntVect(AMREX_D_DECL(inBox[0], inBox[1], inBox[2])),
+        IntVect(AMREX_D_DECL(inBox[d], inBox[d + 1], inBox[d + 2])),
+        IndexType::TheCellType());
     }
 
     Vector<std::string> names(comps.size());
-   
+
     Vector<Real> plo(AMREX_SPACEDIM), phi(AMREX_SPACEDIM);
-    Vector<Box> psize(finestLevel+1);
+    Vector<Box> psize(finestLevel + 1);
     const IntVect ilo = subbox.smallEnd();
     const IntVect ihi = subbox.bigEnd();
 
-    for (int i =0 ; i< AMREX_SPACEDIM; i++) {   
-       plo[i] = amrData.ProbLo()[i]+(ilo[i])*amrData.DxLevel()[finestLevel][i];
-       phi[i] = amrData.ProbLo()[i]+(ihi[i]+1)*amrData.DxLevel()[finestLevel][i];
+    for (int i = 0; i < AMREX_SPACEDIM; i++) {
+      plo[i] =
+        amrData.ProbLo()[i] + (ilo[i]) * amrData.DxLevel()[finestLevel][i];
+      phi[i] =
+        amrData.ProbLo()[i] + (ihi[i] + 1) * amrData.DxLevel()[finestLevel][i];
     }
 
-    int dir = 0; pp.query("dir",dir); AMREX_ALWAYS_ASSERT(dir>=0 && dir<AMREX_SPACEDIM);
+    int dir = 0;
+    pp.query("dir", dir);
+    AMREX_ALWAYS_ASSERT(dir >= 0 && dir < AMREX_SPACEDIM);
     int loc = 0;
-    
+
     BoxArray ba_sub(subbox);
-    int max_grid_size = 32; pp.query("max_grid_size",max_grid_size);
+    int max_grid_size = 32;
+    pp.query("max_grid_size", max_grid_size);
     ba_sub.maxSize(max_grid_size);
 
-    if (ba_sub.size() > 0)
-    {
+    if (ba_sub.size() > 0) {
       BoxList bl_flat;
-      for (int i=0; i<ba_sub.size(); ++i) {
-        bl_flat.push_back(ProjectBox(ba_sub[i],dir,loc));
+      for (int i = 0; i < ba_sub.size(); ++i) {
+        bl_flat.push_back(ProjectBox(ba_sub[i], dir, loc));
       }
       BoxArray ba_flat(bl_flat);
       DistributionMapping dmap_sub(ba_sub);
 
-      MultiFab mf_full(ba_sub,dmap_sub,1,0);
-      MultiFab mf_flat(ba_flat,dmap_sub,1,0); mf_flat.setVal(0);
+      MultiFab mf_full(ba_sub, dmap_sub, 1, 0);
+      MultiFab mf_flat(ba_flat, dmap_sub, 1, 0);
+      mf_flat.setVal(0);
 
-      Box res_box = ProjectBox(subbox,dir,loc);
+      Box res_box = ProjectBox(subbox, dir, loc);
       const Vector<int> dm_vec({0});
       DistributionMapping res_dm(dm_vec);
-      MultiFab res_mf(BoxArray(res_box),res_dm,comps.size(),0); res_mf.setVal(0);
+      MultiFab res_mf(BoxArray(res_box), res_dm, comps.size(), 0);
+      res_mf.setVal(0);
 
-      for (int i=0; i<comps.size(); ++i)
-      {
+      for (int i = 0; i < comps.size(); ++i) {
         names[i] = amrData.PlotVarNames()[comps[i]];
-        if (ParallelDescriptor::IOProcessor()) 
-          std::cout << "Filling " << names[i] << " on level " << finestLevel << std::endl;
+        if (ParallelDescriptor::IOProcessor())
+          std::cout << "Filling " << names[i] << " on level " << finestLevel
+                    << std::endl;
 
-        mf_full.ParallelCopy(amrData.GetGrids(finestLevel,comps[i],subbox),0,0,1);
-        amrData.FlushGrids(comps[i]);                
+        mf_full.ParallelCopy(
+          amrData.GetGrids(finestLevel, comps[i], subbox), 0, 0, 1);
+        amrData.FlushGrids(comps[i]);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-        for (MFIter mfi(mf_full, false); mfi.isValid(); ++mfi) // do not tile, to avoid race on += below
+        for (MFIter mfi(mf_full, false); mfi.isValid();
+             ++mfi) // do not tile, to avoid race on += below
         {
           auto const& full_fab = mf_full[mfi];
           Array4<Real const> const& full_arr = full_fab.const_array();
 
-          const Box& tile_box  = mfi.tilebox();
-          Box flat_box = ProjectBox(tile_box,dir,loc);
+          const Box& tile_box = mfi.tilebox();
+          Box flat_box = ProjectBox(tile_box, dir, loc);
           auto& flat_fab = mf_flat[mfi];
           Array4<Real> const& flat_arr = flat_fab.array();
 
-          AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( tile_box, thread_box,
-          {
+          AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA(tile_box, thread_box, {
             const auto lo = lbound(thread_box);
             const auto hi = ubound(thread_box);
 
-            if (dir==0) {
+            if (dir == 0) {
               int ilo = flat_box.smallEnd(dir);
-              for     (int k = lo.z; k <= hi.z; ++k) {
-                for   (int j = lo.y; j <= hi.y; ++j) {
-                    for (int i = lo.x; i <= hi.x; ++i) {
-                      flat_arr(ilo,j,k) += full_arr(i,j,k);
-                    }
+              for (int k = lo.z; k <= hi.z; ++k) {
+                for (int j = lo.y; j <= hi.y; ++j) {
+                  for (int i = lo.x; i <= hi.x; ++i) {
+                    flat_arr(ilo, j, k) += full_arr(i, j, k);
+                  }
                 }
               }
-            }
-            else if (dir==1) {
+            } else if (dir == 1) {
               int jlo = flat_box.smallEnd(dir);
-              for     (int k = lo.z; k <= hi.z; ++k) {
-                for   (int j = lo.y; j <= hi.y; ++j) {
-                    for (int i = lo.x; i <= hi.x; ++i) {
-                      flat_arr(i,jlo,k) += full_arr(i,j,k);
-                    }
+              for (int k = lo.z; k <= hi.z; ++k) {
+                for (int j = lo.y; j <= hi.y; ++j) {
+                  for (int i = lo.x; i <= hi.x; ++i) {
+                    flat_arr(i, jlo, k) += full_arr(i, j, k);
+                  }
                 }
               }
-            }
-            else if (dir==2) {
+            } else if (dir == 2) {
               int klo = flat_box.smallEnd(dir);
-              for     (int k = lo.z; k <= hi.z; ++k) {
-                for   (int j = lo.y; j <= hi.y; ++j) {
-                    for (int i = lo.x; i <= hi.x; ++i) {
-                      flat_arr(i,j,klo) += full_arr(i,j,k);
-                    }
+              for (int k = lo.z; k <= hi.z; ++k) {
+                for (int j = lo.y; j <= hi.y; ++j) {
+                  for (int i = lo.x; i <= hi.x; ++i) {
+                    flat_arr(i, j, klo) += full_arr(i, j, k);
+                  }
                 }
               }
             }
           });
         }
-        res_mf.ParallelAdd(mf_flat,0,i,1);
+        res_mf.ParallelAdd(mf_flat, 0, i, 1);
       }
 
       if (ParallelDescriptor::IOProcessor()) {
         FArrayBox& data = res_mf[0];
         Real data_min = data.min();
         Real data_max = data.max();
-        pp.query("min",data_min);
-        pp.query("max",data_max);
-      
+        pp.query("min", data_min);
+        pp.query("max", data_max);
+
         BaseFab<int> image;
         const int nVals = 256;
-        pixelizeData(data,dir,loc,image,data_min,data_max,nVals);
-      
+        pixelizeData(data, dir, loc, image, data_min, data_max, nVals);
+
         const int width = image.box().length(0);
-        const int height= image.box().length(1);
+        const int height = image.box().length(1);
 
         std::string palfile;
-        pp.get("palette",palfile);
+        pp.get("palette", palfile);
         int r[256], g[256], b[256], t[256];
-        LOAD_PALETTE_STR(palfile,r,g,b,t);
-            
+        LOAD_PALETTE_STR(palfile, r, g, b, t);
+
         std::string outfile = getFileRoot(plotFileName) + PPM;
         STORE_PPM_STR(outfile, width, height, image.dataPtr(), r, g, b);
       }
-      
     }
   }
   Finalize();
   return 0;
 }
 
-void pixelizeData(const FArrayBox& data, int slicedir, int sliceloc,
-                  BaseFab<int>& image, Real data_min, Real data_max, int nVals)
+void
+pixelizeData(
+  const FArrayBox& data,
+  int slicedir,
+  int sliceloc,
+  BaseFab<int>& image,
+  Real data_min,
+  Real data_max,
+  int nVals)
 {
   const Box& box = data.box();
   const Real del = data_max - data_min;
-  AMREX_ASSERT(std::abs(del)>0.0);
-  const int nvm1 = nVals-1;
-  int cnt=0;
+  AMREX_ASSERT(std::abs(del) > 0.0);
+  const int nvm1 = nVals - 1;
+  int cnt = 0;
   int d[2];
-  for (int dir=0; dir<AMREX_SPACEDIM; ++dir)
+  for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
     if (dir != slicedir)
       d[cnt++] = dir;
 
   const IntVect se = box.smallEnd();
   const IntVect be = box.bigEnd();
 
-  Print() << Box(se,be) << std::endl;
+  Print() << Box(se, be) << std::endl;
 
-  IntVect img(AMREX_D_DECL(box.length(d[0]) - 1,box.length(d[1]) - 1,0));
-  image.resize(Box(IntVect::TheZeroVector(),img),1);
+  IntVect img(AMREX_D_DECL(box.length(d[0]) - 1, box.length(d[1]) - 1, 0));
+  image.resize(Box(IntVect::TheZeroVector(), img), 1);
 
   IntVect div;
-  if (slicedir>=0 && slicedir<AMREX_SPACEDIM)
-      div[slicedir] = sliceloc;
+  if (slicedir >= 0 && slicedir < AMREX_SPACEDIM)
+    div[slicedir] = sliceloc;
 
-  for (int i=se[d[0]]; i<=be[d[0]]; ++i) {
-    for (int j=se[d[1]]; j<=be[d[1]]; ++j) {
+  for (int i = se[d[0]]; i <= be[d[0]]; ++i) {
+    for (int j = se[d[1]]; j <= be[d[1]]; ++j) {
       div[d[0]] = i;
       div[d[1]] = j;
-      image(IntVect(AMREX_D_DECL(i - se[d[0]],j - se[d[1]],0)),0) =
-        std::max(0,(int)(nvm1*std::min( (data(div,0) - data_min)/del,1.0))); 
+      image(IntVect(AMREX_D_DECL(i - se[d[0]], j - se[d[1]], 0)), 0) = std::max(
+        0, (int)(nvm1 * std::min((data(div, 0) - data_min) / del, 1.0)));
     }
   }
-  //BaseFab<int> imageRev(image.box(), 1);
-  //imageRev.copy(image);
-  //int rMult(1);
-  //image.copyRev(image.box(), imageRev, image.box(), 1, &rMult);
+  // BaseFab<int> imageRev(image.box(), 1);
+  // imageRev.copy(image);
+  // int rMult(1);
+  // image.copyRev(image.box(), imageRev, image.box(), 1, &rMult);
 }
 
 #include <cstdlib>
@@ -277,106 +296,97 @@ static const char RPGM_MAGIC2 = '5';
 static const char RPGM_MAGIC3 = '6';
 
 void
-STORE_PPM_STR (const std::string& file, int width, int height, int iimage[],
-	       const int r[], const int g[], const int b[])
+STORE_PPM_STR(
+  const std::string& file,
+  int width,
+  int height,
+  int iimage[],
+  const int r[],
+  const int g[],
+  const int b[])
 {
-  FILE *image_fp;	/* file descriptor for image (output) */
-  
+  FILE* image_fp; /* file descriptor for image (output) */
+
   /* create image file */
-  if ((image_fp = fopen(file.c_str(), "w")) == NULL)
-  {
-      fprintf(stderr, "cannot open output file %s\n", file.c_str());
-      exit(1);
+  if ((image_fp = fopen(file.c_str(), "w")) == NULL) {
+    fprintf(stderr, "cannot open output file %s\n", file.c_str());
+    exit(1);
   }
-  
+
   /* translate Fortran image data to chars */
-  unsigned char* image = new unsigned char[3*width*height];
-  for (int i = 0; i < width*height; i++ )
-  {
-      const int j = iimage[i];
-      if ( j < 0 || j > 255 ) 
-      {
-	  fprintf(stderr,"out of bounds on image[%d] = %d\n", i, j);
-	  exit(1);
-      }
-      image[3*i+0] = r[j];
-      image[3*i+1] = g[j];
-      image[3*i+2] = b[j];
-  }
-  fprintf(image_fp, "%c%c\n%d %d\n%d\n", PGM_MAGIC1, RPGM_MAGIC3,
-	  width, height, 255);
-  fwrite(image, 1, 3*width*height, image_fp);
-  delete [] image;
-  fclose(image_fp);
-}
-
-void
-STORE_PGM_STR (const std::string& file, int width, int height, int iimage[])
-{
-  FILE *image_fp;	/* file descriptor for image (output) */
-
-  /* create image file */
-  if ((image_fp = fopen(file.c_str(), "w")) == NULL)
-    {
-      fprintf(stderr, "cannot open output file %s\n", file.c_str());
+  unsigned char* image = new unsigned char[3 * width * height];
+  for (int i = 0; i < width * height; i++) {
+    const int j = iimage[i];
+    if (j < 0 || j > 255) {
+      fprintf(stderr, "out of bounds on image[%d] = %d\n", i, j);
       exit(1);
     }
-
-  /* translate Fortran image data to chars */
-  unsigned char* image = new unsigned char[width*height];
-  for (int i = 0; i < width*height; ++i )
-  {
-      image[i] = iimage[i];
+    image[3 * i + 0] = r[j];
+    image[3 * i + 1] = g[j];
+    image[3 * i + 2] = b[j];
   }
-  fprintf(image_fp, "%c%c\n%d %d\n%d\n", PGM_MAGIC1, RPGM_MAGIC2,
-	  width, height, 255);
-  fwrite(image, 1, width*height, image_fp);
-  delete [] image;
+  fprintf(
+    image_fp, "%c%c\n%d %d\n%d\n", PGM_MAGIC1, RPGM_MAGIC3, width, height, 255);
+  fwrite(image, 1, 3 * width * height, image_fp);
+  delete[] image;
   fclose(image_fp);
 }
 
 void
-LOAD_PALETTE_STR (const std::string& file, int r[], int g[], int b[], int a[])
+STORE_PGM_STR(const std::string& file, int width, int height, int iimage[])
 {
-  FILE *pal_fp;	/* file descriptor for image (output) */
+  FILE* image_fp; /* file descriptor for image (output) */
+
+  /* create image file */
+  if ((image_fp = fopen(file.c_str(), "w")) == NULL) {
+    fprintf(stderr, "cannot open output file %s\n", file.c_str());
+    exit(1);
+  }
+
+  /* translate Fortran image data to chars */
+  unsigned char* image = new unsigned char[width * height];
+  for (int i = 0; i < width * height; ++i) {
+    image[i] = iimage[i];
+  }
+  fprintf(
+    image_fp, "%c%c\n%d %d\n%d\n", PGM_MAGIC1, RPGM_MAGIC2, width, height, 255);
+  fwrite(image, 1, width * height, image_fp);
+  delete[] image;
+  fclose(image_fp);
+}
+
+void
+LOAD_PALETTE_STR(const std::string& file, int r[], int g[], int b[], int a[])
+{
+  FILE* pal_fp; /* file descriptor for image (output) */
   unsigned char c[256];
   int i;
 
-  if ((pal_fp = fopen(file.c_str(), "rb")) == NULL)
-    {
-      fprintf(stderr, "cannot open palette file %s\n", file.c_str());
-      exit(1);
-    }
+  if ((pal_fp = fopen(file.c_str(), "rb")) == NULL) {
+    fprintf(stderr, "cannot open palette file %s\n", file.c_str());
+    exit(1);
+  }
   fread(c, 1, 256, pal_fp);
-  for ( i = 0; i < 256; ++i )
-    {
-      r[i] = c[i];
-    }
+  for (i = 0; i < 256; ++i) {
+    r[i] = c[i];
+  }
   fread(c, 1, 256, pal_fp);
-  for ( i = 0; i < 256; ++i )
-    {
-      g[i] = c[i];
-    }
+  for (i = 0; i < 256; ++i) {
+    g[i] = c[i];
+  }
   fread(c, 1, 256, pal_fp);
-  for ( i = 0; i < 256; ++i )
-    {
-      b[i] = c[i];
-    }
+  for (i = 0; i < 256; ++i) {
+    b[i] = c[i];
+  }
   i = fread(c, 1, 256, pal_fp);
-  if ( i == 256 )
-    {
-      for ( i = 0; i < 256; ++i )
-	{
-	  a[i] = c[i];
-	}
+  if (i == 256) {
+    for (i = 0; i < 256; ++i) {
+      a[i] = c[i];
     }
-  else
-    {
-      for ( i = 0; i < 256; ++i )
-	{
-	  a[i] = 0;
-	}
+  } else {
+    for (i = 0; i < 256; ++i) {
+      a[i] = 0;
     }
+  }
   fclose(pal_fp);
 }
-

--- a/Src/binMEF.cpp
+++ b/Src/binMEF.cpp
@@ -7,14 +7,14 @@
 #include <map>
 #include <cmath>
 #include <algorithm>
-using std::cout;
 using std::cerr;
+using std::cout;
 using std::endl;
+using std::list;
+using std::map;
+using std::set;
 using std::string;
 using std::vector;
-using std::set;
-using std::map;
-using std::list;
 #ifndef WIN32
 using std::pow;
 #endif
@@ -27,322 +27,334 @@ using std::pow;
 
 using namespace amrex;
 
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return Tokenize(line,std::string(" "));
+  std::string line;
+  std::getline(is, line);
+  return Tokenize(line, std::string(" "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return line;
+  std::string line;
+  std::getline(is, line);
+  return line;
 }
 
-static
-Real triangleArea(const vector<Real>& p0,
-                  const vector<Real>& p1,
-                  const vector<Real>& p2)
+static Real
+triangleArea(
+  const vector<Real>& p0, const vector<Real>& p1, const vector<Real>& p2)
 {
-    // Note: assumes (x,y,z) are first 3 components
-    return 0.5*sqrt(
-        pow(  ( p1[1] - p0[1])*(p2[2]-p0[2]) 
-              -(p1[2] - p0[2])*(p2[1]-p0[1]), 2)
-                                            
-        + pow(( p1[2] - p0[2])*(p2[0]-p0[0]) 
-              -(p1[0] - p0[0])*(p2[2]-p0[2]), 2)
-                                            
-        + pow(( p1[0] - p0[0])*(p2[1]-p0[1]) 
-              -(p1[1] - p0[1])*(p2[0]-p0[0]), 2));
+  // Note: assumes (x,y,z) are first 3 components
+  return 0.5 * sqrt(
+                 pow(
+                   (p1[1] - p0[1]) * (p2[2] - p0[2]) -
+                     (p1[2] - p0[2]) * (p2[1] - p0[1]),
+                   2)
+
+                 + pow(
+                     (p1[2] - p0[2]) * (p2[0] - p0[0]) -
+                       (p1[0] - p0[0]) * (p2[2] - p0[2]),
+                     2)
+
+                 + pow(
+                     (p1[0] - p0[0]) * (p2[1] - p0[1]) -
+                       (p1[1] - p0[1]) * (p2[0] - p0[0]),
+                     2));
 }
 
-
-static
-void orderNodes(vector<Real>& A, vector<int>& Abin,
-                vector<Real>& B, vector<int>& Bbin,
-                vector<Real>& C, vector<int>& Cbin, int binID)
+static void
+orderNodes(
+  vector<Real>& A,
+  vector<int>& Abin,
+  vector<Real>& B,
+  vector<int>& Bbin,
+  vector<Real>& C,
+  vector<int>& Cbin,
+  int binID)
 {
-    // Order big to small. 
-    if (Bbin[binID] > Abin[binID])
-    {
-        vector<Real> t = A;
-        vector<int> tbin = Abin;
-        A = B; Abin = Bbin;
-        B = t; Bbin = tbin;
-    }
-    if (Cbin[binID] > Bbin[binID])
-    {
-        vector<Real> t = B;
-        vector<int> tbin = Bbin;
-        B = C; Bbin = Cbin;
-        C = t; Cbin = tbin;
-    }
-    if (Bbin[binID] > Abin[binID])
-    {
-        vector<Real> t = A;
-        vector<int> tbin = Abin;
-        A = B; Abin = Bbin;
-        B = t; Bbin = tbin;
-    }
+  // Order big to small.
+  if (Bbin[binID] > Abin[binID]) {
+    vector<Real> t = A;
+    vector<int> tbin = Abin;
+    A = B;
+    Abin = Bbin;
+    B = t;
+    Bbin = tbin;
+  }
+  if (Cbin[binID] > Bbin[binID]) {
+    vector<Real> t = B;
+    vector<int> tbin = Bbin;
+    B = C;
+    Bbin = Cbin;
+    C = t;
+    Cbin = tbin;
+  }
+  if (Bbin[binID] > Abin[binID]) {
+    vector<Real> t = A;
+    vector<int> tbin = Abin;
+    A = B;
+    Abin = Bbin;
+    B = t;
+    Bbin = tbin;
+  }
 }
 
-static
-void findDE(const vector<Real>& A,
-            const vector<Real>& B,
-            const vector<Real>& C,
-            vector<Real>&       D,
-            vector<Real>&       E,
-            const vector<Real>& binLO,
-            Real                binMax,
-            int                 abin,
-            int                 comp)
+static void
+findDE(
+  const vector<Real>& A,
+  const vector<Real>& B,
+  const vector<Real>& C,
+  vector<Real>& D,
+  vector<Real>& E,
+  const vector<Real>& binLO,
+  Real binMax,
+  int abin,
+  int comp)
 {
-    // Assume that A[comp]=B[comp] and A[comp]>C[comp], and that ABC all have the same component layout
-    Real fAC, fBC;
-    if (abin < 0) // then A and B below lower bin bound
-    {
-        fAC = (binLO[0] - A[comp])/(C[comp] - A[comp]);
-        fBC = (binLO[0] - B[comp])/(C[comp] - B[comp]);
-    }
-    else if (abin >= binLO.size()) // then A and B above upper  bin bound
-    {
-        fAC = (A[comp] - binMax)/(A[comp]-C[comp]);
-        fBC = (B[comp] - binMax)/(B[comp]-C[comp]);
-    }
-    else
-    {
-        fAC = (A[comp]-binLO[abin])/(A[comp]-C[comp]);
-        fBC = (B[comp]-binLO[abin])/(B[comp]-C[comp]);
-    }
+  // Assume that A[comp]=B[comp] and A[comp]>C[comp], and that ABC all have the
+  // same component layout
+  Real fAC, fBC;
+  if (abin < 0) // then A and B below lower bin bound
+  {
+    fAC = (binLO[0] - A[comp]) / (C[comp] - A[comp]);
+    fBC = (binLO[0] - B[comp]) / (C[comp] - B[comp]);
+  } else if (abin >= binLO.size()) // then A and B above upper  bin bound
+  {
+    fAC = (A[comp] - binMax) / (A[comp] - C[comp]);
+    fBC = (B[comp] - binMax) / (B[comp] - C[comp]);
+  } else {
+    fAC = (A[comp] - binLO[abin]) / (A[comp] - C[comp]);
+    fBC = (B[comp] - binLO[abin]) / (B[comp] - C[comp]);
+  }
 
-    AMREX_ALWAYS_ASSERT(fAC>=0 && fAC<=1 && fBC>=0 && fBC<=1);
+  AMREX_ALWAYS_ASSERT(fAC >= 0 && fAC <= 1 && fBC >= 0 && fBC <= 1);
 
-    // Interpolate all states to the interface
-    for (int i=0; i<A.size(); ++i)
-    {
-        D[i] = A[i] - fAC*(A[i] - C[i]);
-        E[i] = B[i] - fBC*(B[i] - C[i]);
-    }
+  // Interpolate all states to the interface
+  for (int i = 0; i < A.size(); ++i) {
+    D[i] = A[i] - fAC * (A[i] - C[i]);
+    E[i] = B[i] - fBC * (B[i] - C[i]);
+  }
 }
 
-static
-void findFG(const vector<Real>& A,
-            const vector<Real>& B,
-            const vector<Real>& C,
-            vector<Real>&       F,
-            vector<Real>&       G,
-            const vector<Real>& binLO,
-            Real                binMax,
-            int                 abin,
-            int                 comp)
+static void
+findFG(
+  const vector<Real>& A,
+  const vector<Real>& B,
+  const vector<Real>& C,
+  vector<Real>& F,
+  vector<Real>& G,
+  const vector<Real>& binLO,
+  Real binMax,
+  int abin,
+  int comp)
 {
-    // Assume that A[comp]>B[comp] and A[comp]>C[comp], and that ABC all have the same component layout
-    Real fAB, fAC;
-    if (abin < 0) // then A below lower bin bound
-    {
-        fAB = (binLO[0] - A[comp])/(A[comp] - B[comp]);
-        fAC = (binLO[0] - C[comp])/(A[comp] - C[comp]);
-    }
-    else if (abin >= binLO.size()) // then A above upper bin bound
-    {
-        fAB = (A[comp] - binMax)/(A[comp]-B[comp]);
-        fAC = (A[comp] - binMax)/(A[comp]-C[comp]);
-    }
-    else
-    {
-        fAB = (A[comp]-binLO[abin])/(A[comp]-B[comp]);
-        fAC = (A[comp]-binLO[abin])/(A[comp]-C[comp]);
-    }
-    AMREX_ALWAYS_ASSERT(fAB>=0 && fAB<=1 && fAC>=0 && fAC<=1);
-    for (int i=0; i<A.size(); ++i)
-    {
-        F[i] = A[i] - fAB*(A[i] - B[i]);
-        G[i] = A[i] - fAC*(A[i] - C[i]);
-    }
+  // Assume that A[comp]>B[comp] and A[comp]>C[comp], and that ABC all have the
+  // same component layout
+  Real fAB, fAC;
+  if (abin < 0) // then A below lower bin bound
+  {
+    fAB = (binLO[0] - A[comp]) / (A[comp] - B[comp]);
+    fAC = (binLO[0] - C[comp]) / (A[comp] - C[comp]);
+  } else if (abin >= binLO.size()) // then A above upper bin bound
+  {
+    fAB = (A[comp] - binMax) / (A[comp] - B[comp]);
+    fAC = (A[comp] - binMax) / (A[comp] - C[comp]);
+  } else {
+    fAB = (A[comp] - binLO[abin]) / (A[comp] - B[comp]);
+    fAC = (A[comp] - binLO[abin]) / (A[comp] - C[comp]);
+  }
+  AMREX_ALWAYS_ASSERT(fAB >= 0 && fAB <= 1 && fAC >= 0 && fAC <= 1);
+  for (int i = 0; i < A.size(); ++i) {
+    F[i] = A[i] - fAB * (A[i] - B[i]);
+    G[i] = A[i] - fAC * (A[i] - C[i]);
+  }
 }
 
-static
-vector<int>
-getBin (const vector<Real>&          val,
-        const vector<int>&           binComps,
-        const vector<vector<Real> >& binLO,
-        const vector<Real>&          binMax)
+static vector<int>
+getBin(
+  const vector<Real>& val,
+  const vector<int>& binComps,
+  const vector<vector<Real>>& binLO,
+  const vector<Real>& binMax)
 {
-    const int nc = binComps.size();
+  const int nc = binComps.size();
 
-    vector<int> retVal(nc,0);
+  vector<int> retVal(nc, 0);
 
-    for (int j = 0; j < nc; ++j)
-    {
-        if (val[binComps[j]]<binLO[j][0])
-        {
-            retVal[j] = -1;
-        }
-        else if (val[binComps[j]]>binMax[j])
-        {
-            retVal[j] = binLO[j].size();
-        }
-        else
-        {
-            std::vector<Real>::const_iterator it =
-                std::upper_bound(binLO[j].begin(), binLO[j].end(), val[binComps[j]]);
+  for (int j = 0; j < nc; ++j) {
+    if (val[binComps[j]] < binLO[j][0]) {
+      retVal[j] = -1;
+    } else if (val[binComps[j]] > binMax[j]) {
+      retVal[j] = binLO[j].size();
+    } else {
+      std::vector<Real>::const_iterator it =
+        std::upper_bound(binLO[j].begin(), binLO[j].end(), val[binComps[j]]);
 
-            --it;
-            
-            retVal[j] = it - binLO[j].begin();
-        }
+      --it;
+
+      retVal[j] = it - binLO[j].begin();
     }
+  }
 
-    return retVal;
+  return retVal;
 }
 
 // This is the running sum of triangles not added because
 //  they didn't satisfy the condition
 static Real areaOutsideCondition = 0.;
-static
-bool satisfyCondition(const vector<Real>& A, const vector<Real>& B, const vector<Real>& C,
-                      int condComp, Real condVal, int condSgn)
+static bool
+satisfyCondition(
+  const vector<Real>& A,
+  const vector<Real>& B,
+  const vector<Real>& C,
+  int condComp,
+  Real condVal,
+  int condSgn)
 {
-    if (condSgn > 0)
-    {
-        if (A[condComp] > condVal  &&  B[condComp] > condVal  &&  C[condComp] > condVal)
-            return true;
-    }
-    else if (condSgn < 0)
-    {
-        if (A[condComp] < condVal  &&  B[condComp] < condVal  &&  C[condComp] < condVal)
-            return true;
-    }
-    else
-    {
-        if (A[condComp] == condVal  &&  B[condComp] == condVal  &&  C[condComp] == condVal)
-            return true;
-    }
+  if (condSgn > 0) {
+    if (A[condComp] > condVal && B[condComp] > condVal && C[condComp] > condVal)
+      return true;
+  } else if (condSgn < 0) {
+    if (A[condComp] < condVal && B[condComp] < condVal && C[condComp] < condVal)
+      return true;
+  } else {
+    if (
+      A[condComp] == condVal && B[condComp] == condVal &&
+      C[condComp] == condVal)
+      return true;
+  }
 
-    return false;
+  return false;
 }
 
 static long NmyTriangles = 0;
 
-static
-void processTriangle(const vector<Real>& Ai, const vector<int>& AbinI,
-                     const vector<Real>& Bi, const vector<int>& BbinI,
-                     const vector<Real>& Ci, const vector<int>& CbinI,
-                     map<vector<int>,Real >& bins,
-                     const vector<vector<Real> >& binLO,
-                     const vector<Real>& binMax,
-                     Real areaEps,
-                     const vector<int>& binComps,
-                     int condComp, Real condVal, int condSgn, bool condApply,
-                     int binID=0)
+static void
+processTriangle(
+  const vector<Real>& Ai,
+  const vector<int>& AbinI,
+  const vector<Real>& Bi,
+  const vector<int>& BbinI,
+  const vector<Real>& Ci,
+  const vector<int>& CbinI,
+  map<vector<int>, Real>& bins,
+  const vector<vector<Real>>& binLO,
+  const vector<Real>& binMax,
+  Real areaEps,
+  const vector<int>& binComps,
+  int condComp,
+  Real condVal,
+  int condSgn,
+  bool condApply,
+  int binID = 0)
 {
-    const Real area = triangleArea(Ai,Bi,Ci);
+  const Real area = triangleArea(Ai, Bi, Ci);
 
-    if (area < areaEps) {
-      return;
+  if (area < areaEps) {
+    return;
+  }
+
+  if (binID >= AbinI.size()) {
+    bool in_range = true;
+    for (int i = 0; i < AbinI.size(); ++i)
+      if (AbinI[i] < 0 || AbinI[i] >= binLO[i].size())
+        in_range = false;
+
+    if (in_range) {
+      NmyTriangles++;
+
+      if (
+        !(condApply) ||
+        satisfyCondition(Ai, Bi, Ci, condComp, condVal, condSgn)) {
+        bins[AbinI] += area;
+      } else {
+        areaOutsideCondition += area;
+      }
     }
+    return;
+  } else if ((AbinI[binID] == BbinI[binID]) && (BbinI[binID] == CbinI[binID])) {
+    processTriangle(
+      Ai, AbinI, Bi, BbinI, Ci, CbinI, bins, binLO, binMax, areaEps, binComps,
+      condComp, condVal, condSgn, condApply, binID + 1);
+  } else {
+    vector<int> Abin = AbinI;
+    vector<int> Bbin = BbinI;
+    vector<int> Cbin = CbinI;
+    vector<Real> A = Ai;
+    vector<Real> B = Bi;
+    vector<Real> C = Ci;
+    orderNodes(A, Abin, B, Bbin, C, Cbin, binID);
+    if (Abin[binID] == Bbin[binID]) {
+      int nComp = A.size();
+      vector<Real> D(nComp), E(nComp);
+      findDE(
+        A, B, C, D, E, binLO[binID], binMax[binID], Abin[binID],
+        binComps[binID]);
+      vector<int> Dbin = getBin(D, binComps, binLO, binMax);
+      vector<int> Ebin = getBin(E, binComps, binLO, binMax);
+      for (int i = 0; i <= binID; ++i) {
+        Dbin[i] = Abin[i];
+        Ebin[i] = Dbin[i];
+      }
+      processTriangle(
+        A, Abin, B, Bbin, E, Ebin, bins, binLO, binMax, areaEps, binComps,
+        condComp, condVal, condSgn, condApply, binID + 1);
+      processTriangle(
+        A, Abin, E, Ebin, D, Dbin, bins, binLO, binMax, areaEps, binComps,
+        condComp, condVal, condSgn, condApply, binID + 1);
 
-    if (binID >= AbinI.size())
-    {
-        bool in_range = true;
-        for (int i=0; i<AbinI.size(); ++i)
-            if (AbinI[i]<0 || AbinI[i]>=binLO[i].size())
-                in_range = false;
+      // Decrement bin for triangles on other side of interp line
+      Dbin[binID] = Abin[binID] - 1;
+      Ebin[binID] = Ebin[binID] - 1;
+      processTriangle(
+        D, Dbin, C, Cbin, E, Ebin, bins, binLO, binMax, areaEps, binComps,
+        condComp, condVal, condSgn, condApply, binID);
+    } else {
+      int nComp = A.size();
+      vector<Real> F(nComp), G(nComp);
+      findFG(
+        A, B, C, F, G, binLO[binID], binMax[binID], Abin[binID],
+        binComps[binID]);
+      vector<int> Fbin = getBin(F, binComps, binLO, binMax);
+      vector<int> Gbin = getBin(G, binComps, binLO, binMax);
+      for (int i = 0; i <= binID; ++i) {
+        Fbin[i] = Abin[i];
+        Gbin[i] = Fbin[i];
+      }
+      processTriangle(
+        A, Abin, F, Fbin, G, Gbin, bins, binLO, binMax, areaEps, binComps,
+        condComp, condVal, condSgn, condApply, binID + 1);
 
-        if (in_range)
-        {
-            NmyTriangles++;
-
-            if ( !(condApply) || satisfyCondition(Ai,Bi,Ci,condComp,condVal,condSgn))
-            {
-                bins[AbinI] += area;
-            }
-            else
-            {
-                areaOutsideCondition += area;
-            }
-        }
-        return;
+      // Decrement bin for triangles on other side of interp line
+      Fbin[binID] = Abin[binID] - 1;
+      Gbin[binID] = Abin[binID] - 1;
+      processTriangle(
+        F, Fbin, B, Bbin, C, Cbin, bins, binLO, binMax, areaEps, binComps,
+        condComp, condVal, condSgn, condApply, binID);
+      processTriangle(
+        F, Fbin, C, Cbin, G, Gbin, bins, binLO, binMax, areaEps, binComps,
+        condComp, condVal, condSgn, condApply, binID);
     }
-    else if ( (AbinI[binID]==BbinI[binID]) && (BbinI[binID]==CbinI[binID]) )
-    {        
-        processTriangle(Ai,AbinI,Bi,BbinI,Ci,CbinI,bins,binLO,binMax,areaEps,binComps,
-                        condComp,condVal,condSgn,condApply,binID+1);
-    }
-    else
-    {
-        vector<int> Abin = AbinI;
-        vector<int> Bbin = BbinI;
-        vector<int> Cbin = CbinI;
-        vector<Real> A = Ai;
-        vector<Real> B = Bi;
-        vector<Real> C = Ci;
-        orderNodes(A,Abin,B,Bbin,C,Cbin,binID);
-        if (Abin[binID] == Bbin[binID])
-        {
-            int nComp = A.size();
-            vector<Real> D(nComp), E(nComp);
-            findDE(A,B,C,D,E,binLO[binID],binMax[binID],Abin[binID],binComps[binID]);
-            vector<int> Dbin = getBin(D,binComps,binLO,binMax);
-            vector<int> Ebin = getBin(E,binComps,binLO,binMax);
-            for (int i=0; i<=binID; ++i)
-            {
-                Dbin[i] = Abin[i];
-                Ebin[i] = Dbin[i];
-            }
-            processTriangle(A,Abin,B,Bbin,E,Ebin,bins,binLO,binMax,areaEps,binComps,
-                            condComp,condVal,condSgn,condApply,binID+1);
-            processTriangle(A,Abin,E,Ebin,D,Dbin,bins,binLO,binMax,areaEps,binComps,
-                            condComp,condVal,condSgn,condApply,binID+1);
-
-            // Decrement bin for triangles on other side of interp line
-            Dbin[binID] = Abin[binID] - 1;
-            Ebin[binID] = Ebin[binID] - 1;
-            processTriangle(D,Dbin,C,Cbin,E,Ebin,bins,binLO,binMax,areaEps,binComps,
-                            condComp,condVal,condSgn,condApply,binID);
-        }
-        else
-        {
-            int nComp = A.size();
-            vector<Real> F(nComp), G(nComp);
-            findFG(A,B,C,F,G,binLO[binID],binMax[binID],Abin[binID],binComps[binID]);
-            vector<int> Fbin = getBin(F,binComps,binLO,binMax);
-            vector<int> Gbin = getBin(G,binComps,binLO,binMax);
-            for (int i=0; i<=binID; ++i)
-            {
-                Fbin[i] = Abin[i];
-                Gbin[i] = Fbin[i];
-            }
-            processTriangle(A,Abin,F,Fbin,G,Gbin,bins,binLO,binMax,areaEps,binComps,
-                            condComp,condVal,condSgn,condApply,binID+1);
-
-            // Decrement bin for triangles on other side of interp line
-            Fbin[binID] = Abin[binID] - 1;
-            Gbin[binID] = Abin[binID] - 1;
-            processTriangle(F,Fbin,B,Bbin,C,Cbin,bins,binLO,binMax,areaEps,binComps,
-                            condComp,condVal,condSgn,condApply,binID);
-            processTriangle(F,Fbin,C,Cbin,G,Gbin,bins,binLO,binMax,areaEps,binComps,
-                            condComp,condVal,condSgn,condApply,binID);
-        }
-    }   
+  }
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     ParmParse pp;
 
-    bool dumpFab = false; pp.query("dumpFab",dumpFab);
-    std::string fabFileBase="bin"; pp.query("fabFileBase",fabFileBase);
+    bool dumpFab = false;
+    pp.query("dumpFab", dumpFab);
+    std::string fabFileBase = "bin";
+    pp.query("fabFileBase", fabFileBase);
 
-    vector<vector<Real> > nodeVec;
-    vector<vector<int> > eltVec;
+    vector<vector<Real>> nodeVec;
+    vector<vector<int>> eltVec;
 
 #define DEBUG_TEST
 #undef DEBUG_TEST
@@ -361,7 +373,8 @@ main (int   argc,
     // run with: binComps=0 1 binMin=0 0  binMax=1 1 nBins=1 1
     // Total area of this surface: 1.44 (sum of bins: 1)
 #else
-    std::string infile; pp.get("infile",infile);
+    std::string infile;
+    pp.get("infile", infile);
     std::ifstream ifs;
     ifs.open(infile.c_str());
 
@@ -382,31 +395,30 @@ main (int   argc,
     Real* nodeData = nodeFab.dataPtr();
     int nPts = nodeFab.box().numPts();
     if (ParallelDescriptor::IOProcessor())
-      cerr << "..." << nPts << " nodes read from data file (nComp=" << nComp << ")" << endl;
+      cerr << "..." << nPts << " nodes read from data file (nComp=" << nComp
+           << ")" << endl;
 
     // Rotate data to be accessible pointwise for triangle stuff below
     nodeVec.resize(nPts);
-    for (int i=0; i<nPts; ++i)
-    {
+    for (int i = 0; i < nPts; ++i) {
       nodeVec[i].resize(nComp);
-      for (int n=0; n<nComp; ++n)
+      for (int n = 0; n < nComp; ++n)
         nodeVec[i][n] = *nodeData++;
     }
     nodeFab.clear();
 
-    Vector<int> connData(nElts*MYLEN,0);
-    ifs.read((char*)connData.dataPtr(),sizeof(int)*connData.size());
+    Vector<int> connData(nElts * MYLEN, 0);
+    ifs.read((char*)connData.dataPtr(), sizeof(int) * connData.size());
     if (ParallelDescriptor::IOProcessor())
       cerr << "..." << nElts << " elements read from data file" << endl;
 
     // Rearrange elt data into handy format (this sure takes a while...)
     eltVec.resize(nElts);
     int cnt = 0;
-    for (int i=0; i<nElts; ++i)
-    {
+    for (int i = 0; i < nElts; ++i) {
       eltVec[i].resize(MYLEN);
-      for (int n=0; n<MYLEN; ++n)
-        eltVec[i][n]=connData[cnt++];
+      for (int n = 0; n < MYLEN; ++n)
+        eltVec[i][n] = connData[cnt++];
     }
     connData.clear();
 
@@ -416,94 +428,85 @@ main (int   argc,
 
     vector<int> binComps;
     int nc;
-    if (nc = pp.countval("binComps"))
-    {
+    if (nc = pp.countval("binComps")) {
       binComps.resize(nc);
-      pp.getarr("binComps",binComps,0,nc);
-      for (int i=0; i<nc; ++i)
-        if (binComps[i]>=nComp)
-          Abort("At least one element in binComps out of range");                
-    }
-    else
+      pp.getarr("binComps", binComps, 0, nc);
+      for (int i = 0; i < nc; ++i)
+        if (binComps[i] >= nComp)
+          Abort("At least one element in binComps out of range");
+    } else
       Abort("Need to specify binComps array");
 
     int nmin = pp.countval("binMin");
     vector<Real> binMin(nc);
-    if (nmin==nc)
-    {
+    if (nmin == nc) {
       binMin.resize(nc);
-      pp.getarr("binMin",binMin,0,nc);
-    }
-    else
-      Abort("Number of binMin components must match number of binComps components");
+      pp.getarr("binMin", binMin, 0, nc);
+    } else
+      Abort(
+        "Number of binMin components must match number of binComps components");
 
     int nmax = pp.countval("binMax");
     vector<Real> binMax(nc);
-    if (nmax==nc)
-    {
+    if (nmax == nc) {
       binMax.resize(nc);
-      pp.getarr("binMax",binMax,0,nc);
-    }
-    else
-      Abort("Number of binMax components must match number of binComps components");
+      pp.getarr("binMax", binMax, 0, nc);
+    } else
+      Abort(
+        "Number of binMax components must match number of binComps components");
 
     int nsize = pp.countval("nBins");
     vector<int> nBins(nc);
-    if (nsize==nc)
-    {
+    if (nsize == nc) {
       nBins.resize(nc);
-      pp.getarr("nBins",nBins,0,nc);
-    }
-    else
-      Abort("Number of nBins components must match number of binComps components");
+      pp.getarr("nBins", nBins, 0, nc);
+    } else
+      Abort(
+        "Number of nBins components must match number of binComps components");
 
     // Conditional binning?
     //   condApply == true?  Do it
     //   condSgn=(-,0,+) --> op=(<,==,>)
     //   condition:
     //    area added if ALL vertices, v,  satisfy v[condComp] op condVal
-    bool condApply = false; pp.query("condApply",condApply);
+    bool condApply = false;
+    pp.query("condApply", condApply);
     int condComp = 0;
     Real condVal = 0.;
     int condSgn = 0;
-    if (condApply)
-    {
+    if (condApply) {
       // Force the user to supply conditional parameters
-      pp.get("condComp",condComp);
-      pp.get("condVal",condVal);
-      pp.get("condSgn",condSgn);
+      pp.get("condComp", condComp);
+      pp.get("condVal", condVal);
+      pp.get("condSgn", condSgn);
     }
 
     vector<Real> dBin(nc);
-    for (int i=0; i<nc; ++i)
-      dBin[i] = (binMax[i]-binMin[i])/nBins[i];
+    for (int i = 0; i < nc; ++i)
+      dBin[i] = (binMax[i] - binMin[i]) / nBins[i];
 
-
-    bool dumpBins = false; pp.query("dumpBins",dumpBins);
-    vector<vector<Real> > binLO(nc);
-    for (int j=0; j<nc; ++j)
-    {
-      AMREX_ASSERT(nBins[j]>0);
+    bool dumpBins = false;
+    pp.query("dumpBins", dumpBins);
+    vector<vector<Real>> binLO(nc);
+    for (int j = 0; j < nc; ++j) {
+      AMREX_ASSERT(nBins[j] > 0);
       binLO[j].resize(nBins[j]);
-      for (int i=0; i<nBins[j]; ++i)
-        binLO[j][i] = binMin[j]+i*dBin[j];
+      for (int i = 0; i < nBins[j]; ++i)
+        binLO[j][i] = binMin[j] + i * dBin[j];
 
-      if (dumpBins && ParallelDescriptor::IOProcessor())
-      {
+      if (dumpBins && ParallelDescriptor::IOProcessor()) {
         cout << "bin: " << binComps[j] << " bounds: " << endl;
-        for (int i=0; i<nBins[j]; ++i)
-        {
+        for (int i = 0; i < nBins[j]; ++i) {
           Real lo = binLO[j][i];
-          Real hi = (i==nBins[j]-1 ?  binMax[j] : binLO[j][i+1]);
+          Real hi = (i == nBins[j] - 1 ? binMax[j] : binLO[j][i + 1]);
           cout << "         bin: [" << lo << "," << hi << "]" << endl;
         }
         cout << endl;
       }
     }
 
-    Real areaEps = 1.e-20; pp.query("areaEps",areaEps);
-
-
+    Real areaEps = 1.e-20;
+    pp.query("areaEps", areaEps);
 
     //
     // Let each CPU process a non-intersecting group of the triangles.
@@ -511,178 +514,174 @@ main (int   argc,
     const int MyProc = ParallelDescriptor::MyProc();
     const int NProcs = ParallelDescriptor::NProcs();
     const int IOProc = ParallelDescriptor::IOProcessorNumber();
-    const int M      = nElts / NProcs;
-    const int lo     =  M * MyProc;
-    const int hi     = (MyProc == NProcs-1) ? nElts-1 : (MyProc+1)*M-1;
+    const int M = nElts / NProcs;
+    const int lo = M * MyProc;
+    const int hi = (MyProc == NProcs - 1) ? nElts - 1 : (MyProc + 1) * M - 1;
 
     Real area = 0;
-    map<vector<int>,Real > bins;
-    
+    map<vector<int>, Real> bins;
+
     int idx = 0;
-    for (int i=0; i<nElts; ++i, ++idx)
-    {
-      if (idx >= lo && idx <= hi)
-      {
-        const vector<int>&  E = eltVec[i];
-        const vector<Real>& A = nodeVec[E[0]-1];
-        const vector<Real>& B = nodeVec[E[1]-1];
-        const vector<Real>& C = nodeVec[E[2]-1];
+    for (int i = 0; i < nElts; ++i, ++idx) {
+      if (idx >= lo && idx <= hi) {
+        const vector<int>& E = eltVec[i];
+        const vector<Real>& A = nodeVec[E[0] - 1];
+        const vector<Real>& B = nodeVec[E[1] - 1];
+        const vector<Real>& C = nodeVec[E[2] - 1];
 
-        vector<int> Abin = getBin(A,binComps,binLO,binMax);
-        vector<int> Bbin = getBin(B,binComps,binLO,binMax);
-        vector<int> Cbin = getBin(C,binComps,binLO,binMax);
-            
-        area += triangleArea(A,B,C);
+        vector<int> Abin = getBin(A, binComps, binLO, binMax);
+        vector<int> Bbin = getBin(B, binComps, binLO, binMax);
+        vector<int> Cbin = getBin(C, binComps, binLO, binMax);
 
-        processTriangle(A,Abin,B,Bbin,C,Cbin,bins,binLO,binMax,areaEps,binComps,
-                        condComp,condVal,condSgn,condApply);
+        area += triangleArea(A, B, C);
+
+        processTriangle(
+          A, Abin, B, Bbin, C, Cbin, bins, binLO, binMax, areaEps, binComps,
+          condComp, condVal, condSgn, condApply);
       }
     }
     //
     // Communicate results back to IOProc.
     //
-    //std::cerr << ParallelDescriptor::MyProc() << ": finished processing triangles." << std::endl;
+    // std::cerr << ParallelDescriptor::MyProc() << ": finished processing
+    // triangles." << std::endl;
     ParallelDescriptor::ReduceRealSum(area, IOProc);
-    
-    vector<int>  binIdx(bins.size()*nc);
+
+    vector<int> binIdx(bins.size() * nc);
     vector<Real> binDat(bins.size());
     int icnt = 0;
-    for (std::map<vector<int>,Real >::const_iterator it=bins.begin(); it!=bins.end(); ++it, ++icnt)
-    {
-      const vector<int>& k=it->first;
-      for (int j=0; j<nc; ++j)
-        binIdx[icnt*nc+j] = k[j];
+    for (std::map<vector<int>, Real>::const_iterator it = bins.begin();
+         it != bins.end(); ++it, ++icnt) {
+      const vector<int>& k = it->first;
+      for (int j = 0; j < nc; ++j)
+        binIdx[icnt * nc + j] = k[j];
       binDat[icnt] = it->second;
     }
-    //std::cerr << ParallelDescriptor::MyProc() << ": building maps, size = " << bins.size() << std::endl;
+    // std::cerr << ParallelDescriptor::MyProc() << ": building maps, size = "
+    // << bins.size() << std::endl;
     //
-    // Now get data to IOProc.
+    //  Now get data to IOProc.
     //
-    std::vector<int> pSizes = ParallelDescriptor::Gather(int(bins.size()),IOProc);
-    
-    for (int i=0; i<ParallelDescriptor::NProcs(); ++i)
-    {
-      if (ParallelDescriptor::IOProcessor())
-      {
-        if (i!=0)
-        {
-          std::vector<int> tmpI(pSizes[i]*nc); ParallelDescriptor::Recv(tmpI,i,101);
-          std::vector<Real> tmpR(pSizes[i]);   ParallelDescriptor::Recv(tmpR,i,102);
+    std::vector<int> pSizes =
+      ParallelDescriptor::Gather(int(bins.size()), IOProc);
+
+    for (int i = 0; i < ParallelDescriptor::NProcs(); ++i) {
+      if (ParallelDescriptor::IOProcessor()) {
+        if (i != 0) {
+          std::vector<int> tmpI(pSizes[i] * nc);
+          ParallelDescriptor::Recv(tmpI, i, 101);
+          std::vector<Real> tmpR(pSizes[i]);
+          ParallelDescriptor::Recv(tmpR, i, 102);
           //
           // Add to map on IOProc.
           //
           vector<int> itmp(nc);
-          for (int j=0; j<pSizes[i]; ++j)
-          {
-            for (int k=0; k<nc; ++k)
-              itmp[k] = tmpI[j*nc+k];
+          for (int j = 0; j < pSizes[i]; ++j) {
+            for (int k = 0; k < nc; ++k)
+              itmp[k] = tmpI[j * nc + k];
             bins[itmp] += tmpR[j];
           }
         }
 
-        //std::cerr << "Bin data received from proc: " << i << std::endl;
+        // std::cerr << "Bin data received from proc: " << i << std::endl;
+      } else if (ParallelDescriptor::MyProc() == i) {
+        ParallelDescriptor::Send(binIdx, IOProc, 101);
+        ParallelDescriptor::Send(binDat, IOProc, 102);
       }
-      else if (ParallelDescriptor::MyProc()==i)
-      {
-        ParallelDescriptor::Send(binIdx,IOProc,101);
-        ParallelDescriptor::Send(binDat,IOProc,102);
-      }
-       
+
       ParallelDescriptor::Barrier();
     }
-    
-    if (ParallelDescriptor::IOProcessor())
-    {
+
+    if (ParallelDescriptor::IOProcessor()) {
       cerr << "number of nonempty bins: " << bins.size() << endl;
 
       // Sum bins
       Real binSum = 0;
-      for (std::map<vector<int>,Real >::const_iterator it=bins.begin(); it!=bins.end(); ++it)
+      for (std::map<vector<int>, Real>::const_iterator it = bins.begin();
+           it != bins.end(); ++it)
         binSum += it->second;
-        
 
       //
       // Dump binned data.
       //
-      if (dumpFab && nc<=2)
-      {
+      if (dumpFab && nc <= 2) {
         string outFabFile = fabFileBase + ".fab";
 
         Box box;
-        if (nc==1)
-        {
-          box = Box(IntVect::TheZeroVector(),IntVect(AMREX_D_DECL(nBins[0]-1,0,0)));
+        if (nc == 1) {
+          box = Box(
+            IntVect::TheZeroVector(),
+            IntVect(AMREX_D_DECL(nBins[0] - 1, 0, 0)));
+        } else {
+          box = Box(
+            IntVect::TheZeroVector(),
+            IntVect(AMREX_D_DECL(nBins[0] - 1, nBins[1] - 1, 0)));
         }
-        else
-        {
-          box = Box(IntVect::TheZeroVector(),IntVect(AMREX_D_DECL(nBins[0]-1,nBins[1]-1,0)));
-        }
-            
-        FArrayBox outFab(box,1);
+
+        FArrayBox outFab(box, 1);
         outFab.setVal(0.0);
-        for (std::map<vector<int>,Real >::const_iterator it=bins.begin(); it!=bins.end(); ++it)
-        {
+        for (std::map<vector<int>, Real>::const_iterator it = bins.begin();
+             it != bins.end(); ++it) {
           IntVect iv = IntVect::TheZeroVector();
           const vector<int>& myBins = it->first;
-          for (int j=0; j<myBins.size(); ++j)
-          {
+          for (int j = 0; j < myBins.size(); ++j) {
             iv[j] = myBins[j];
           }
-          outFab(iv,0) = it->second;
+          outFab(iv, 0) = it->second;
         }
 
-
-        bool normalize = false; pp.query("normalize",normalize);
-        if (normalize && dumpFab && nc<=2) {
-          outFab.mult(1./binSum);
+        bool normalize = false;
+        pp.query("normalize", normalize);
+        if (normalize && dumpFab && nc <= 2) {
+          outFab.mult(1. / binSum);
         }
 
         std::ofstream ofs;
-        ofs.open(outFabFile.c_str(),std::ios::out|std::ios::trunc|std::ios::binary);
+        ofs.open(
+          outFabFile.c_str(),
+          std::ios::out | std::ios::trunc | std::ios::binary);
         outFab.writeOn(ofs);
         ofs.close();
-      }
-      else
-      {
-        for (std::map<vector<int>,Real >::const_iterator it=bins.begin(); it!=bins.end(); ++it)
-        {
+      } else {
+        for (std::map<vector<int>, Real>::const_iterator it = bins.begin();
+             it != bins.end(); ++it) {
           const vector<int>& idxs = it->first;
-          for (int j=0; j<idxs.size(); ++j)
-          {
+          for (int j = 0; j < idxs.size(); ++j) {
 #if 0
             Real lo = binLO[j][idxs[j]];
             Real hi = (idxs[j]==nBins[j]-1 ?  binMax[j] : binLO[j][idxs[j]+1]);
             cout << "[" << lo << "," << hi << "]: ";
 #else
             Real lo = binLO[j][idxs[j]];
-            Real hi = (idxs[j]==nBins[j]-1 ?  binMax[j] : binLO[j][idxs[j]+1]);
-            cout << 0.5*(lo+hi) << " ";
+            Real hi =
+              (idxs[j] == nBins[j] - 1 ? binMax[j] : binLO[j][idxs[j] + 1]);
+            cout << 0.5 * (lo + hi) << " ";
 #endif
           }
           cout << it->second << endl;
         }
       }
-        
-      cerr << "Total area of this surface: " << area << " (sum of bins: " << binSum << ")" << endl;
+
+      cerr << "Total area of this surface: " << area
+           << " (sum of bins: " << binSum << ")" << endl;
       if (condApply)
         cerr << "   area outside condition: " << areaOutsideCondition
              << " (total: " << areaOutsideCondition + binSum << ")" << endl;
     }
 
-    if (ParallelDescriptor::NProcs()>1) {
+    if (ParallelDescriptor::NProcs() > 1) {
       if (ParallelDescriptor::IOProcessor())
         std::cerr << "Load balance: " << std::endl;
-        
-      for (int i=0; i<ParallelDescriptor::NProcs(); ++i)
-      {
-        if (i==ParallelDescriptor::MyProc())
+
+      for (int i = 0; i < ParallelDescriptor::NProcs(); ++i) {
+        if (i == ParallelDescriptor::MyProc())
           std::cerr << "    " << i << ": " << NmyTriangles << std::endl;
-            
+
         ParallelDescriptor::Barrier();
       }
-        
-      ParallelDescriptor::ReduceLongSum(NmyTriangles); 
-        
+
+      ParallelDescriptor::ReduceLongSum(NmyTriangles);
+
       if (ParallelDescriptor::IOProcessor())
         std::cerr << "  Total: " << NmyTriangles << std::endl;
     }

--- a/Src/buildDistance.cpp
+++ b/Src/buildDistance.cpp
@@ -10,48 +10,48 @@
 #include "makelevelset3.h"
 
 using namespace amrex;
-using std::list;
-using std::vector;
-using std::string;
-using std::endl;
 using std::cerr;
+using std::endl;
+using std::list;
+using std::string;
+using std::vector;
 
-
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
   std::string line;
-  std::getline(is,line);
-  return Tokenize(line,std::string(", "));
+  std::getline(is, line);
+  return Tokenize(line, std::string(", "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
   std::string line;
-  std::getline(is,line);
+  std::getline(is, line);
   return line;
 }
 
 std::string
 getFileRoot(const std::string& infile)
 {
-  vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
   {
     ParmParse pp;
 
     // Read in isosurface
-    std::string isoFile; pp.get("isoFile",isoFile);
+    std::string isoFile;
+    pp.get("isoFile", isoFile);
     if (ParallelDescriptor::IOProcessor())
       std::cerr << "Reading isoFile... " << isoFile << std::endl;
-    
+
     Real strt_io = ParallelDescriptor::second();
 
     FArrayBox nodes;
@@ -60,9 +60,9 @@ main (int   argc,
     int nodesPerElt;
     int nNodes, nCompNodes;
     std::vector<std::string> surfNames;
-  
+
     std::ifstream ifs;
-    ifs.open(isoFile.c_str(),std::ios::in|std::ios::binary);
+    ifs.open(isoFile.c_str(), std::ios::in | std::ios::binary);
     const std::string title = parseTitle(ifs);
     surfNames = parseVarNames(ifs);
     nCompNodes = surfNames.size();
@@ -77,75 +77,84 @@ main (int   argc,
     tnodes.readFrom(ifs);
     nNodes = tnodes.box().numPts();
 
-    // transpose the data so that the components are 'in the right spot for fab data'
-    nodes.resize(tnodes.box(),nCompNodes);
+    // transpose the data so that the components are 'in the right spot for fab
+    // data'
+    nodes.resize(tnodes.box(), nCompNodes);
     Real** np = new Real*[nCompNodes];
-    for (int j=0; j<nCompNodes; ++j)
+    for (int j = 0; j < nCompNodes; ++j)
       np[j] = nodes.dataPtr(j);
 
     Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-      for (int j=0; j<nCompNodes; ++j)
-      {
+    for (int i = 0; i < nNodes; ++i) {
+      for (int j = 0; j < nCompNodes; ++j) {
         np[j][i] = ndat[j];
       }
       ndat += nCompNodes;
     }
-    delete [] np;
+    delete[] np;
     tnodes.clear();
 
-    faceData.resize(nElts*nodesPerElt,0);
-    ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
+    faceData.resize(nElts * nodesPerElt, 0);
+    ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
     ifs.close();
 
-    Print() << "Read " << nElts << " elements and " << nNodes << " nodes" << std::endl;
+    Print() << "Read " << nElts << " elements and " << nNodes << " nodes"
+            << std::endl;
 
-    int nCell = 64; pp.query("nCell",nCell);
-    int max_grid_size = 32; pp.query("max_grid_size",max_grid_size);
-    Box domain(IntVect(AMREX_D_DECL(0,0,0)),
-               //IntVect(AMREX_D_DECL(nCell-1,nCell-1,nCell-1)));
-               IntVect(AMREX_D_DECL(64-1,64-1,192-1)));
+    int nCell = 64;
+    pp.query("nCell", nCell);
+    int max_grid_size = 32;
+    pp.query("max_grid_size", max_grid_size);
+    Box domain(
+      IntVect(AMREX_D_DECL(0, 0, 0)),
+      // IntVect(AMREX_D_DECL(nCell-1,nCell-1,nCell-1)));
+      IntVect(AMREX_D_DECL(64 - 1, 64 - 1, 192 - 1)));
     BoxArray grids(domain);
     grids.maxSize(max_grid_size);
-    //RealBox probDomain({AMREX_D_DECL(0,0,0)},{AMREX_D_DECL(1,1,1)});
-    //RealBox probDomain({AMREX_D_DECL(-0.0033,-0.0033,-0.0099)},{AMREX_D_DECL(0.0033,0.0033,.0099)});
-    RealBox probDomain({AMREX_D_DECL(0,0,0)},{AMREX_D_DECL(0.03,0.03,.09)});
-    
-    Array<int,AMREX_SPACEDIM> is_periodic = {AMREX_D_DECL(0,0,0)};
-    Geometry geom(domain,probDomain,0,is_periodic);
+    // RealBox probDomain({AMREX_D_DECL(0,0,0)},{AMREX_D_DECL(1,1,1)});
+    // RealBox
+    // probDomain({AMREX_D_DECL(-0.0033,-0.0033,-0.0099)},{AMREX_D_DECL(0.0033,0.0033,.0099)});
+    RealBox probDomain(
+      {AMREX_D_DECL(0, 0, 0)}, {AMREX_D_DECL(0.03, 0.03, .09)});
+
+    Array<int, AMREX_SPACEDIM> is_periodic = {AMREX_D_DECL(0, 0, 0)};
+    Geometry geom(domain, probDomain, 0, is_periodic);
     const Real* dx = geom.CellSize();
     const Real* plo = geom.ProbLo();
 
     Real dmax = dx[0];
-    pp.query("dmax",dmax);
+    pp.query("dmax", dmax);
     Print() << "dmax: " << dmax << std::endl;
-    int nGrow = int(dmax*(1.0000001) / dx[0]);
-    MultiFab distance(grids,DistributionMapping(grids),1,nGrow);
+    int nGrow = int(dmax * (1.0000001) / dx[0]);
+    MultiFab distance(grids, DistributionMapping(grids), 1, nGrow);
 
-    for (MFIter mfi(distance); mfi.isValid(); ++mfi)
-    {
+    for (MFIter mfi(distance); mfi.isValid(); ++mfi) {
       std::vector<Vec3f> vertList;
       std::vector<Vec3ui> faceList;
 
-      for (int node=0; node<nNodes; ++node) {
-        const IntVect iv(AMREX_D_DECL(node,0,0));
-        vertList.push_back(Vec3f(AMREX_D_DECL(nodes(iv,0),nodes(iv,1),nodes(iv,2))));
+      for (int node = 0; node < nNodes; ++node) {
+        const IntVect iv(AMREX_D_DECL(node, 0, 0));
+        vertList.push_back(
+          Vec3f(AMREX_D_DECL(nodes(iv, 0), nodes(iv, 1), nodes(iv, 2))));
       }
-      for (int elt=0; elt<nElts; ++elt) {
+      for (int elt = 0; elt < nElts; ++elt) {
         int offset = elt * nodesPerElt;
-        faceList.push_back(Vec3ui(AMREX_D_DECL(faceData[offset]-1,faceData[offset+1]-1,faceData[offset+2]-1)));
+        faceList.push_back(Vec3ui(AMREX_D_DECL(
+          faceData[offset] - 1, faceData[offset + 1] - 1,
+          faceData[offset + 2] - 1)));
       }
 
       const Box& vbox = distance[mfi].box();
-      Vec3f local_origin(plo[0] + vbox.smallEnd()[0]*dx[0],
-                         plo[1] + vbox.smallEnd()[1]*dx[1],
-                         plo[2] + vbox.smallEnd()[2]*dx[2]);
+      Vec3f local_origin(
+        plo[0] + vbox.smallEnd()[0] * dx[0],
+        plo[1] + vbox.smallEnd()[1] * dx[1],
+        plo[2] + vbox.smallEnd()[2] * dx[2]);
       Array3f phi_grid;
       float dx1 = float(dx[0]);
-      
-      make_level_set3(faceList, vertList, local_origin, dx1,
-                      vbox.length(0),vbox.length(1),vbox.length(2), phi_grid);
+
+      make_level_set3(
+        faceList, vertList, local_origin, dx1, vbox.length(0), vbox.length(1),
+        vbox.length(2), phi_grid);
 
       vertList.clear();
       faceList.clear();
@@ -153,22 +162,19 @@ main (int   argc,
       const auto& d = distance.array(mfi);
       const int* lo = vbox.loVect();
       const int* hi = vbox.hiVect();
-      for (int k=lo[2]; k<=hi[2]; ++k)
-      {
-        int kL=k-lo[2];
-        for (int j=lo[1]; j<=hi[1]; ++j)
-        {
-          int jL=j-lo[1];
-          for (int i=lo[0]; i<=hi[0]; ++i)
-          {
-            int iL=i-lo[0];
-            d(i,j,k) = phi_grid(iL,jL,kL);
+      for (int k = lo[2]; k <= hi[2]; ++k) {
+        int kL = k - lo[2];
+        for (int j = lo[1]; j <= hi[1]; ++j) {
+          int jL = j - lo[1];
+          for (int i = lo[0]; i <= hi[0]; ++i) {
+            int iL = i - lo[0];
+            d(i, j, k) = phi_grid(iL, jL, kL);
           }
         }
       }
     }
 
-    VisMF::Write(distance,"distance");
+    VisMF::Write(distance, "distance");
   }
   amrex::Finalize();
   return 0;

--- a/Src/checkIso.cpp
+++ b/Src/checkIso.cpp
@@ -9,52 +9,54 @@
 #include <AMReX_FillPatchUtil.H>
 
 using namespace amrex;
-using std::set;
-using std::vector;
-using std::string;
-using std::endl;
 using std::cerr;
+using std::endl;
+using std::set;
+using std::string;
+using std::vector;
 
-
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
   std::string line;
-  std::getline(is,line);
-  return Tokenize(line,std::string(", "));
+  std::getline(is, line);
+  return Tokenize(line, std::string(", "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
   std::string line;
-  std::getline(is,line);
+  std::getline(is, line);
   return line;
 }
 
 std::string
 getFileRoot(const std::string& infile)
 {
-  vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 struct Edge
 {
   Edge(int aL, int aR) noexcept : mL(aL), mR(aR) {}
-  int L() const noexcept {return mL;}
-  int R() const noexcept {return mR;}
-  Edge reverse() const noexcept {return Edge(mR,mL);}
+  int L() const noexcept { return mL; }
+  int R() const noexcept { return mR; }
+  Edge reverse() const noexcept { return Edge(mR, mL); }
+
 protected:
   int mL, mR;
 };
 
 struct Compare
 {
-  bool operator() (const Edge& L, const Edge& R) const noexcept {
-    int Lmin = std::min(L.L(),L.R());
-    int Lmax = std::max(L.L(),L.R());
-    int Rmin = std::min(R.L(),R.R());
-    int Rmax = std::max(R.L(),R.R());
+  bool operator()(const Edge& L, const Edge& R) const noexcept
+  {
+    int Lmin = std::min(L.L(), L.R());
+    int Lmax = std::max(L.L(), L.R());
+    int Rmin = std::min(R.L(), R.R());
+    int Rmax = std::max(R.L(), R.R());
     if (Lmin == Rmin) {
       return Lmax < Rmax;
     }
@@ -63,18 +65,18 @@ struct Compare
 };
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
   {
     ParmParse pp;
 
     // Read in isosurface
-    std::string isoFile; pp.get("isoFile",isoFile);
+    std::string isoFile;
+    pp.get("isoFile", isoFile);
     if (ParallelDescriptor::IOProcessor())
       std::cerr << "Reading isoFile... " << isoFile << std::endl;
-    
+
     Real strt_io = ParallelDescriptor::second();
 
     FArrayBox nodes;
@@ -83,9 +85,9 @@ main (int   argc,
     int nodesPerElt;
     int nNodes, nCompNodes;
     std::vector<std::string> surfNames;
-  
+
     std::ifstream ifs;
-    ifs.open(isoFile.c_str(),std::ios::in|std::ios::binary);
+    ifs.open(isoFile.c_str(), std::ios::in | std::ios::binary);
     const std::string title = parseTitle(ifs);
     surfNames = parseVarNames(ifs);
     nCompNodes = surfNames.size();
@@ -100,51 +102,55 @@ main (int   argc,
     tnodes.readFrom(ifs);
     nNodes = tnodes.box().numPts();
 
-    // transpose the data so that the components are 'in the right spot for fab data'
-    nodes.resize(tnodes.box(),nCompNodes);
+    // transpose the data so that the components are 'in the right spot for fab
+    // data'
+    nodes.resize(tnodes.box(), nCompNodes);
     Real** np = new Real*[nCompNodes];
-    for (int j=0; j<nCompNodes; ++j)
+    for (int j = 0; j < nCompNodes; ++j)
       np[j] = nodes.dataPtr(j);
 
     Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-      for (int j=0; j<nCompNodes; ++j)
-      {
+    for (int i = 0; i < nNodes; ++i) {
+      for (int j = 0; j < nCompNodes; ++j) {
         np[j][i] = ndat[j];
       }
       ndat += nCompNodes;
     }
-    delete [] np;
+    delete[] np;
     tnodes.clear();
 
-    faceData.resize(nElts*nodesPerElt,0);
-    ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
+    faceData.resize(nElts * nodesPerElt, 0);
+    ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
     ifs.close();
 
-    Print() << "Read " << nElts << " elements and " << nNodes << " nodes" << std::endl;
+    Print() << "Read " << nElts << " elements and " << nNodes << " nodes"
+            << std::endl;
 
-    set<Edge,Compare> edgeSet;
-    for (int elt=0; elt<nElts; ++elt) {
+    set<Edge, Compare> edgeSet;
+    for (int elt = 0; elt < nElts; ++elt) {
       int offset = elt * nodesPerElt;
 
-      Edge e1(faceData[offset+0],faceData[offset+1]);
-      std::pair<set<Edge,Compare>::const_iterator,bool> it1 = edgeSet.insert(e1);
+      Edge e1(faceData[offset + 0], faceData[offset + 1]);
+      std::pair<set<Edge, Compare>::const_iterator, bool> it1 =
+        edgeSet.insert(e1);
       if (!(it1.second)) {
-        AMREX_ALWAYS_ASSERT(edgeSet.find(e1.reverse())!=edgeSet.end());
+        AMREX_ALWAYS_ASSERT(edgeSet.find(e1.reverse()) != edgeSet.end());
       }
-      Edge e2(faceData[offset+1],faceData[offset+2]);
-      std::pair<set<Edge,Compare>::const_iterator,bool> it2 = edgeSet.insert(e2);
+      Edge e2(faceData[offset + 1], faceData[offset + 2]);
+      std::pair<set<Edge, Compare>::const_iterator, bool> it2 =
+        edgeSet.insert(e2);
       if (!(it2.second)) {
-        AMREX_ALWAYS_ASSERT(edgeSet.find(e2.reverse())!=edgeSet.end());
+        AMREX_ALWAYS_ASSERT(edgeSet.find(e2.reverse()) != edgeSet.end());
       }
-      Edge e3(faceData[offset+2],faceData[offset+0]);
-      std::pair<set<Edge,Compare>::const_iterator,bool> it3 = edgeSet.insert(e3);
+      Edge e3(faceData[offset + 2], faceData[offset + 0]);
+      std::pair<set<Edge, Compare>::const_iterator, bool> it3 =
+        edgeSet.insert(e3);
       if (!(it3.second)) {
-        AMREX_ALWAYS_ASSERT(edgeSet.find(e3.reverse())!=edgeSet.end());
+        AMREX_ALWAYS_ASSERT(edgeSet.find(e3.reverse()) != edgeSet.end());
       }
     }
-    Print() << "Found " << edgeSet.size() << " edges (nElts * 3 = " << nElts*3 << ")" << std::endl;
+    Print() << "Found " << edgeSet.size() << " edges (nElts * 3 = " << nElts * 3
+            << ")" << std::endl;
     Print() << "All shared edges are consistently numbered." << std::endl;
   }
   amrex::Finalize();

--- a/Src/combineMEF.cpp
+++ b/Src/combineMEF.cpp
@@ -12,264 +12,253 @@
 #include "DataServices.H"
 #include "Geometry.H"
 #include "Utility.H"
-using std::vector;
-using std::map;
-using std::string;
 using std::cerr;
-using std::endl;
 using std::cout;
+using std::endl;
+using std::map;
 using std::ofstream;
+using std::string;
+using std::vector;
 
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Array<int>&        faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label);
+void read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Array<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label);
 
-void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Array<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label);
+void write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label);
 
 vector<std::string>
-Tokenize (const std::string& instr, const std::string& separators)
+Tokenize(const std::string& instr, const std::string& separators)
 {
-    vector<char*> ptr;
-    //
-    // Make copy of line that we can modify.
-    //
-    char* line = new char[instr.size()+1];
+  vector<char*> ptr;
+  //
+  // Make copy of line that we can modify.
+  //
+  char* line = new char[instr.size() + 1];
 
-    (void) strcpy(line, instr.c_str());
+  (void)strcpy(line, instr.c_str());
 
-    char* token = 0;
+  char* token = 0;
 
-    if (!((token = strtok(line, separators.c_str())) == 0))
-    {
-        ptr.push_back(token);
-        while (!((token = strtok(0, separators.c_str())) == 0))
-            ptr.push_back(token);
-    }
+  if (!((token = strtok(line, separators.c_str())) == 0)) {
+    ptr.push_back(token);
+    while (!((token = strtok(0, separators.c_str())) == 0))
+      ptr.push_back(token);
+  }
 
-    vector<std::string> tokens(ptr.size());
+  vector<std::string> tokens(ptr.size());
 
-    for (int i = 1; i < ptr.size(); i++)
-    {
-        char* p = ptr[i];
+  for (int i = 1; i < ptr.size(); i++) {
+    char* p = ptr[i];
 
-        while (strchr(separators.c_str(), *(p-1)) != 0)
-            *--p = 0;
-    }
+    while (strchr(separators.c_str(), *(p - 1)) != 0)
+      *--p = 0;
+  }
 
-    for (int i = 0; i < ptr.size(); i++)
-        tokens[i] = ptr[i];
+  for (int i = 0; i < ptr.size(); i++)
+    tokens[i] = ptr[i];
 
-    delete line;
+  delete line;
 
-    return tokens;
+  return tokens;
 }
 
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return Tokenize(line,std::string(", "));
+  std::string line;
+  std::getline(is, line);
+  return Tokenize(line, std::string(", "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return line;
+  std::string line;
+  std::getline(is, line);
+  return line;
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    BoxLib::Initialize(argc,argv);
-    {
+  BoxLib::Initialize(argc, argv);
+  {
     ParmParse pp;
 
-    string infileL; pp.get("infileL",infileL);
-    string infileR; pp.get("infileR",infileR);
-    string outfile; pp.get("outfile",outfile);
+    string infileL;
+    pp.get("infileL", infileL);
+    string infileR;
+    pp.get("infileR", infileR);
+    string outfile;
+    pp.get("outfile", outfile);
 
-    int nEltsL,nEltsR;
-    FArrayBox nodesL,nodesR;
-    Array<int> faceDataL,faceDataR;
-    vector<string> namesL,namesR;
-    string labelL,labelR;
-    read_iso(infileL,nodesL,faceDataL,nEltsL,namesL,labelL);
-    read_iso(infileR,nodesR,faceDataR,nEltsR,namesR,labelR);
+    int nEltsL, nEltsR;
+    FArrayBox nodesL, nodesR;
+    Array<int> faceDataL, faceDataR;
+    vector<string> namesL, namesR;
+    string labelL, labelR;
+    read_iso(infileL, nodesL, faceDataL, nEltsL, namesL, labelL);
+    read_iso(infileR, nodesR, faceDataR, nEltsR, namesR, labelR);
     int nodesPerElt = faceDataL.size() / nEltsL;
-    AMREX_ASSERT(nodesPerElt*nElts == faceData.size());
+    AMREX_ASSERT(nodesPerElt * nElts == faceData.size());
 
     nEltsL = faceDataL.size() / nodesPerElt;
     nEltsR = faceDataR.size() / nodesPerElt;
 
-    if (nEltsL != nEltsR)
-    {
-        BoxLib::Abort("MEF files not compible");
+    if (nEltsL != nEltsR) {
+      BoxLib::Abort("MEF files not compible");
     }
 
     int nCompMEFL = nodesL.nComp();
-    AMREX_ASSERT(nEltsL*nodesPerElt == faceDataL.size());
+    AMREX_ASSERT(nEltsL * nodesPerElt == faceDataL.size());
     int nCompMEFR = nodesR.nComp();
-    AMREX_ASSERT(nEltsR*nodesPerElt == faceDataR.size());
+    AMREX_ASSERT(nEltsR * nodesPerElt == faceDataR.size());
 
     Array<int> compsL;
     int nCompL = pp.countval("compsL");
-    if (nCompL>0)
-    {
-        compsL.resize(nCompL);
-        pp.getarr("compsL",compsL,0,nCompL);
-    }
-    else
-    {
-        int sCompL = 0;
-        pp.query("sCompL",sCompL);
-        nCompL = namesL.size();
-        pp.query("nCompL",nCompL);
-        AMREX_ASSERT(sCompL+nCompL <= nCompMEFL);
-        compsL.resize(nCompL);
-        for (int i=0; i<nCompL; ++i)
-            compsL[i] = sCompL + i;
+    if (nCompL > 0) {
+      compsL.resize(nCompL);
+      pp.getarr("compsL", compsL, 0, nCompL);
+    } else {
+      int sCompL = 0;
+      pp.query("sCompL", sCompL);
+      nCompL = namesL.size();
+      pp.query("nCompL", nCompL);
+      AMREX_ASSERT(sCompL + nCompL <= nCompMEFL);
+      compsL.resize(nCompL);
+      for (int i = 0; i < nCompL; ++i)
+        compsL[i] = sCompL + i;
     }
 
     Array<int> compsR;
-    int nCompR=pp.countval("compsR");
-    if (nCompR > 0)
-    {
-        compsR.resize(nCompR);
-        pp.getarr("compsR",compsR,0,nCompR);
-    }
-    else
-    {
-        int sCompR = 0;
-        pp.query("sCompR",sCompR);
-        nCompR = namesR.size();
-        pp.query("nCompR",nCompR);
-        AMREX_ASSERT(sCompR+nCompR <= nCompMEFR);
-        compsR.resize(nCompR);
-        for (int i=0; i<nCompR; ++i)
-            compsR[i] = sCompR + i;
+    int nCompR = pp.countval("compsR");
+    if (nCompR > 0) {
+      compsR.resize(nCompR);
+      pp.getarr("compsR", compsR, 0, nCompR);
+    } else {
+      int sCompR = 0;
+      pp.query("sCompR", sCompR);
+      nCompR = namesR.size();
+      pp.query("nCompR", nCompR);
+      AMREX_ASSERT(sCompR + nCompR <= nCompMEFR);
+      compsR.resize(nCompR);
+      for (int i = 0; i < nCompR; ++i)
+        compsR[i] = sCompR + i;
     }
 
-    int nCompOut = compsL.size()+compsR.size();
-    FArrayBox nodesOut(nodesL.box(),nCompOut);
+    int nCompOut = compsL.size() + compsR.size();
+    FArrayBox nodesOut(nodesL.box(), nCompOut);
     vector<string> namesOut(nCompOut);
-    for (int i=0; i<compsL.size(); ++i)
-    {
-        std::cout << "(L): " << namesL[compsL[i]] << std::endl;
-        namesOut[i] = namesL[compsL[i]];
-        nodesOut.copy(nodesL,compsL[i],i,1);
+    for (int i = 0; i < compsL.size(); ++i) {
+      std::cout << "(L): " << namesL[compsL[i]] << std::endl;
+      namesOut[i] = namesL[compsL[i]];
+      nodesOut.copy(nodesL, compsL[i], i, 1);
     }
-    for (int i=0; i<compsR.size(); ++i)
-    {
-        std::cout << "(R): " << namesR[compsR[i]] << std::endl;
-        namesOut[compsL.size()+i] = namesR[compsR[i]];
-        nodesOut.copy(nodesR,compsR[i],compsL.size()+i,1);
+    for (int i = 0; i < compsR.size(); ++i) {
+      std::cout << "(R): " << namesR[compsR[i]] << std::endl;
+      namesOut[compsL.size() + i] = namesR[compsR[i]];
+      nodesOut.copy(nodesR, compsR[i], compsL.size() + i, 1);
     }
 
-    write_iso(outfile,nodesOut,faceDataL,nEltsL,namesOut,labelL);
-    }
-    BoxLib::Finalize();
-    return 0;
+    write_iso(outfile, nodesOut, faceDataL, nEltsL, namesOut, labelL);
+  }
+  BoxLib::Finalize();
+  return 0;
 }
 
 void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Array<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label)
+write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label)
 {
-    // Rotate data to vary quickest on component
-    int nCompSurf = nodes.nComp();
-    int nNodes = nodes.box().numPts();
+  // Rotate data to vary quickest on component
+  int nCompSurf = nodes.nComp();
+  int nNodes = nodes.box().numPts();
 
-    FArrayBox tnodes(nodes.box(),nCompSurf);
-    const Real** np = new const Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            ndat[j] = np[j][i];
-        }
-        ndat += nCompSurf;
+  FArrayBox tnodes(nodes.box(), nCompSurf);
+  const Real** np = new const Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      ndat[j] = np[j][i];
     }
-    delete [] np;
+    ndat += nCompSurf;
+  }
+  delete[] np;
 
-    std::ofstream ofs;
-    ofs.open(outfile.c_str(),std::ios::out|std::ios::trunc|std::ios::binary);
-    ofs << label << endl;
-    for (int i=0; i<nCompSurf; ++i)
-    {
-        ofs << names[i];
-        if (i < nCompSurf-1)
-            ofs << " ";
-        else
-            ofs << std::endl;
-    }
-    int nodesPerElt = faceData.size() / nElts;
-    ofs << nElts << " " << nodesPerElt << endl;
-    tnodes.writeOn(ofs);
-    ofs.write((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-    ofs.close();
+  std::ofstream ofs;
+  ofs.open(outfile.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
+  ofs << label << endl;
+  for (int i = 0; i < nCompSurf; ++i) {
+    ofs << names[i];
+    if (i < nCompSurf - 1)
+      ofs << " ";
+    else
+      ofs << std::endl;
+  }
+  int nodesPerElt = faceData.size() / nElts;
+  ofs << nElts << " " << nodesPerElt << endl;
+  tnodes.writeOn(ofs);
+  ofs.write((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
+  ofs.close();
 }
 
 void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Array<int>&        faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label)
+read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Array<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label)
 {
-    std::ifstream ifs;
-    ifs.open(infile.c_str(),std::ios::in|std::ios::binary);
-    label = parseTitle(ifs);
-    names = parseVarNames(ifs);
-    const int nCompSurf = names.size();
+  std::ifstream ifs;
+  ifs.open(infile.c_str(), std::ios::in | std::ios::binary);
+  label = parseTitle(ifs);
+  names = parseVarNames(ifs);
+  const int nCompSurf = names.size();
 
-    int nodesPerElt;
-    ifs >> nElts;
-    ifs >> nodesPerElt;
+  int nodesPerElt;
+  ifs >> nElts;
+  ifs >> nodesPerElt;
 
-    FArrayBox tnodes;
-    tnodes.readFrom(ifs);
-    const int nNodes = tnodes.box().numPts();
+  FArrayBox tnodes;
+  tnodes.readFrom(ifs);
+  const int nNodes = tnodes.box().numPts();
 
-    // "rotate" the data so that the components are 'in the right spot for fab data'
-    nodes.resize(tnodes.box(),nCompSurf);
-    Real** np = new Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
+  // "rotate" the data so that the components are 'in the right spot for fab
+  // data'
+  nodes.resize(tnodes.box(), nCompSurf);
+  Real** np = new Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
 
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            np[j][i] = ndat[j];
-        }
-        ndat += nCompSurf;
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      np[j][i] = ndat[j];
     }
-    delete [] np;
-    tnodes.clear();
+    ndat += nCompSurf;
+  }
+  delete[] np;
+  tnodes.clear();
 
-    faceData.resize(nElts*nodesPerElt,0);
-    ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
+  faceData.resize(nElts * nodesPerElt, 0);
+  ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
 }
-

--- a/Src/combinePlts.cpp
+++ b/Src/combinePlts.cpp
@@ -9,141 +9,153 @@
 
 using namespace amrex;
 
-static void print_usage (int, char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
-  std::cerr << argv[0] << " infiles=<> outfile=<> vars=<>" ;
+  std::cerr << argv[0] << " infiles=<> outfile=<> vars=<>";
   exit(1);
 }
 
-int main (int argc, char* argv[])
+int
+main(int argc, char* argv[])
 {
-  amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
 
   if (argc < 2)
-    print_usage(argc,argv);
-  
+    print_usage(argc, argv);
+
   ParmParse pp;
 
   // get infile names and count
   int nfiles(pp.countval("infiles"));
-  Vector<std::string> infiles; infiles.resize(nfiles);
-  pp.getarr("infiles",infiles);
-  
+  Vector<std::string> infiles;
+  infiles.resize(nfiles);
+  pp.getarr("infiles", infiles);
+
   // get and count variables to copy
   int nvars(pp.countval("vars"));
   int id_comp_last = 0;
-  Vector<std::string> vars; vars.resize(nvars);
-  pp.getarr("vars",vars);  
+  Vector<std::string> vars;
+  vars.resize(nvars);
+  pp.getarr("vars", vars);
   Vector<std::string> new_vars = vars;
   Vector<std::string> names;
-  
+
   // outfile name
   std::string outfile;
-  pp.get("outfile",outfile);
-  
+  pp.get("outfile", outfile);
+
   DataServices::SetBatchMode();
   Amrvis::FileType fileType(Amrvis::NEWPLT);
-  
-    // setting up reading for pltfile
+
+  // setting up reading for pltfile
   DataServices dataServices0(infiles[0], fileType);
-  
+
   // check if plotfile is good
   if (!dataServices0.AmrDataOk())
     DataServices::Dispatch(DataServices::ExitRequest, NULL);
-  
+
   AmrData& amrData0 = dataServices0.AmrDataRef();
-  
+
   // getting the finest level (or whatever user sets)
   int finestLevel = -1;
   finestLevel = amrData0.FinestLevel();
-  pp.query("finestLevel",finestLevel);
+  pp.query("finestLevel", finestLevel);
   int Nlev = finestLevel + 1;
 
   // setting up periodicity
-  Vector<int> is_per(AMREX_SPACEDIM,1);
-  pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+  Vector<int> is_per(AMREX_SPACEDIM, 1);
+  pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
   Print() << "Periodicity assumed for this case: ";
   for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
     Print() << is_per[idim] << " ";
   }
   Print() << "\n";
-  
+
   // setting up pltfile boxes
-  RealBox rb(&(amrData0.ProbLo()[0]), 
-	     &(amrData0.ProbHi()[0]));
+  RealBox rb(&(amrData0.ProbLo()[0]), &(amrData0.ProbHi()[0]));
   Vector<MultiFab*> fileData(Nlev);
   Vector<Geometry> geoms(Nlev);
   int coord = 0;
-  for (int lev=0; lev<Nlev; ++lev)
-    {
-      const DistributionMapping dm(amrData0.boxArray(lev));
-      geoms[lev] = Geometry(amrData0.ProbDomain()[lev],&rb,coord,&(is_per[0]));
-      fileData[lev] = new MultiFab(amrData0.boxArray(lev),dm,nvars,0);
-    }
-  
+  for (int lev = 0; lev < Nlev; ++lev) {
+    const DistributionMapping dm(amrData0.boxArray(lev));
+    geoms[lev] = Geometry(amrData0.ProbDomain()[lev], &rb, coord, &(is_per[0]));
+    fileData[lev] = new MultiFab(amrData0.boxArray(lev), dm, nvars, 0);
+  }
+
   // loop over all files
   for (int iFile = 0; iFile < nfiles; iFile++) {
     Print() << "Loading plotfile: " << infiles[iFile] << std::endl;
-    
+
     // set up for reading pltfile
     DataServices dataServices(infiles[iFile], fileType);
-    
+
     // check if file is okay
     if (!dataServices.AmrDataOk())
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
-    
+
     AmrData& amrData = dataServices.AmrDataRef();
-    
+
     // check if finest level is all the same
     int usrfinestLevel = -1;
-    pp.query("finestLevel",usrfinestLevel);
-    if (amrData.FinestLevel() != amrData0.FinestLevel() && usrfinestLevel != -1) {
+    pp.query("finestLevel", usrfinestLevel);
+    if (
+      amrData.FinestLevel() != amrData0.FinestLevel() && usrfinestLevel != -1) {
       Print() << "Warning, finest levels for all pltfiles are not the same \n";
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
 
     const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    
+
     Vector<int> idcomp;
-    for (int i = 0; i < plotVarNames.size(); ++i) {  // loop though current pltfile variable names
-      for (int j = 0; j < new_vars.size(); ++j) {   // loop though remaining search variable names
-	if (plotVarNames[i] == new_vars[j]) {       // if search name = current pltfile variable name
-	  idcomp.push_back(i);                       // sets index location of plotVarName that matches
-	  new_vars.erase(new_vars.begin() + j);    // delets search variable name so we do not get repeats
-	}
+    for (int i = 0; i < plotVarNames.size();
+         ++i) { // loop though current pltfile variable names
+      for (int j = 0; j < new_vars.size();
+           ++j) { // loop though remaining search variable names
+        if (plotVarNames[i] == new_vars[j]) { // if search name = current
+                                              // pltfile variable name
+          idcomp.push_back(
+            i); // sets index location of plotVarName that matches
+          new_vars.erase(
+            new_vars.begin() +
+            j); // delets search variable name so we do not get repeats
+        }
       }
     }
-    
+
     // copys data
-    if (idcomp.size() > 0) {   // makes sure there a variable we want to copy
-      for (int lev=0; lev<Nlev; ++lev) {
-	for (int i=0; i<idcomp.size(); ++i) {
-	  fileData[lev]->ParallelCopy(amrData.GetGrids(lev,idcomp[i]),0,id_comp_last+i,1);	    
-	}
+    if (idcomp.size() > 0) { // makes sure there a variable we want to copy
+      for (int lev = 0; lev < Nlev; ++lev) {
+        for (int i = 0; i < idcomp.size(); ++i) {
+          fileData[lev]->ParallelCopy(
+            amrData.GetGrids(lev, idcomp[i]), 0, id_comp_last + i, 1);
+        }
       }
       // set the correct name with the correct location
-      for (int i=0; i<idcomp.size(); ++i)
-	names.push_back(plotVarNames[idcomp[i]]);
+      for (int i = 0; i < idcomp.size(); ++i)
+        names.push_back(plotVarNames[idcomp[i]]);
     }
-    
+
     // updates ids of comps
     id_comp_last += idcomp.size();
     idcomp.clear();
   }
-  
+
   if (new_vars.size() > 0) {
     Print() << "Error the following comps were not found: \n";
     for (int i = 0; i < new_vars.size(); ++i)
       Print() << new_vars[i] << std::endl;
-    DataServices::Dispatch(DataServices::ExitRequest, NULL);	      
+    DataServices::Dispatch(DataServices::ExitRequest, NULL);
   }
-  
+
   // write pltfile
   Vector<int> isteps(Nlev, 0);
-  Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-  amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(fileData), names, geoms, 0.0, isteps, refRatios);
-  
+  Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+  amrex::WriteMultiLevelPlotfile(
+    outfile, Nlev, GetVecOfConstPtrs(fileData), names, geoms, 0.0, isteps,
+    refRatios);
+
   amrex::Finalize();
   return 0;
 }

--- a/Src/conditionalMean.cpp
+++ b/Src/conditionalMean.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <iostream>
-using std::cout;
 using std::cerr;
+using std::cout;
 using std::endl;
 
 #include <AMReX_ParmParse.H>
@@ -10,397 +10,388 @@ using std::endl;
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
-    std::cerr << "usage:\n";
-    std::cerr << argv[0] << " infile=<filename>\n"
-	      << "   binComp=i            : Variable id number to condition on\n"
-	      << "   AvgComps=j k l       : Variable id numbers to average\n"
-	      << "   min=m;  max=m        : min/max values for bins%i\n"
-              << "   nBins=n              : Number of bins in PDF (default=64)\n"
-	      << "   finestLevel=n        : Finest level at which to evaluate PDF\n"
-	      << "   outSuffix=str        : Suffix to add to the pltfile name as an alt dir for results (default="")\n"
-	      << "   aja=true/false       : Put the header in a separate file for gnuplot/matlab (default=false)\n"
-              << "   infile= plt1 plt2    : List of plot files" << std::endl;
-    exit(1);
+  std::cerr << "usage:\n";
+  std::cerr
+    << argv[0] << " infile=<filename>\n"
+    << "   binComp=i            : Variable id number to condition on\n"
+    << "   AvgComps=j k l       : Variable id numbers to average\n"
+    << "   min=m;  max=m        : min/max values for bins%i\n"
+    << "   nBins=n              : Number of bins in PDF (default=64)\n"
+    << "   finestLevel=n        : Finest level at which to evaluate PDF\n"
+    << "   outSuffix=str        : Suffix to add to the pltfile name as an alt "
+       "dir for results (default="
+       ")\n"
+    << "   aja=true/false       : Put the header in a separate file for "
+       "gnuplot/matlab (default=false)\n"
+    << "   infile= plt1 plt2    : List of plot files" << std::endl;
+  exit(1);
 }
 
 typedef BaseFab<int> IntFab;
 typedef FabArray<IntFab> IntMF;
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
 
-    if (argc < 2)
-        print_usage(argc,argv);
+  if (argc < 2)
+    print_usage(argc, argv);
 
-    ParmParse pp;
+  ParmParse pp;
 
-    if (pp.contains("help"))
-        print_usage(argc,argv);
+  if (pp.contains("help"))
+    print_usage(argc, argv);
 
-    bool isioproc = ParallelDescriptor::IOProcessor();
-    int ioproc = ParallelDescriptor::IOProcessorNumber();
-    int verbose=0; pp.query("verbose",verbose);
-    if ( !(isioproc) )
-        verbose=0;
+  bool isioproc = ParallelDescriptor::IOProcessor();
+  int ioproc = ParallelDescriptor::IOProcessorNumber();
+  int verbose = 0;
+  pp.query("verbose", verbose);
+  if (!(isioproc))
+    verbose = 0;
 
-    if (verbose>1)
-        AmrData::SetVerbose(true);
+  if (verbose > 1)
+    AmrData::SetVerbose(true);
 
-    // Get plot file
-    int nPlotFiles(pp.countval("infile"));
-    if(nPlotFiles <= 0) {
-        std::cerr << "Bad nPlotFiles:  " << nPlotFiles << std::endl;
-        std::cerr << "Exiting." << std::endl;
-        DataServices::Dispatch(DataServices::ExitRequest, NULL);
-    }
+  // Get plot file
+  int nPlotFiles(pp.countval("infile"));
+  if (nPlotFiles <= 0) {
+    std::cerr << "Bad nPlotFiles:  " << nPlotFiles << std::endl;
+    std::cerr << "Exiting." << std::endl;
+    DataServices::Dispatch(DataServices::ExitRequest, NULL);
+  }
+  if (verbose)
+    std::cout << "Processing " << nPlotFiles << " plotfiles..." << std::endl;
+
+  std::string outSuffix = "";
+  pp.query("outSuffix", outSuffix);
+
+  // Make an array of srings containing paths of input plot files
+  Vector<std::string> plotFileNames(nPlotFiles);
+  for (int iPlot = 0; iPlot < nPlotFiles; ++iPlot) {
+    pp.get("infile", plotFileNames[iPlot], iPlot);
     if (verbose)
-        std::cout << "Processing " << nPlotFiles << " plotfiles..." << std::endl;
+      std::cout << "   " << plotFileNames[iPlot] << std::endl;
+  }
 
-    std::string outSuffix = ""; pp.query("outSuffix",outSuffix);
+  // Get finest level argument
+  int finestLevel(-1);
+  pp.query("finestLevel", finestLevel);
 
-    // Make an array of srings containing paths of input plot files
-    Vector<std::string> plotFileNames(nPlotFiles);
-    for(int iPlot = 0; iPlot < nPlotFiles; ++iPlot) {
-        pp.get("infile", plotFileNames[iPlot], iPlot);
-        if (verbose)
-            std::cout << "   " << plotFileNames[iPlot] << std::endl;
+  // Number of bins
+  int nBins(64);
+  pp.query("nBins", nBins);
+
+  // Variables to bin, and to average
+  int binComp = -1;
+  pp.get("binComp", binComp);
+  int nAvgComps = pp.countval("avgComps");
+  Vector<int> avgComps;
+  if (nAvgComps > 0) {
+    avgComps.resize(nAvgComps);
+    pp.getarr("avgComps", avgComps, 0, nAvgComps);
+  } else {
+    amrex::Abort("need to specify avgComps");
+  }
+  Vector<Real> binVals(nBins * nAvgComps, 0);
+  Vector<Real> binValsSq(nBins * nAvgComps, 0);
+  bool writeBinMinMax = false;
+  pp.query("writeBinMinMax", writeBinMinMax);
+  Vector<Real> binMinVals;
+  Vector<Real> binMaxVals;
+  Vector<int> binHits(nBins, 0);
+  if (writeBinMinMax) {
+    binMinVals.resize(nBins * nAvgComps, 0);
+    binMaxVals.resize(nBins * nAvgComps, 0);
+  }
+
+  Real binMin = 0;
+  pp.get("binMin", binMin);
+  Real binMax = 1;
+  pp.get("binMax", binMax);
+  if (binMax <= binMin)
+    amrex::Abort("Bad bin min,max");
+
+  bool floor = false;
+  pp.query("floor", floor);
+  bool ceiling = false;
+  pp.query("ceiling", ceiling);
+
+  Real domainVol = -1;
+  Vector<int> weights;
+  Vector<std::string> compNames;
+  Vector<int> destFillComps(avgComps.size() + 1);
+  for (int i = 0; i < destFillComps.size(); ++i)
+    destFillComps[i] = i + 1; // zero slot for mask
+  int nComp = destFillComps.size() + 1;
+
+  Vector<Real> dataIV(nComp);
+
+  Vector<Real> bbll, bbur;
+  if (int nx = pp.countval("bounds")) {
+    Vector<Real> barr;
+    pp.getarr("bounds", barr, 0, nx);
+    int d = AMREX_SPACEDIM;
+    AMREX_ASSERT(barr.size() == 2 * d);
+    bbll.resize(d);
+    bbur.resize(d);
+    for (int i = 0; i < d; ++i) {
+      bbll[i] = barr[i];
+      bbur[i] = barr[d + i];
     }
+  }
 
-    // Get finest level argument
-    int finestLevel(-1);
-    pp.query("finestLevel",finestLevel);
+  bool aja(false);
+  pp.query("aja", aja);
+  if (aja && isioproc)
+    std::cout << "Output for aja" << std::endl;
 
-    // Number of bins
-    int nBins(64); pp.query("nBins",nBins);
+  // Loop over files
+  for (int iPlot = 0; iPlot < nPlotFiles; iPlot++) {
+    // Open file and get an amrData pointer
+    const std::string& infile = plotFileNames[iPlot];
+    if (verbose)
+      std::cout << "\nOpening " << infile << "..." << std::endl;
+    DataServices::SetBatchMode();
+    Amrvis::FileType fileType(Amrvis::NEWPLT);
+    DataServices dataServices(infile, fileType);
+    if (!dataServices.AmrDataOk())
+      DataServices::Dispatch(DataServices::ExitRequest, NULL);
 
-    // Variables to bin, and to average
-    int binComp = -1; pp.get("binComp",binComp);
-    int nAvgComps = pp.countval("avgComps");
-    Vector<int> avgComps;
-    if (nAvgComps > 0)
-    {
-        avgComps.resize(nAvgComps);
-        pp.getarr("avgComps",avgComps,0,nAvgComps);
-    }
-    else
-    {
-        amrex::Abort("need to specify avgComps");
-    }
-    Vector<Real>    binVals(nBins*nAvgComps,0);
-    Vector<Real>  binValsSq(nBins*nAvgComps,0);
-    bool writeBinMinMax = false; pp.query("writeBinMinMax",writeBinMinMax);
-    Vector<Real> binMinVals;
-    Vector<Real> binMaxVals;
-    Vector<int>  binHits(nBins,0);
-    if (writeBinMinMax)
-    {
-        binMinVals.resize(nBins*nAvgComps,0);
-        binMaxVals.resize(nBins*nAvgComps,0);
-    }
-    
-    Real binMin=0; pp.get("binMin",binMin);
-    Real binMax=1; pp.get("binMax",binMax);
-    if (binMax <= binMin)
-        amrex::Abort("Bad bin min,max");
+    AmrData& amrData = dataServices.AmrDataRef();
+    int ngrow = 0;
 
+    Box domain;
+    if (iPlot == 0) {
+      compNames.resize(avgComps.size() + 1);
+      compNames[0] = amrData.PlotVarNames()[binComp];
+      for (int i = 0; i < avgComps.size(); ++i) {
+        int comp = avgComps[i];
+        if (comp < 0 || comp >= amrData.NComp())
+          amrex::Abort("Bad comp: " + comp);
+        compNames[i + 1] = amrData.PlotVarNames()[comp];
+      }
 
-    bool floor=false; pp.query("floor",floor);
-    bool ceiling=false; pp.query("ceiling",ceiling);
-    
-    Real domainVol = -1;
-    Vector<int> weights;
-    Vector<std::string> compNames;
-    Vector<int> destFillComps(avgComps.size()+1);
-    for (int i=0; i<destFillComps.size(); ++i)
-        destFillComps[i] = i+1;// zero slot for mask
-    int nComp = destFillComps.size() + 1;
-    
-    Vector<Real> dataIV(nComp);
+      domain = amrData.ProbDomain()[0];
 
-    Vector<Real> bbll,bbur;
-    if (int nx=pp.countval("bounds"))
-    {
-        Vector<Real> barr;
-        pp.getarr("bounds",barr,0,nx);
-        int d=AMREX_SPACEDIM;
-        AMREX_ASSERT(barr.size()==2*d);
-        bbll.resize(d);
-        bbur.resize(d);
-        for (int i=0; i<d; ++i)
-        {
-            bbll[i] = barr[i];
-            bbur[i] = barr[d+i];
+      if (bbll.size() == AMREX_SPACEDIM && bbur.size() == AMREX_SPACEDIM) {
+        // Find coarse-grid coordinates of bounding box, round outwardly
+        for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+          const Real dx =
+            amrData.ProbSize()[i] / amrData.ProbDomain()[0].length(i);
+          domain.setSmall(
+            i, std::max(
+                 domain.smallEnd()[i],
+                 (int)((bbll[i] - amrData.ProbLo()[i] + .0001 * dx) / dx)));
+          domain.setBig(
+            i, std::min(
+                 domain.bigEnd()[i],
+                 (int)((bbur[i] - amrData.ProbLo()[i] - .0001 * dx) / dx)));
         }
+      }
+      domainVol = domain.d_numPts();
+
+      if (finestLevel < 0)
+        finestLevel = amrData.FinestLevel();
+
+      weights.resize(finestLevel + 1, 1);
+      for (int i = finestLevel - 1; i >= 0; --i) {
+        int rat = amrData.RefRatio()[i];
+        weights[i] = weights[i + 1];
+        for (int d = 0; d < AMREX_SPACEDIM; ++d)
+          weights[i] *= rat;
+      }
     }
 
-    bool aja(false);
-    pp.query("aja",aja);
-    if (aja && isioproc)
-	std::cout << "Output for aja" << std::endl;
+    // Build boxarrays for fillvar call
+    Box levelDomain = domain;
+    int thisFinestLevel = std::min(finestLevel, amrData.FinestLevel());
+    int Nlevels = thisFinestLevel + 1;
+    Vector<BoxArray> bas(Nlevels);
+    for (int iLevel = 0; iLevel <= thisFinestLevel; ++iLevel) {
+      BoxArray baThisLev =
+        amrex::intersect(amrData.boxArray(iLevel), levelDomain);
+      BoxList blThisLev(baThisLev);
+      blThisLev.simplify();
+      blThisLev.simplify();
+      baThisLev = BoxArray(blThisLev);
 
-    // Loop over files
-    for (int iPlot=0; iPlot<nPlotFiles; iPlot++)
-    {
-        // Open file and get an amrData pointer
-        const std::string& infile = plotFileNames[iPlot];
-        if (verbose)
-            std::cout << "\nOpening " << infile << "..." << std::endl;
-        DataServices::SetBatchMode();
-        Amrvis::FileType fileType(Amrvis::NEWPLT);
-        DataServices dataServices(infile, fileType);
-        if (!dataServices.AmrDataOk())
-            DataServices::Dispatch(DataServices::ExitRequest, NULL);
-
-        AmrData& amrData = dataServices.AmrDataRef();
-        int ngrow = 0;
-
-        Box domain;
-        if (iPlot==0)
-        {
-            compNames.resize(avgComps.size()+1);
-            compNames[0] = amrData.PlotVarNames()[binComp];
-            for (int i=0; i<avgComps.size(); ++i)
-            {
-                int comp = avgComps[i];
-                if (comp<0 || comp>=amrData.NComp())
-                    amrex::Abort("Bad comp: " + comp);
-                compNames[i+1] = amrData.PlotVarNames()[comp];
-            }
-
-            domain = amrData.ProbDomain()[0];
-
-            if (bbll.size()==AMREX_SPACEDIM  && bbur.size()==AMREX_SPACEDIM)
-            {
-                // Find coarse-grid coordinates of bounding box, round outwardly
-                for (int i=0; i<AMREX_SPACEDIM; ++i) {
-                    const Real dx = amrData.ProbSize()[i] / amrData.ProbDomain()[0].length(i);
-                    domain.setSmall(i,
-                                    std::max(domain.smallEnd()[i],
-                                             (int)((bbll[i]-amrData.ProbLo()[i]+.0001*dx)/dx)));
-                    domain.setBig(i,
-                                  std::min(domain.bigEnd()[i],
-                                           (int)((bbur[i]-amrData.ProbLo()[i]-.0001*dx)/dx)));
-                }
-            }
-            domainVol = domain.d_numPts();
-
-            if (finestLevel<0)
-                finestLevel = amrData.FinestLevel();
-
-            weights.resize(finestLevel+1,1);
-            for (int i=finestLevel-1; i>=0; --i)
-            {
-                int rat = amrData.RefRatio()[i];
-                weights[i] = weights[i+1];
-                for (int d=0; d<AMREX_SPACEDIM; ++d)
-                    weights[i] *= rat;
-            }
+      if (baThisLev.size() > 0) {
+        // bas.set(iLevel,baThisLev);
+        bas[iLevel] = baThisLev;
+        bas[iLevel].maxSize(32);
+        if (iLevel < thisFinestLevel) {
+          levelDomain.refine(amrData.RefRatio()[iLevel]);
         }
-        
-        // Build boxarrays for fillvar call
-        Box levelDomain = domain;
-        int thisFinestLevel = std::min(finestLevel,amrData.FinestLevel());
-        int Nlevels = thisFinestLevel+1;
-        Vector<BoxArray> bas(Nlevels);
-        for (int iLevel=0; iLevel<=thisFinestLevel; ++iLevel)
-        {
-            BoxArray baThisLev = amrex::intersect(amrData.boxArray(iLevel),levelDomain);
-            BoxList blThisLev(baThisLev);
-            blThisLev.simplify();
-            blThisLev.simplify();
-            baThisLev = BoxArray(blThisLev);
-            
-            if (baThisLev.size() > 0) {
-	        //bas.set(iLevel,baThisLev);
-		bas[iLevel] = baThisLev;
-		bas[iLevel].maxSize(32);
-                if (iLevel < thisFinestLevel) {
-                    levelDomain.refine(amrData.RefRatio()[iLevel]);
-                }
-            }
-            else
-            {
-                bas.resize(iLevel);
-            }
+      } else {
+        bas.resize(iLevel);
+      }
+    }
+
+    int ratio = 1;
+    for (int iLevel = 0; iLevel <= thisFinestLevel; ++iLevel) {
+      if (bas.size() > iLevel) {
+        DistributionMapping dmap(bas[iLevel]);
+        MultiFab mf(bas[iLevel], dmap, nComp, ngrow);
+        amrData.FillVar(mf, iLevel, compNames, destFillComps);
+        mf.setVal(1, 0, 1); // initlaize mask to value
+
+        // zero out covered data
+        if (iLevel < thisFinestLevel) {
+          ratio = amrData.RefRatio()[iLevel];
+          BoxArray baf = BoxArray(bas[iLevel + 1]).coarsen(ratio);
+          for (MFIter mfi(mf); mfi.isValid(); ++mfi) {
+            const Box& box = mfi.validbox();
+            FArrayBox& fab = mf[mfi];
+            std::vector<std::pair<int, Box>> isects = baf.intersections(box);
+            for (int ii = 0; ii < isects.size(); ii++)
+              fab.setVal(0, isects[ii].second, 0, 1);
+          }
         }
 
-        int ratio = 1;
-        for (int iLevel=0; iLevel<=thisFinestLevel; ++iLevel)
-        {
-            if (bas.size()>iLevel)
+        for (MFIter mfi(mf); mfi.isValid(); ++mfi) {
+          FArrayBox& fab = mf[mfi];
+          const Box& box = mfi.validbox();
+          for (IntVect iv = box.smallEnd(); iv <= box.bigEnd(); box.next(iv)) {
+            fab.getVal(dataIV.dataPtr(), iv);
+            if (dataIV[0] != 0) // not covered
             {
-                DistributionMapping dmap(bas[iLevel]);
-                MultiFab mf(bas[iLevel], dmap, nComp, ngrow);
-                amrData.FillVar(mf, iLevel, compNames, destFillComps);
-                mf.setVal(1,0,1); // initlaize mask to value
-
-                // zero out covered data
-                if (iLevel<thisFinestLevel)
-                {
-                    ratio = amrData.RefRatio()[iLevel];
-                    BoxArray baf = BoxArray(bas[iLevel+1]).coarsen(ratio);
-                    for (MFIter mfi(mf); mfi.isValid(); ++mfi)
-                    {
-                        const Box& box = mfi.validbox();
-                        FArrayBox& fab = mf[mfi];
-                        std::vector< std::pair<int,Box> > isects = baf.intersections(box);
-                        for (int ii = 0; ii < isects.size(); ii++)
-                            fab.setVal(0,isects[ii].second,0,1);
+              Real binVal = dataIV[1];
+              if (binVal >= binMin && binVal < binMax) {
+                int myBin =
+                  (int)(nBins * (binVal - binMin) / (binMax - binMin));
+                if (myBin < 0 || myBin >= binHits.size())
+                  amrex::Abort("Bad bin");
+                int myWeight = weights[iLevel];
+                for (int j = 0; j < nAvgComps; ++j) {
+                  Real val = dataIV[j + 2];
+                  int binIdx = myBin * nAvgComps + j;
+                  binVals[binIdx] += myWeight * val;
+                  binValsSq[binIdx] += myWeight * val * val;
+                  if (writeBinMinMax) {
+                    if (binHits[myBin] == 0) {
+                      binMinVals[binIdx] = val;
+                      binMaxVals[binIdx] = val;
                     }
+                    binMinVals[binIdx] = std::min(val, binMinVals[binIdx]);
+                    binMaxVals[binIdx] = std::max(val, binMaxVals[binIdx]);
+                  }
                 }
+                binHits[myBin] += myWeight;
+              }
+            }
+          }
+        } // MFI
+      } // if
+    } // Level
+  } // iPlot
 
-                for(MFIter mfi(mf); mfi.isValid(); ++mfi)
-                {
-                    FArrayBox& fab = mf[mfi];
-                    const Box& box = mfi.validbox();
-                    for (IntVect iv=box.smallEnd(); iv<=box.bigEnd(); box.next(iv))
-                    {
-                        fab.getVal(dataIV.dataPtr(),iv);
-                        if (dataIV[0] != 0) // not covered
-                        {
-                            Real binVal = dataIV[1];
-                            if (binVal>=binMin && binVal<binMax)
-                            {
-                                int myBin = (int)(nBins*(binVal-binMin)/(binMax-binMin));
-                                if (myBin<0 || myBin>=binHits.size())
-                                    amrex::Abort("Bad bin");
-                                int myWeight = weights[iLevel];
-                                for (int j=0; j<nAvgComps; ++j)
-                                {
-                                    Real val = dataIV[j+2];
-                                    int binIdx = myBin*nAvgComps + j;
-                                    binVals[binIdx]    += myWeight * val;
-                                    binValsSq[binIdx]  += myWeight * val * val;
-                                    if (writeBinMinMax)
-                                    {
-                                        if (binHits[myBin]==0) {
-                                            binMinVals[binIdx] = val;
-                                            binMaxVals[binIdx] = val;
-                                        }
-                                        binMinVals[binIdx] = std::min(val,binMinVals[binIdx]);
-                                        binMaxVals[binIdx] = std::max(val,binMaxVals[binIdx]);
-                                    }
-                                }
-                                binHits[myBin] += myWeight;
-                            }
-                        }
-                    }
-                } // MFI
-            } // if
-        } // Level
-    } // iPlot
-        
-    ParallelDescriptor::ReduceIntSum(binHits.dataPtr(),binHits.size(),ioproc);
-    ParallelDescriptor::ReduceRealSum(binVals.dataPtr(),binVals.size(),ioproc);
-    ParallelDescriptor::ReduceRealSum(binValsSq.dataPtr(),binValsSq.size(),ioproc);
-    if (writeBinMinMax)
-    {
-        ParallelDescriptor::ReduceRealMin(binMinVals.dataPtr(),binMinVals.size(),ioproc);
-        ParallelDescriptor::ReduceRealMax(binMaxVals.dataPtr(),binMaxVals.size(),ioproc);
+  ParallelDescriptor::ReduceIntSum(binHits.dataPtr(), binHits.size(), ioproc);
+  ParallelDescriptor::ReduceRealSum(binVals.dataPtr(), binVals.size(), ioproc);
+  ParallelDescriptor::ReduceRealSum(
+    binValsSq.dataPtr(), binValsSq.size(), ioproc);
+  if (writeBinMinMax) {
+    ParallelDescriptor::ReduceRealMin(
+      binMinVals.dataPtr(), binMinVals.size(), ioproc);
+    ParallelDescriptor::ReduceRealMax(
+      binMaxVals.dataPtr(), binMaxVals.size(), ioproc);
+  }
+
+  // Output result
+  if (isioproc) {
+    std::string filename;
+    // Output data for tecplot
+    // filename = infile + outSuffix + "/CM_" + compNames[0] + ".dat";
+    if (aja) {
+      filename = plotFileNames[0] + "/CM_" + compNames[0] + ".key";
+      std::cout << "Opening file " << filename << std::endl;
+    } else {
+      // Default
+      filename = "CM_" + compNames[0] + ".dat";
+      std::cout << "Opening file " << filename << std::endl;
     }
-    
-    // Output result
-    if (isioproc)
-    {            
-        std::string filename;
-        // Output data for tecplot
-        //filename = infile + outSuffix + "/CM_" + compNames[0] + ".dat";
-	if (aja) {
-	    filename = plotFileNames[0] + "/CM_" + compNames[0] + ".key";
-	    std::cout << "Opening file " << filename << std::endl;
-	} else {
-	    // Default
-	    filename = "CM_" + compNames[0] + ".dat";
-	    std::cout << "Opening file " << filename << std::endl;
-	}
-        std::ofstream ofs(filename.c_str());
-        std::string variables = "VARIABLES = " + compNames[0];
-	for (int i=1; i<compNames.size(); ++i)
-	    variables += " " + compNames[i] + "_sum";
-	for (int i=1; i<compNames.size(); ++i)
-	    variables += " " + compNames[i] + "_sumSq";
-	for (int i=1; i<compNames.size(); ++i)
-	    variables += " " + compNames[i] + "_avg";
-	for (int i=1; i<compNames.size(); ++i)
-	    variables += " " + compNames[i] + "_std";
-        if (writeBinMinMax)
-        {
-            for (int i=1; i<compNames.size(); ++i)
-                variables += " " + compNames[i] + "_min";
-            for (int i=1; i<compNames.size(); ++i)
-                variables += " " + compNames[i] + "_max";
+    std::ofstream ofs(filename.c_str());
+    std::string variables = "VARIABLES = " + compNames[0];
+    for (int i = 1; i < compNames.size(); ++i)
+      variables += " " + compNames[i] + "_sum";
+    for (int i = 1; i < compNames.size(); ++i)
+      variables += " " + compNames[i] + "_sumSq";
+    for (int i = 1; i < compNames.size(); ++i)
+      variables += " " + compNames[i] + "_avg";
+    for (int i = 1; i < compNames.size(); ++i)
+      variables += " " + compNames[i] + "_std";
+    if (writeBinMinMax) {
+      for (int i = 1; i < compNames.size(); ++i)
+        variables += " " + compNames[i] + "_min";
+      for (int i = 1; i < compNames.size(); ++i)
+        variables += " " + compNames[i] + "_max";
+    }
+    variables += " N ";
+    variables += " p ";
+    variables += '\n';
+    ofs << variables.c_str();
+    ofs << "ZONE I=" << nBins << " DATAPACKING=POINT\n";
+    if (aja) {
+      ofs.close();
+      filename = plotFileNames[0] + "/CM_" + compNames[0] + ".dat";
+      std::cout << "Opening file " << filename << std::endl;
+      ofs.open(filename.c_str());
+    }
+    const Real dv = (binMax - binMin) / nBins;
+    int ntot = 0;
+    for (int i = 0; i < nBins; i++) {
+      ntot += binHits[i];
+    }
+    for (int i = 0; i < nBins; i++) {
+      const Real v = binMin + dv * (0.5 + (Real)i);
+      ofs << v << " ";
+      // Sum
+      for (int j = 0; j < nAvgComps; j++) {
+        ofs << binVals[i * nAvgComps + j] << " ";
+      }
+      // SumSq
+      for (int j = 0; j < nAvgComps; j++) {
+        ofs << binValsSq[i * nAvgComps + j] << " ";
+      }
+      if (binHits[i] > 0) {
+        // Avg
+        for (int j = 0; j < nAvgComps; j++) {
+          ofs << binVals[i * nAvgComps + j] / (Real)binHits[i] << " ";
         }
-	variables += " N ";
-	variables += " p ";
-        variables += '\n';
-        ofs << variables.c_str();
-        ofs << "ZONE I=" << nBins << " DATAPACKING=POINT\n";
-	if (aja) {
-	    ofs.close();
-	    filename = plotFileNames[0] + "/CM_" + compNames[0] + ".dat";
-	    std::cout << "Opening file " << filename << std::endl;
-	    ofs.open(filename.c_str());
-	}
-        const Real dv = (binMax - binMin)/nBins;
-        int ntot = 0;
-	for (int i=0; i<nBins; i++)
-	{
-	    ntot += binHits[i];
-	}
-        for (int i=0; i<nBins; i++) {
-            const Real v = binMin + dv*(0.5+(Real)i);
-            ofs << v << " ";
-	    // Sum
-            for (int j=0; j<nAvgComps; j++) {
-                ofs << binVals[i*nAvgComps + j] << " ";
-            }
-	    // SumSq
-            for (int j=0; j<nAvgComps; j++) {
-                ofs << binValsSq[i*nAvgComps + j] << " ";
-            }
-	    if (binHits[i]>0) {
-		// Avg
-		for (int j=0; j<nAvgComps; j++) {
-		    ofs << binVals[i*nAvgComps + j]/(Real)binHits[i] << " ";
-		}
-		// Std Dev
-		for (int j=0; j<nAvgComps; j++) {
-		    int idx = i*nAvgComps + j;
-		    Real bh = (Real)binHits[i];
-                    ofs << std::sqrt( (binValsSq[idx]/bh) - (binVals[idx]/bh)*(binVals[idx]/bh) ) << " ";
-		}
-	    } else {
-		// Avg & Std Dev
-		for (int j=0; j<nAvgComps*2; j++) {
-                    ofs << "0.0 ";
-		}
-	    }
-	    if (writeBinMinMax)
-            {
-                for (int j=0; j<nAvgComps; j++) {
-                    ofs << binMinVals[i*nAvgComps + j] << " ";
-                }
-                for (int j=0; j<nAvgComps; j++) {
-                    ofs << binMaxVals[i*nAvgComps + j] << " ";
-                }
-            }
-	    ofs << Real(binHits[i]) << " ";
-            ofs << Real(binHits[i])/ntot << '\n';
+        // Std Dev
+        for (int j = 0; j < nAvgComps; j++) {
+          int idx = i * nAvgComps + j;
+          Real bh = (Real)binHits[i];
+          ofs << std::sqrt(
+                   (binValsSq[idx] / bh) -
+                   (binVals[idx] / bh) * (binVals[idx] / bh))
+              << " ";
         }
-        cout << "total bins: " << ntot << endl;
-        ofs.close();
-        
-    } // IOProcessor
-    
-    amrex::Finalize();
-    return 0;
+      } else {
+        // Avg & Std Dev
+        for (int j = 0; j < nAvgComps * 2; j++) {
+          ofs << "0.0 ";
+        }
+      }
+      if (writeBinMinMax) {
+        for (int j = 0; j < nAvgComps; j++) {
+          ofs << binMinVals[i * nAvgComps + j] << " ";
+        }
+        for (int j = 0; j < nAvgComps; j++) {
+          ofs << binMaxVals[i * nAvgComps + j] << " ";
+        }
+      }
+      ofs << Real(binHits[i]) << " ";
+      ofs << Real(binHits[i]) / ntot << '\n';
+    }
+    cout << "total bins: " << ntot << endl;
+    ofs.close();
+
+  } // IOProcessor
+
+  amrex::Finalize();
+  return 0;
 }
-

--- a/Src/convert2hdf5.cpp
+++ b/Src/convert2hdf5.cpp
@@ -8,18 +8,24 @@
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_PlotFileUtilHDF5.H>
 
-static void print_usage(int, char *argv[]) {
+static void
+print_usage(int, char* argv[])
+{
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
   exit(1);
 }
 
-std::string getFileRoot(const std::string &infile) {
+std::string
+getFileRoot(const std::string& infile)
+{
   std::vector<std::string> tokens = amrex::Tokenize(infile, std::string("/"));
   return tokens[tokens.size() - 1];
 }
 
-int main(int argc, char *argv[]) {
+int
+main(int argc, char* argv[])
+{
   amrex::Initialize(argc, argv);
   {
     if (argc < 2) {
@@ -43,12 +49,12 @@ int main(int argc, char *argv[]) {
     if (!dataServices.AmrDataOk()) {
       amrex::DataServices::Dispatch(amrex::DataServices::ExitRequest, NULL);
     }
-    amrex::AmrData &amrData = dataServices.AmrDataRef();
+    amrex::AmrData& amrData = dataServices.AmrDataRef();
 
     // Plotfile global infos
     finestLevel = std::min(finestLevel, amrData.FinestLevel());
     int Nlev = finestLevel + 1;
-    const amrex::Vector<std::string> &plotVarNames = amrData.PlotVarNames();
+    const amrex::Vector<std::string>& plotVarNames = amrData.PlotVarNames();
     int nvars = plotVarNames.size();
     int id_comp_last = 0;
     amrex::RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
@@ -56,7 +62,7 @@ int main(int argc, char *argv[]) {
     int coord = 0;
 
     // Copy data
-    amrex::Vector<amrex::MultiFab *> fileData(Nlev);
+    amrex::Vector<amrex::MultiFab*> fileData(Nlev);
     amrex::Vector<amrex::Geometry> geoms(Nlev);
     const int nGrow = 1;
 
@@ -64,7 +70,7 @@ int main(int argc, char *argv[]) {
     for (int lev = 0; lev < Nlev; ++lev) {
       const amrex::DistributionMapping dm(amrData.boxArray(lev));
       geoms[lev] =
-          amrex::Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
+        amrex::Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
       fileData[lev] = new amrex::MultiFab(amrData.boxArray(lev), dm, nvars, 0);
     }
 
@@ -76,8 +82,8 @@ int main(int argc, char *argv[]) {
 
     for (int lev = 0; lev < Nlev; ++lev) {
       for (int i = 0; i < nvars; ++i) {
-        fileData[lev]->ParallelCopy(amrData.GetGrids(lev, idcomp[i]), 0,
-                                    id_comp_last + i, 1);
+        fileData[lev]->ParallelCopy(
+          amrData.GetGrids(lev, idcomp[i]), 0, id_comp_last + i, 1);
       }
     }
 
@@ -89,8 +95,8 @@ int main(int argc, char *argv[]) {
     amrex::Vector<int> isteps(Nlev, 0);
     amrex::Vector<amrex::IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
     amrex::WriteMultiLevelPlotfileHDF5SingleDset(
-        outfile, Nlev, amrex::GetVecOfConstPtrs(fileData), plotVarNames, geoms,
-        amrData.Time(), isteps, refRatios, hdf5_compression);
+      outfile, Nlev, amrex::GetVecOfConstPtrs(fileData), plotVarNames, geoms,
+      amrData.Time(), isteps, refRatios, hdf5_compression);
 
     amrex::Real dRunTime2 = amrex::ParallelDescriptor::second();
     amrex::Real runtime_total = dRunTime2 - dRunTime1;

--- a/Src/curvature.cpp
+++ b/Src/curvature.cpp
@@ -21,141 +21,138 @@ using namespace amrex;
 std::string
 getFileRoot(const std::string& infile)
 {
-    std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-    return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
-
-
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    amrex::Initialize(argc,argv);
-    {
+  amrex::Initialize(argc, argv);
+  {
 
     // if (argc < 2)
     //    print_usage(argc,argv);
-    
-    
+
     // if (pp.contains("help"))
     //    print_usage(argc,argv);
 
     // ---------------------------------------------------------------------
     // Set defaults input values
     // ---------------------------------------------------------------------
-    std::string progressName  = "temp";
-    Real progMin              = 1.0e20;
-    Real progMax              = -1.0e20;
-    int finestLevel           = 1000;
-    int verbose               = 0;
-    int floorIt               = 0;
-    int useFileMinMax         = 1;
-    bool do_strain            = false;
-    bool do_gaussCurv         = false;
-    bool getStrainTensor      = false;
-    bool do_velnormal         = false;
-    bool do_threshold         = false;
-    Real threshold            = 0.0001;
-    bool do_smooth            = false;
-    Real smooth_time          = 1.0e-7;
-    int nAuxVar               = 0;
+    std::string progressName = "temp";
+    Real progMin = 1.0e20;
+    Real progMax = -1.0e20;
+    int finestLevel = 1000;
+    int verbose = 0;
+    int floorIt = 0;
+    int useFileMinMax = 1;
+    bool do_strain = false;
+    bool do_gaussCurv = false;
+    bool getStrainTensor = false;
+    bool do_velnormal = false;
+    bool do_threshold = false;
+    Real threshold = 0.0001;
+    bool do_smooth = false;
+    Real smooth_time = 1.0e-7;
+    int nAuxVar = 0;
 
-    
     // ---------------------------------------------------------------------
     // ParmParse
     // ---------------------------------------------------------------------
     ParmParse pp;
 
     // IO
-    pp.query("verbose",verbose);
+    pp.query("verbose", verbose);
     std::string plotFileName;
-    pp.get("infile",plotFileName);
+    pp.get("infile", plotFileName);
     std::string outfile(getFileRoot(plotFileName) + "_K");
-    pp.query("outfile",outfile);
-    pp.query("finestLevel",finestLevel);
-    pp.query("do_gaussCurv",do_gaussCurv);
+    pp.query("outfile", outfile);
+    pp.query("finestLevel", finestLevel);
+    pp.query("do_gaussCurv", do_gaussCurv);
 
     // Progress variable
-    pp.query("progressName",progressName);
-    pp.query("progMin",progMin);
-    pp.query("progMax",progMax);
-    pp.query("floorIt",floorIt);
-    pp.query("useFileMinMax",useFileMinMax);
+    pp.query("progressName", progressName);
+    pp.query("progMin", progMin);
+    pp.query("progMax", progMax);
+    pp.query("floorIt", floorIt);
+    pp.query("useFileMinMax", useFileMinMax);
 
     // Clip results outside the flame front ? ( C ~ 0 or C ~ 1)
-    pp.query("threshold_prog",do_threshold);
-    pp.query("threshold_value",threshold);
+    pp.query("threshold_prog", do_threshold);
+    pp.query("threshold_value", threshold);
 
     // Progress variable smoothing
-    pp.query("do_smooth",do_smooth);
-    pp.query("smoothing_time",smooth_time);
+    pp.query("do_smooth", do_smooth);
+    pp.query("smoothing_time", smooth_time);
 
     // Pertaining to the velocity computation
-    pp.query("do_strain",do_strain);
+    pp.query("do_strain", do_strain);
     if (do_strain) {
-       pp.query("getStrainTensor",getStrainTensor);
+      pp.query("getStrainTensor", getStrainTensor);
     }
-    pp.query("do_velnormal",do_velnormal);
+    pp.query("do_velnormal", do_velnormal);
 
     // Auxiliary variables
     nAuxVar = pp.countval("Aux_Variables");
     Vector<std::string> AuxVar(nAuxVar);
-    for(int ivar = 0; ivar < nAuxVar; ++ivar) { 
-         pp.get("Aux_Variables", AuxVar[ivar],ivar);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      pp.get("Aux_Variables", AuxVar[ivar], ivar);
     }
 
-    if (verbose>1) AmrData::SetVerbose(true);
-    
+    if (verbose > 1)
+      AmrData::SetVerbose(true);
+
     Print() << "infile = " << plotFileName << "\n";
     Print() << "reading plt file = " << plotFileName << "\n";
-    
+
     // Initialize DataService
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
-        DataServices::Dispatch(DataServices::ExitRequest, NULL);
+    if (!dataServices.AmrDataOk()) {
+      DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     // Plotfile global infos
-    finestLevel = std::min(finestLevel,amrData.FinestLevel());
+    finestLevel = std::min(finestLevel, amrData.FinestLevel());
     int Nlev = finestLevel + 1;
     const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    RealBox rb(&(amrData.ProbLo()[0]), 
-               &(amrData.ProbHi()[0]));
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
 
     // ---------------------------------------------------------------------
     // Progress variable construction
     // ---------------------------------------------------------------------
     int idC = amrData.StateNumber(progressName);
-    if ( idC < 0 ) {
-         amrex::Abort("Wrong progress variable name: "+progressName);
+    if (idC < 0) {
+      amrex::Abort("Wrong progress variable name: " + progressName);
     }
     Real progMinlvl = 1.0e20;
     Real progMaxlvl = -1.0e20;
-    if (useFileMinMax || floorIt)
-    {
-        if (useFileMinMax) {
-            for (int lev=0; lev<Nlev; ++lev) {
-                amrData.MinMax(amrData.ProbDomain()[lev], progressName, lev, progMinlvl, progMaxlvl);
-                progMin = std::min(progMin,progMinlvl);
-                progMax = std::max(progMax,progMaxlvl);
-            }
-            ParallelDescriptor::ReduceRealMin(progMin);
-            ParallelDescriptor::ReduceRealMax(progMax);
+    if (useFileMinMax || floorIt) {
+      if (useFileMinMax) {
+        for (int lev = 0; lev < Nlev; ++lev) {
+          amrData.MinMax(
+            amrData.ProbDomain()[lev], progressName, lev, progMinlvl,
+            progMaxlvl);
+          progMin = std::min(progMin, progMinlvl);
+          progMax = std::max(progMax, progMaxlvl);
         }
+        ParallelDescriptor::ReduceRealMin(progMin);
+        ParallelDescriptor::ReduceRealMax(progMax);
+      }
 
-        Print() << "progressName = " << progressName << " at index: " << amrData.StateNumber(progressName) << "\n";
-        Print() << "useFileMinMax = " << useFileMinMax << "\n";
-        Print() << "Min/Max = " << progMin << " / " << progMax << "\n";
+      Print() << "progressName = " << progressName
+              << " at index: " << amrData.StateNumber(progressName) << "\n";
+      Print() << "useFileMinMax = " << useFileMinMax << "\n";
+      Print() << "Min/Max = " << progMin << " / " << progMax << "\n";
 
-        ParallelDescriptor::Barrier();
+      ParallelDescriptor::Barrier();
 
-        if (progMin >= progMax) {
-            amrex::Abort("progMin must be less than progMax");
-        }
+      if (progMin >= progMax) {
+        amrex::Abort("progMin must be less than progMax");
+      }
     }
 
     // ---------------------------------------------------------------------
@@ -171,97 +168,94 @@ main (int   argc,
     if (do_strain) {
       nCompIn += AMREX_SPACEDIM;
       inVarNames.resize(nCompIn);
-      inVarNames[idVst+0] = "x_velocity";
-      inVarNames[idVst+1] = "y_velocity";
+      inVarNames[idVst + 0] = "x_velocity";
+      inVarNames[idVst + 1] = "y_velocity";
 #if AMREX_SPACEDIM == 3
-      inVarNames[idVst+2] = "z_velocity";
+      inVarNames[idVst + 2] = "z_velocity";
 #endif
     }
 
-    if (nAuxVar>0)
-    {
-        inVarNames.resize(nCompIn+nAuxVar);
-        for (int ivar=0; ivar<nAuxVar; ++ivar) {
-            if ( amrData.StateNumber(AuxVar[ivar]) < 0 ) {
-               amrex::Abort("Unknown auxiliary variable name: "+AuxVar[ivar]);
-            }
-            inVarNames[nCompIn] = AuxVar[ivar];
-            nCompIn ++;
-        } 
+    if (nAuxVar > 0) {
+      inVarNames.resize(nCompIn + nAuxVar);
+      for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+        if (amrData.StateNumber(AuxVar[ivar]) < 0) {
+          amrex::Abort("Unknown auxiliary variable name: " + AuxVar[ivar]);
+        }
+        inVarNames[nCompIn] = AuxVar[ivar];
+        nCompIn++;
+      }
     }
 
     Vector<int> destFillComps(nCompIn);
-    for (int i=0; i<nCompIn; ++i) {
-        destFillComps[i] = i;    
+    for (int i = 0; i < nCompIn; ++i) {
+      destFillComps[i] = i;
     }
 
     // Start appending variables that we will compute
-    const int idProg = nCompIn;              // progress variable
-    const int idSmProg = idProg + 1;         // smoothed progress variable
-    const int idKm = idSmProg + 1;           // Mean curvature
-    const int idN= idKm + 1;                 // Flame normal components
-    int idSR = -1;                           // Strain rate
-    int nCompOut = 0;                        // Total number of output variables
+    const int idProg = nCompIn;      // progress variable
+    const int idSmProg = idProg + 1; // smoothed progress variable
+    const int idKm = idSmProg + 1;   // Mean curvature
+    const int idN = idKm + 1;        // Flame normal components
+    int idSR = -1;                   // Strain rate
+    int nCompOut = 0;                // Total number of output variables
 
 #if AMREX_SPACEDIM > 2
-    const int idKg = idN + AMREX_SPACEDIM;   // Gaussian curvature
+    const int idKg = idN + AMREX_SPACEDIM; // Gaussian curvature
     if (do_strain) {
       idSR = idKg + 1;
       nCompOut = idSR + 1;
-    }
-    else {
+    } else {
       nCompOut = idKg + 1;
     }
 #else
     if (do_strain) {
       idSR = idN + AMREX_SPACEDIM;
       nCompOut = idSR + 1;
-    }
-    else {
+    } else {
       nCompOut = idN + AMREX_SPACEDIM;
     }
 #endif
 
-    int idROST=-1;
+    int idROST = -1;
     if (getStrainTensor) {
-        idROST = nCompOut;
-        nCompOut = idROST + AMREX_SPACEDIM*AMREX_SPACEDIM; // Rate-of-strain
+      idROST = nCompOut;
+      nCompOut = idROST + AMREX_SPACEDIM * AMREX_SPACEDIM; // Rate-of-strain
     }
 
-    int idVelNormal=-1;
-    if ( do_velnormal ) {  
-        idVelNormal = nCompOut; 
-        nCompOut += 1; 
-    }  
+    int idVelNormal = -1;
+    if (do_velnormal) {
+      idVelNormal = nCompOut;
+      nCompOut += 1;
+    }
 
-    if (verbose) {  
-       Print() << "Will read the following states: ";
-       for (int i=0; i<nCompIn; ++i) {
-           Print() << " " << amrData.StateNumber(inVarNames[i]);
-       }
-       Print() << '\n';
-       Print() << "States out will be those plus: " << '\n';
-       Print() << "   idProg:   " << idProg << '\n';
-       Print() << "   idSmProg: " << idSmProg << '\n';
-       Print() << "   idKm:     " << idKm << '\n';
+    if (verbose) {
+      Print() << "Will read the following states: ";
+      for (int i = 0; i < nCompIn; ++i) {
+        Print() << " " << amrData.StateNumber(inVarNames[i]);
+      }
+      Print() << '\n';
+      Print() << "States out will be those plus: " << '\n';
+      Print() << "   idProg:   " << idProg << '\n';
+      Print() << "   idSmProg: " << idSmProg << '\n';
+      Print() << "   idKm:     " << idKm << '\n';
 #if AMREX_SPACEDIM > 2
-       Print() << "   idKg:     " << idKg << '\n';
+      Print() << "   idKg:     " << idKg << '\n';
 #endif
-       if (do_strain) {
-          Print() << "   idSR:     " << idSR << '\n';
-       }
+      if (do_strain) {
+        Print() << "   idSR:     " << idSR << '\n';
+      }
     }
-    
-    // Check symmetry/periodicity in given coordinate direction
-    Vector<int> sym_dir(AMREX_SPACEDIM,0);
-    pp.queryarr("sym_dir",sym_dir,0,AMREX_SPACEDIM);  
 
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    // Check symmetry/periodicity in given coordinate direction
+    Vector<int> sym_dir(AMREX_SPACEDIM, 0);
+    pp.queryarr("sym_dir", sym_dir, 0, AMREX_SPACEDIM);
+
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
 
     Print() << "Periodicity assumed for this case: ";
-    for (int i=0; i<AMREX_SPACEDIM; ++i) {
-        Print() << is_per[i] << " ";
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+      Print() << is_per[i] << " ";
     }
     Print() << "\n";
 
@@ -274,519 +268,574 @@ main (int   argc,
     Vector<MultiFab*> flame_normal(Nlev);
     Vector<MultiFab*> cell_normal(Nlev);
     Vector<Geometry*> geoms(Nlev);
-    Vector<Geometry>  geomsOP(Nlev);
-    Vector<BoxArray>  grids(Nlev);
+    Vector<Geometry> geomsOP(Nlev);
+    Vector<BoxArray> grids(Nlev);
     Vector<DistributionMapping> dmap(Nlev);
-    const int nGrow = 2 ;
+    const int nGrow = 2;
 
-    // Read the required data from pltfile and compute progress variable while we're at it.
+    // Read the required data from pltfile and compute progress variable while
+    // we're at it.
     FArrayBox tmp;
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-        const BoxArray ba = amrData.boxArray(lev);
-        grids[lev] = ba;
-        DistributionMapping dm(ba);
-        dmap[lev] = dm; 
-        geoms[lev] = new Geometry(amrData.ProbDomain()[lev],&rb,coord,&(is_per[0]));
-        geomsOP[lev] = *geoms[lev];
+    for (int lev = 0; lev < Nlev; ++lev) {
+      const BoxArray ba = amrData.boxArray(lev);
+      grids[lev] = ba;
+      DistributionMapping dm(ba);
+      dmap[lev] = dm;
+      geoms[lev] =
+        new Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
+      geomsOP[lev] = *geoms[lev];
 
-        state[lev] = new MultiFab(ba,dm,nCompOut,nGrow);
-        flame_normal[lev] = new MultiFab(ba,dm,AMREX_SPACEDIM,nGrow);
-        cell_normal[lev] = new MultiFab(ba,dm,AMREX_SPACEDIM,nGrow);
-        const Vector<Real>& delta = amrData.DxLevel()[lev];
-        Real dxn[3];
-        for (int i=0; i<AMREX_SPACEDIM; ++i) {
-           dxn[i] = delta[i];
+      state[lev] = new MultiFab(ba, dm, nCompOut, nGrow);
+      flame_normal[lev] = new MultiFab(ba, dm, AMREX_SPACEDIM, nGrow);
+      cell_normal[lev] = new MultiFab(ba, dm, AMREX_SPACEDIM, nGrow);
+      const Vector<Real>& delta = amrData.DxLevel()[lev];
+      Real dxn[3];
+      for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+        dxn[i] = delta[i];
+      }
+
+      // Get input state data
+      if (verbose)
+        Print() << "Reading data for level " << lev << "\n";
+      amrData.FillVar(*state[lev], lev, inVarNames, destFillComps);
+
+      // Build progress variable from state at idCst, put into idProg
+      MultiFab StateVar(*state[lev], amrex::make_alias, idCst, 1);
+      MultiFab ProgressVar(*state[lev], amrex::make_alias, idProg, 1);
+      for (MFIter mfi(*state[lev]); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.validbox();
+        const auto& StateVarFab = StateVar.array(mfi);
+        const auto& ProgVarFab = ProgressVar.array(mfi);
+        Real invdenom = 1.0 / (progMax - progMin);
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            ProgVarFab(i, j, k) = (StateVarFab(i, j, k) - progMin) * invdenom;
+          });
+      }
+      ProgressVar.FillBoundary(geoms[lev]->periodicity());
+
+      if (verbose)
+        Print() << "Progress variable computed for level " << lev << "\n";
+
+    } // End lev loop
+
+    if (do_smooth) {
+      // Set a composite ABec solve to smooth the progress variable
+      // Try solving c^{n+1} - ∆t \nabla \cdot b_i \nabla c^{n+1} = c^{n)
+      // In ABec terms  (\alpha A - \beta \nabla \cdot B_i \nabla) \phi = rhs
+      // \alpha = 1, A = I
+      // \beta = ∆t, b_i = ?? let's start with 1, switch to a D_c later if need
+      // be. Adapt ∆t accordingly ... rhs = c^{n}
+
+      LPInfo info;
+      info.setAgglomeration(1);
+      info.setConsolidation(1);
+      info.setMetricTerm(false);
+
+      MLABecLaplacian mlabec(geomsOP, grids, dmap, info);
+      mlabec.setMaxOrder(4);
+
+      const Real tol_rel = 1.e-12;
+      const Real tol_abs = 1.e-12;
+
+      // Problem with Periodic or Neumann BC
+      std::array<LinOpBCType, AMREX_SPACEDIM> lo_bc;
+      std::array<LinOpBCType, AMREX_SPACEDIM> hi_bc;
+      for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+        if (is_per[idim] == 1) {
+          lo_bc[idim] = hi_bc[idim] = LinOpBCType::Periodic;
+        } else {
+          lo_bc[idim] = hi_bc[idim] = LinOpBCType::Neumann;
         }
+      }
+      mlabec.setDomainBC(lo_bc, hi_bc);
 
-        // Get input state data
-        if (verbose) Print() << "Reading data for level " << lev << "\n";
-        amrData.FillVar(*state[lev],lev,inVarNames,destFillComps);
+      for (int lev = 0; lev < Nlev; ++lev) {
+        // for problem with homogeneous Neumann BC, we need to pass nullptr
+        mlabec.setLevelBC(lev, nullptr);
+      }
 
-        // Build progress variable from state at idCst, put into idProg
-        MultiFab StateVar(*state[lev], amrex::make_alias, idCst, 1);
-        MultiFab ProgressVar(*state[lev], amrex::make_alias, idProg, 1);
-        for (MFIter mfi(*state[lev]); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = mfi.validbox();
-            const auto& StateVarFab = StateVar.array(mfi); 
-            const auto& ProgVarFab  = ProgressVar.array(mfi); 
-            Real invdenom = 1.0 / (progMax - progMin);
-            amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-            {
-                ProgVarFab(i,j,k) = ( StateVarFab(i,j,k) - progMin ) * invdenom;
-            });
+      Real alpha = 1.0;
+      Real beta = smooth_time;
+      mlabec.setScalars(alpha, beta);
+
+      for (int lev = 0; lev < Nlev; ++lev) {
+        // Set A = I  at each level
+        MultiFab acoef(
+          state[lev]->boxArray(), state[lev]->DistributionMap(), 1, 0);
+        acoef.setVal(1.0);
+        mlabec.setACoeffs(lev, acoef);
+
+        // Set b_i = 1.0  at each level
+        Array<MultiFab, AMREX_SPACEDIM> face_bcoef;
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+          const BoxArray& ba = amrex::convert(
+            state[lev]->boxArray(), IntVect::TheDimensionVector(idim));
+          face_bcoef[idim].define(ba, state[lev]->DistributionMap(), 1, 0);
+          face_bcoef[idim].setVal(1.0);
         }
-        ProgressVar.FillBoundary(geoms[lev]->periodicity());
+        mlabec.setBCoeffs(lev, amrex::GetArrOfConstPtrs(face_bcoef));
+      }
 
-        if (verbose) Print() << "Progress variable computed for level " << lev << "\n";
+      Vector<MultiFab> solution(Nlev);
+      Vector<MultiFab> rhs(Nlev);
+      for (int lev = 0; lev < Nlev; ++lev) {
+        rhs[lev].define(grids[lev], dmap[lev], 1, 0);
+        MultiFab::Copy(rhs[lev], *state[lev], idProg, 0, 1, 0);
+        solution[lev].define(grids[lev], dmap[lev], 1, nGrow);
+        solution[lev].setVal(0.0);
+      }
 
-    }  // End lev loop
+      MLMG mlmg(mlabec);
+      mlmg.setMaxIter(100);
+      mlmg.setVerbose(1);
+      mlmg.solve(
+        GetVecOfPtrs(solution), GetVecOfConstPtrs(rhs), tol_rel, tol_abs);
 
-    if ( do_smooth ) {
-       // Set a composite ABec solve to smooth the progress variable 
-       // Try solving c^{n+1} - ∆t \nabla \cdot b_i \nabla c^{n+1} = c^{n)
-       // In ABec terms  (\alpha A - \beta \nabla \cdot B_i \nabla) \phi = rhs
-       // \alpha = 1, A = I
-       // \beta = ∆t, b_i = ?? let's start with 1, switch to a D_c later if need be. Adapt ∆t accordingly ...
-       // rhs = c^{n}
-       
-       LPInfo info;
-       info.setAgglomeration(1);
-       info.setConsolidation(1);
-       info.setMetricTerm(false);
-
-       MLABecLaplacian mlabec(geomsOP, grids, dmap, info);
-       mlabec.setMaxOrder(4);
-
-       const Real tol_rel = 1.e-12;
-       const Real tol_abs = 1.e-12;
-
-       // Problem with Periodic or Neumann BC 
-       std::array<LinOpBCType, AMREX_SPACEDIM> lo_bc;
-       std::array<LinOpBCType, AMREX_SPACEDIM> hi_bc;
-       for (int idim = 0; idim< AMREX_SPACEDIM; idim++){
-          if (is_per[idim] == 1) {
-              lo_bc[idim] = hi_bc[idim] = LinOpBCType::Periodic;
-          } else {
-              lo_bc[idim] = hi_bc[idim] = LinOpBCType::Neumann;
-          }
-       }
-       mlabec.setDomainBC(lo_bc,hi_bc);
-
-       for (int lev = 0; lev < Nlev; ++lev)
-       {
-          // for problem with homogeneous Neumann BC, we need to pass nullptr
-          mlabec.setLevelBC(lev, nullptr);
-       }
-
-       Real alpha = 1.0;
-       Real beta = smooth_time;
-       mlabec.setScalars(alpha, beta);
-
-       for (int lev = 0; lev < Nlev; ++lev) {
-           // Set A = I  at each level
-           MultiFab acoef(state[lev]->boxArray(), state[lev]->DistributionMap(), 1, 0);
-           acoef.setVal(1.0);
-           mlabec.setACoeffs(lev, acoef);
-
-           // Set b_i = 1.0  at each level
-           Array<MultiFab,AMREX_SPACEDIM> face_bcoef; 
-           for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
-           {   
-               const BoxArray& ba = amrex::convert(state[lev]->boxArray(),
-                                                   IntVect::TheDimensionVector(idim));
-               face_bcoef[idim].define(ba, state[lev]->DistributionMap(), 1, 0); 
-               face_bcoef[idim].setVal(1.0);   
-           }   
-           mlabec.setBCoeffs(lev, amrex::GetArrOfConstPtrs(face_bcoef));
-       }
-
-       Vector<MultiFab> solution(Nlev);
-       Vector<MultiFab> rhs(Nlev);
-       for (int lev = 0; lev < Nlev; ++lev) {
-           rhs[lev].define(grids[lev], dmap[lev], 1, 0);
-           MultiFab::Copy(rhs[lev],*state[lev], idProg, 0, 1, 0);
-           solution[lev].define(grids[lev], dmap[lev], 1, nGrow);
-           solution[lev].setVal(0.0);
-       }
-
-       MLMG mlmg(mlabec);
-       mlmg.setMaxIter(100);
-       mlmg.setVerbose(1);
-       mlmg.solve(GetVecOfPtrs(solution), GetVecOfConstPtrs(rhs), tol_rel, tol_abs);
-
-       for (int lev = 0; lev < Nlev; ++lev) {
-          MultiFab::Copy(*state[lev], solution[lev],0,idSmProg, 1, nGrow);
-          state[lev]->FillBoundary(idSmProg,1,geoms[lev]->periodicity()); 
-       }  
-       if (verbose) Print() << "Progress variable smoothed successfully \n";
+      for (int lev = 0; lev < Nlev; ++lev) {
+        MultiFab::Copy(*state[lev], solution[lev], 0, idSmProg, 1, nGrow);
+        state[lev]->FillBoundary(idSmProg, 1, geoms[lev]->periodicity());
+      }
+      if (verbose)
+        Print() << "Progress variable smoothed successfully \n";
     }
 
-    int idprogvar = do_smooth ? idSmProg : idProg;  
+    int idprogvar = do_smooth ? idSmProg : idProg;
 
-//  Compute curvature using LinearOperators
+    //  Compute curvature using LinearOperators
     // Set-up Poisson Linear Solver
     LPInfo info;
     info.setAgglomeration(1);
     info.setConsolidation(1);
     info.setMetricTerm(false);
     info.setMaxCoarseningLevel(0);
-        
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-        const BoxArray ba = amrData.boxArray(lev);
-        DistributionMapping dm(ba);
 
-        if (verbose) Print() << "Starting mean curvature on level " << lev << "\n";
+    for (int lev = 0; lev < Nlev; ++lev) {
+      const BoxArray ba = amrData.boxArray(lev);
+      DistributionMapping dm(ba);
 
-        // Get face gradients of progress variable 
-        MLPoisson poisson({*geoms[lev]}, {ba}, {dmap[lev]}, info);
-        poisson.setMaxOrder(4);
-        std::array<LinOpBCType, AMREX_SPACEDIM> lo_bc;
-        std::array<LinOpBCType, AMREX_SPACEDIM> hi_bc;
-        for (int idim = 0; idim< AMREX_SPACEDIM; idim++){
-           if (is_per[idim] == 1) {
-              lo_bc[idim] = hi_bc[idim] = LinOpBCType::Periodic;
-           } else {
-              if (sym_dir[idim] == 1) {
-                 lo_bc[idim] = hi_bc[idim] = LinOpBCType::reflect_odd;
-              } else {
-                 lo_bc[idim] = hi_bc[idim] = LinOpBCType::Neumann;
-              }
-           }
+      if (verbose)
+        Print() << "Starting mean curvature on level " << lev << "\n";
+
+      // Get face gradients of progress variable
+      MLPoisson poisson({*geoms[lev]}, {ba}, {dmap[lev]}, info);
+      poisson.setMaxOrder(4);
+      std::array<LinOpBCType, AMREX_SPACEDIM> lo_bc;
+      std::array<LinOpBCType, AMREX_SPACEDIM> hi_bc;
+      for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+        if (is_per[idim] == 1) {
+          lo_bc[idim] = hi_bc[idim] = LinOpBCType::Periodic;
+        } else {
+          if (sym_dir[idim] == 1) {
+            lo_bc[idim] = hi_bc[idim] = LinOpBCType::reflect_odd;
+          } else {
+            lo_bc[idim] = hi_bc[idim] = LinOpBCType::Neumann;
+          }
         }
-        poisson.setDomainBC(lo_bc, hi_bc);
-        if ( lev > 0 ) {
-           MultiFab* ProgVarCoarse = new MultiFab(state[lev-1]->boxArray(), state[lev-1]->DistributionMap(), 1, state[lev-1]->nGrow()); 
-           MultiFab::Copy(*ProgVarCoarse, *state[lev-1], idprogvar, 0, 1, nGrow);
-           poisson.setCoarseFineBC(ProgVarCoarse,2);
+      }
+      poisson.setDomainBC(lo_bc, hi_bc);
+      if (lev > 0) {
+        MultiFab* ProgVarCoarse = new MultiFab(
+          state[lev - 1]->boxArray(), state[lev - 1]->DistributionMap(), 1,
+          state[lev - 1]->nGrow());
+        MultiFab::Copy(*ProgVarCoarse, *state[lev - 1], idprogvar, 0, 1, nGrow);
+        poisson.setCoarseFineBC(ProgVarCoarse, 2);
+      }
+      MultiFab ProgVar(ba, dmap[lev], 1, nGrow);
+      MultiFab::Copy(ProgVar, *state[lev], idprogvar, 0, 1, nGrow);
+      poisson.setLevelBC(0, &ProgVar);
+
+      MLMG mlmg(poisson);
+
+      std::array<MultiFab, AMREX_SPACEDIM> face_gradient;
+      AMREX_D_TERM(
+        face_gradient[0].define(
+          convert(ba, IntVect::TheDimensionVector(0)), dmap[lev], 1, 0);
+        , face_gradient[1].define(
+            convert(ba, IntVect::TheDimensionVector(1)), dmap[lev], 1, 0);
+        , face_gradient[2].define(
+            convert(ba, IntVect::TheDimensionVector(2)), dmap[lev], 1, 0););
+      mlmg.getFluxes({amrex::GetArrOfPtrs(face_gradient)}, {&ProgVar});
+
+      // Convert to cell avg gradient
+      MultiFab cellavg_gradient(ba, dmap[lev], AMREX_SPACEDIM, 0);
+      average_face_to_cellcenter(
+        cellavg_gradient, 0, amrex::GetArrOfConstPtrs(face_gradient));
+      cellavg_gradient.mult(-1.0, 0, AMREX_SPACEDIM);
+
+      // Compute ||\nabla c||
+      MultiFab cellnorm_gradient(ba, dmap[lev], 1, 1);
+      cellnorm_gradient.setVal(0.0);
+      for (MFIter mfi(cellnorm_gradient); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.validbox();
+        AMREX_D_TERM(auto const& Cx = cellavg_gradient.array(mfi, 0);
+                     , auto const& Cy = cellavg_gradient.array(mfi, 1);
+                     , auto const& Cz = cellavg_gradient.array(mfi, 2););
+        const auto& normgrad = cellnorm_gradient.array(mfi);
+        const auto& progvar = ProgVar.array(mfi);
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            normgrad(i, j, k) = std::max(
+              1e-14, std::sqrt(AMREX_D_TERM(
+                       std::pow(Cx(i, j, k), 2.0), +std::pow(Cy(i, j, k), 2.0),
+                       +std::pow(Cz(i, j, k), 2.0))));
+            normgrad(i, j, k) = -normgrad(i, j, k);
+          });
+      }
+      cellnorm_gradient.FillBoundary(geoms[lev]->periodicity());
+
+      // Get the cell centered flame normal N_i (pointing toward fresh gases)
+      MultiFab::Copy(
+        *cell_normal[lev], cellavg_gradient, 0, 0, AMREX_SPACEDIM, 0);
+      cell_normal[lev]->FillBoundary(
+        0, AMREX_SPACEDIM, geoms[lev]->periodicity());
+
+      if (verbose)
+        Print() << "Done with flame normal on level " << lev << "\n";
+
+      //      At this point, I got the flame normal from clean gradients
+      //      provided by the MLMG Now try to compute the divergence of the
+      //      flame normal using another linear solver: 1 -> get the clean face
+      //      gradient of flame normal components from MLMG: d N_i/d x_i 2 ->
+      //      manually get the divergence from the gradients: ∑_i d N_i/d x_i
+
+      //      Copy into level aware flame_normal MF and fill same level ghost
+      //      cells on normal
+      MultiFab::Copy(
+        *flame_normal[lev], *cell_normal[lev], 0, 0, AMREX_SPACEDIM, 0);
+      for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+        MultiFab::Divide(*flame_normal[lev], cellnorm_gradient, 0, idim, 1, 0);
+      }
+      flame_normal[lev]->FillBoundary(
+        0, AMREX_SPACEDIM, geoms[lev]->periodicity());
+
+      //      Define curvature
+      MultiFab Curv(ba, dmap[lev], 1, 0);
+      Curv.setVal(0.0);
+
+      for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+
+        MLPoisson poisson2({*geoms[lev]}, {ba}, {dmap[lev]}, info);
+        poisson2.setMaxOrder(4);
+        poisson2.setDomainBC(lo_bc, hi_bc);
+        if (lev > 0) {
+          MultiFab* FlameNormalIdimCoarse = new MultiFab(
+            flame_normal[lev - 1]->boxArray(),
+            flame_normal[lev - 1]->DistributionMap(), 1, 0);
+          MultiFab::Copy(
+            *FlameNormalIdimCoarse, *flame_normal[lev - 1], idim, 0, 1, 0);
+          poisson2.setCoarseFineBC(FlameNormalIdimCoarse, 2);
         }
-        MultiFab ProgVar(ba, dmap[lev], 1, nGrow); 
-        MultiFab::Copy(ProgVar, *state[lev], idprogvar, 0, 1, nGrow);
-        poisson.setLevelBC(0,&ProgVar);
+        MultiFab* FlameNormalIdim = new MultiFab(ba, dmap[lev], 1, 1);
+        MultiFab::Copy(*FlameNormalIdim, *flame_normal[lev], idim, 0, 1, 1);
+        poisson2.setLevelBC(0, FlameNormalIdim);
 
-        MLMG mlmg(poisson);
+        MLMG mlmg2(poisson2);
 
-        std::array<MultiFab,AMREX_SPACEDIM> face_gradient;
-        AMREX_D_TERM(face_gradient[0].define(convert(ba,IntVect::TheDimensionVector(0)), dmap[lev], 1, 0); ,
-                     face_gradient[1].define(convert(ba,IntVect::TheDimensionVector(1)), dmap[lev], 1, 0); ,
-                     face_gradient[2].define(convert(ba,IntVect::TheDimensionVector(2)), dmap[lev], 1, 0); );
-        mlmg.getFluxes({amrex::GetArrOfPtrs(face_gradient)},{&ProgVar});
+        // Get the fluxes : d N_i / d x_j   , i = idim, j = 0, 1 (,2)
+        std::array<MultiFab, AMREX_SPACEDIM> faceg;
+        AMREX_D_TERM(
+          faceg[0].define(
+            convert(ba, IntVect::TheDimensionVector(0)), dmap[lev], 1, 0);
+          , faceg[1].define(
+              convert(ba, IntVect::TheDimensionVector(1)), dmap[lev], 1, 0);
+          , faceg[2].define(
+              convert(ba, IntVect::TheDimensionVector(2)), dmap[lev], 1, 0););
+        mlmg2.getFluxes({amrex::GetArrOfPtrs(faceg)}, {FlameNormalIdim});
 
-        // Convert to cell avg gradient
-        MultiFab cellavg_gradient(ba, dmap[lev], AMREX_SPACEDIM, 0);
-        average_face_to_cellcenter(cellavg_gradient, 0, amrex::GetArrOfConstPtrs(face_gradient));
-        cellavg_gradient.mult(-1.0,0,AMREX_SPACEDIM);
+        // Get cell centered d N_i / d x_y
+        MultiFab cell_avgg(ba, dmap[lev], AMREX_SPACEDIM, 0);
+        average_face_to_cellcenter(
+          cell_avgg, 0, amrex::GetArrOfConstPtrs(faceg));
+        cell_avgg.mult(-1.0, 0, AMREX_SPACEDIM);
 
-        // Compute ||\nabla c||
-        MultiFab cellnorm_gradient(ba, dmap[lev], 1, 1);
-        cellnorm_gradient.setVal(0.0);
-        for (MFIter mfi(cellnorm_gradient); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = mfi.validbox();
-            AMREX_D_TERM(auto const& Cx = cellavg_gradient.array(mfi,0);,
-                         auto const& Cy = cellavg_gradient.array(mfi,1);,
-                         auto const& Cz = cellavg_gradient.array(mfi,2););
-            const auto& normgrad  = cellnorm_gradient.array(mfi); 
-            const auto& progvar   = ProgVar.array(mfi); 
-            amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-            {
-                normgrad(i,j,k) = std::max(1e-14, std::sqrt( AMREX_D_TERM (   std::pow(Cx(i,j,k),2.0),
-                                                                            + std::pow(Cy(i,j,k),2.0),
-                                                                            + std::pow(Cz(i,j,k),2.0)) ) ) ;
-                normgrad(i,j,k) = -normgrad(i,j,k);
-            });
-        }
-        cellnorm_gradient.FillBoundary(geoms[lev]->periodicity());
-
-        // Get the cell centered flame normal N_i (pointing toward fresh gases)
-        MultiFab::Copy(*cell_normal[lev],cellavg_gradient,0,0,AMREX_SPACEDIM,0);
-        cell_normal[lev]->FillBoundary(0, AMREX_SPACEDIM, geoms[lev]->periodicity());
-
-        if (verbose) Print() << "Done with flame normal on level " << lev << "\n";
-
-//      At this point, I got the flame normal from clean gradients provided by the MLMG
-//      Now try to compute the divergence of the flame normal using another linear solver:
-//      1 -> get the clean face gradient of flame normal components from MLMG: d N_i/d x_i
-//      2 -> manually get the divergence from the gradients: ∑_i d N_i/d x_i 
-
-//      Copy into level aware flame_normal MF and fill same level ghost cells on normal 
-        MultiFab::Copy(*flame_normal[lev], *cell_normal[lev], 0, 0, AMREX_SPACEDIM, 0);
-        for (int idim = 0; idim< AMREX_SPACEDIM; idim++){
-            MultiFab::Divide(*flame_normal[lev],cellnorm_gradient,0,idim,1,0);
-        }  
-        flame_normal[lev]->FillBoundary(0, AMREX_SPACEDIM, geoms[lev]->periodicity());
-
-//      Define curvature        
-        MultiFab Curv(ba, dmap[lev], 1, 0);     
-        Curv.setVal(0.0); 
-
-        for (int idim = 0; idim< AMREX_SPACEDIM; idim++){
-
-           MLPoisson poisson2({*geoms[lev]}, {ba}, {dmap[lev]}, info);
-           poisson2.setMaxOrder(4);
-           poisson2.setDomainBC(lo_bc, hi_bc);
-           if ( lev > 0 ) {
-               MultiFab* FlameNormalIdimCoarse = new MultiFab(flame_normal[lev-1]->boxArray(),
-                                                              flame_normal[lev-1]->DistributionMap(),
-                                                              1, 0); 
-               MultiFab::Copy(*FlameNormalIdimCoarse, *flame_normal[lev-1], idim, 0, 1, 0);
-               poisson2.setCoarseFineBC(FlameNormalIdimCoarse,2);
-           }
-           MultiFab* FlameNormalIdim = new MultiFab(ba, dmap[lev], 1, 1); 
-           MultiFab::Copy(*FlameNormalIdim, *flame_normal[lev], idim, 0, 1, 1);
-           poisson2.setLevelBC(0,FlameNormalIdim);
-            
-           MLMG mlmg2(poisson2);
-
-           // Get the fluxes : d N_i / d x_j   , i = idim, j = 0, 1 (,2)
-           std::array<MultiFab,AMREX_SPACEDIM> faceg;
-           AMREX_D_TERM(faceg[0].define(convert(ba,IntVect::TheDimensionVector(0)), dmap[lev], 1, 0); ,
-                        faceg[1].define(convert(ba,IntVect::TheDimensionVector(1)), dmap[lev], 1, 0); ,
-                        faceg[2].define(convert(ba,IntVect::TheDimensionVector(2)), dmap[lev], 1, 0); );
-           mlmg2.getFluxes({amrex::GetArrOfPtrs(faceg)},{FlameNormalIdim});
-
-           // Get cell centered d N_i / d x_y
-           MultiFab cell_avgg(ba, dmap[lev], AMREX_SPACEDIM, 0);
-           average_face_to_cellcenter(cell_avgg, 0, amrex::GetArrOfConstPtrs(faceg));
-           cell_avgg.mult(-1.0,0,AMREX_SPACEDIM);
-
-           // Add d N_i / d x_i to curvature
-           MultiFab::Add(Curv,cell_avgg,idim,0,1,0);
-        }
+        // Add d N_i / d x_i to curvature
+        MultiFab::Add(Curv, cell_avgg, idim, 0, 1, 0);
+      }
 
 #if AMREX_SPACEDIM == 3
-        // Mean curvature : 0.5 * \div \cdot n
-        // TODO: I only need to do that in 3D ... right ?
-        Curv.mult(0.5,0,1);  
+      // Mean curvature : 0.5 * \div \cdot n
+      // TODO: I only need to do that in 3D ... right ?
+      Curv.mult(0.5, 0, 1);
 #endif
 
-        // Clip curvature & flame normal for c < threshold or c > 1.0-threshold
-        for (MFIter mfi(Curv); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = mfi.validbox();
-            const auto& CurvFab  = Curv.array(mfi); 
-            AMREX_D_TERM(const auto& FnormXFab  = flame_normal[lev]->array(mfi,0); ,
-                         const auto& FnormYFab  = flame_normal[lev]->array(mfi,1); ,
-                         const auto& FnormZFab  = flame_normal[lev]->array(mfi,2); );
-            const auto& progvar   = ProgVar.array(mfi); 
-            amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-            {
-                if ( do_threshold && ( progvar(i,j,k) < threshold || progvar(i,j,k) > 1.0-threshold ) ) {
-                   CurvFab(i,j,k) = 0.0;
-                   AMREX_D_TERM( FnormXFab(i,j,k) = 0.0; ,
-                                 FnormYFab(i,j,k) = 0.0; ,
-                                 FnormZFab(i,j,k) = 0.0; );
-                }
-            });
-        }
+      // Clip curvature & flame normal for c < threshold or c > 1.0-threshold
+      for (MFIter mfi(Curv); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.validbox();
+        const auto& CurvFab = Curv.array(mfi);
+        AMREX_D_TERM(const auto& FnormXFab = flame_normal[lev]->array(mfi, 0);
+                     , const auto& FnormYFab = flame_normal[lev]->array(mfi, 1);
+                     ,
+                     const auto& FnormZFab = flame_normal[lev]->array(mfi, 2););
+        const auto& progvar = ProgVar.array(mfi);
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            if (
+              do_threshold && (progvar(i, j, k) < threshold ||
+                               progvar(i, j, k) > 1.0 - threshold)) {
+              CurvFab(i, j, k) = 0.0;
+              AMREX_D_TERM(FnormXFab(i, j, k) = 0.0;, FnormYFab(i, j, k) = 0.0;
+                           , FnormZFab(i, j, k) = 0.0;);
+            }
+          });
+      }
 
-        MultiFab::Copy(*state[lev], Curv, 0, idKm, 1, 0);
-        MultiFab::Copy(*state[lev], *flame_normal[lev], 0, idN, AMREX_SPACEDIM, 0);
+      MultiFab::Copy(*state[lev], Curv, 0, idKm, 1, 0);
+      MultiFab::Copy(
+        *state[lev], *flame_normal[lev], 0, idN, AMREX_SPACEDIM, 0);
 
-        if (verbose) Print() << "Mean curvature has been computed on level " << lev << "\n";
+      if (verbose)
+        Print() << "Mean curvature has been computed on level " << lev << "\n";
 
         // Now work on the gaussian curvature: only if 3D and required
 #if AMREX_SPACEDIM == 3
-        if ( do_gaussCurv ) { 
+      if (do_gaussCurv) {
 
-           // Start by getting the Hessian of the progress variable
-           MultiFab Hessian(ba, dmap[lev], 9, 0);     
+        // Start by getting the Hessian of the progress variable
+        MultiFab Hessian(ba, dmap[lev], 9, 0);
 
-           // Compute grad of grad in each dim and store in Hessian
-           for (int idim = 0; idim< AMREX_SPACEDIM; idim++){
+        // Compute grad of grad in each dim and store in Hessian
+        for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
 
-              MLPoisson poisson2({*geoms[lev]}, {ba}, {dmap[lev]}, info);
-              poisson2.setMaxOrder(4);
-              poisson2.setDomainBC(lo_bc, hi_bc);
-              if ( lev > 0 ) {
-                  MultiFab* gradIdimCoarse = new MultiFab(cell_normal[lev-1]->boxArray(),
-                                                          cell_normal[lev-1]->DistributionMap(),
-                                                          1, 0); 
-                  MultiFab::Copy(*gradIdimCoarse, *cell_normal[lev-1], idim, 0, 1, 0);
-                  poisson2.setCoarseFineBC(gradIdimCoarse,2);
-              }
-              MultiFab* gradIdim = new MultiFab(ba, dmap[lev], 1, 1); 
-              MultiFab::Copy(*gradIdim, *cell_normal[lev], idim, 0, 1, 1);
-              poisson2.setLevelBC(0,gradIdim);
+          MLPoisson poisson2({*geoms[lev]}, {ba}, {dmap[lev]}, info);
+          poisson2.setMaxOrder(4);
+          poisson2.setDomainBC(lo_bc, hi_bc);
+          if (lev > 0) {
+            MultiFab* gradIdimCoarse = new MultiFab(
+              cell_normal[lev - 1]->boxArray(),
+              cell_normal[lev - 1]->DistributionMap(), 1, 0);
+            MultiFab::Copy(
+              *gradIdimCoarse, *cell_normal[lev - 1], idim, 0, 1, 0);
+            poisson2.setCoarseFineBC(gradIdimCoarse, 2);
+          }
+          MultiFab* gradIdim = new MultiFab(ba, dmap[lev], 1, 1);
+          MultiFab::Copy(*gradIdim, *cell_normal[lev], idim, 0, 1, 1);
+          poisson2.setLevelBC(0, gradIdim);
 
-              MLMG mlmg2(poisson2);
+          MLMG mlmg2(poisson2);
 
-              std::array<MultiFab,AMREX_SPACEDIM> faceg;
-              AMREX_D_TERM(faceg[0].define(convert(ba,IntVect::TheDimensionVector(0)), dmap[lev], 1, 0); ,
-                           faceg[1].define(convert(ba,IntVect::TheDimensionVector(1)), dmap[lev], 1, 0); ,
-                           faceg[2].define(convert(ba,IntVect::TheDimensionVector(2)), dmap[lev], 1, 0); );
-              mlmg2.getFluxes({amrex::GetArrOfPtrs(faceg)},{gradIdim});
+          std::array<MultiFab, AMREX_SPACEDIM> faceg;
+          AMREX_D_TERM(
+            faceg[0].define(
+              convert(ba, IntVect::TheDimensionVector(0)), dmap[lev], 1, 0);
+            , faceg[1].define(
+                convert(ba, IntVect::TheDimensionVector(1)), dmap[lev], 1, 0);
+            , faceg[2].define(
+                convert(ba, IntVect::TheDimensionVector(2)), dmap[lev], 1, 0););
+          mlmg2.getFluxes({amrex::GetArrOfPtrs(faceg)}, {gradIdim});
 
-              // Get cell centered d C / d idim _x_y_z
-              MultiFab cell_avgg(ba, dmap[lev], AMREX_SPACEDIM, 0);
-              average_face_to_cellcenter(cell_avgg, 0, amrex::GetArrOfConstPtrs(faceg));
-              cell_avgg.mult(-1.0,0,AMREX_SPACEDIM);
+          // Get cell centered d C / d idim _x_y_z
+          MultiFab cell_avgg(ba, dmap[lev], AMREX_SPACEDIM, 0);
+          average_face_to_cellcenter(
+            cell_avgg, 0, amrex::GetArrOfConstPtrs(faceg));
+          cell_avgg.mult(-1.0, 0, AMREX_SPACEDIM);
 
-              // Copy in Hessian
-              MultiFab::Copy(Hessian,cell_avgg,0,(idim)*3,AMREX_SPACEDIM,0);
-           } 
-
-           // Get the adjugate of the Hessian
-           MultiFab AdjHessian(ba, dmap[lev], 9, 0);     
-
-           for (MFIter mfi(Hessian); mfi.isValid(); ++mfi)
-           {
-               const Box& bx = mfi.validbox();
-               const auto& HxiFab  = Hessian.array(mfi,0);           // Cxx, Cxy, Cxz
-               const auto& HyiFab  = Hessian.array(mfi,3);           // Cyx, Cyy, Cyz
-               const auto& HziFab  = Hessian.array(mfi,6);           // Czx, Czy, Czz
-               const auto& AdjHxiFab  = AdjHessian.array(mfi,0); 
-               const auto& AdjHyiFab  = AdjHessian.array(mfi,3); 
-               const auto& AdjHziFab  = AdjHessian.array(mfi,6); 
-               amrex::ParallelFor(bx,
-               [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-               {
-                   AdjHxiFab(i,j,k,0) = HyiFab(i,j,k,1) * HziFab(i,j,k,2) - HziFab(i,j,k,1) * HyiFab(i,j,k,2); 
-                   AdjHyiFab(i,j,k,0) = HyiFab(i,j,k,2) * HziFab(i,j,k,0) - HziFab(i,j,k,2) * HyiFab(i,j,k,0);
-                   AdjHziFab(i,j,k,0) = HyiFab(i,j,k,0) * HziFab(i,j,k,1) - HziFab(i,j,k,0) * HyiFab(i,j,k,1);
-                   AdjHxiFab(i,j,k,1) = HxiFab(i,j,k,2) * HziFab(i,j,k,1) - HziFab(i,j,k,2) * HxiFab(i,j,k,1);
-                   AdjHyiFab(i,j,k,1) = HxiFab(i,j,k,0) * HziFab(i,j,k,2) - HziFab(i,j,k,0) * HxiFab(i,j,k,2);
-                   AdjHziFab(i,j,k,1) = HxiFab(i,j,k,1) * HziFab(i,j,k,0) - HziFab(i,j,k,1) * HxiFab(i,j,k,0);
-                   AdjHxiFab(i,j,k,2) = HxiFab(i,j,k,1) * HyiFab(i,j,k,2) - HyiFab(i,j,k,1) * HxiFab(i,j,k,2);
-                   AdjHyiFab(i,j,k,2) = HxiFab(i,j,k,2) * HyiFab(i,j,k,0) - HyiFab(i,j,k,2) * HxiFab(i,j,k,0);
-                   AdjHziFab(i,j,k,2) = HxiFab(i,j,k,0) * HyiFab(i,j,k,1) - HyiFab(i,j,k,0) * HxiFab(i,j,k,1); 
-               });
-           }
-
-           // Now get the gausian curvature
-           MultiFab gCurv(ba, dmap[lev], 1, 0);     
-           for (MFIter mfi(gCurv); mfi.isValid(); ++mfi)
-           {
-               const Box& bx = mfi.validbox();
-               const auto& progvar    = ProgVar.array(mfi);
-               const auto& gCurvFab   = gCurv.array(mfi); 
-               const auto& CgradNorm  = cellnorm_gradient.array(mfi); 
-               const auto& CxFab      = cellavg_gradient.array(mfi,0); 
-               const auto& CyFab      = cellavg_gradient.array(mfi,1); 
-               const auto& CzFab      = cellavg_gradient.array(mfi,2); 
-               const auto& AdjHxiFab  = AdjHessian.array(mfi,0); 
-               const auto& AdjHyiFab  = AdjHessian.array(mfi,3); 
-               const auto& AdjHziFab  = AdjHessian.array(mfi,6); 
-               amrex::ParallelFor(bx,
-               [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-               {
-                  gCurvFab(i,j,k) = ( CxFab(i,j,k) * ( AdjHxiFab(i,j,k,0) * CxFab(i,j,k) +
-                                                       AdjHxiFab(i,j,k,1) * CyFab(i,j,k) + 
-                                                       AdjHxiFab(i,j,k,2) * CzFab(i,j,k) ) +
-                                      CyFab(i,j,k) * ( AdjHyiFab(i,j,k,0) * CxFab(i,j,k) +
-                                                       AdjHyiFab(i,j,k,1) * CyFab(i,j,k) +
-                                                       AdjHyiFab(i,j,k,2) * CzFab(i,j,k) ) +
-                                      CzFab(i,j,k) * ( AdjHziFab(i,j,k,0) * CxFab(i,j,k) +
-                                                       AdjHziFab(i,j,k,1) * CyFab(i,j,k) +
-                                                       AdjHziFab(i,j,k,2) * CzFab(i,j,k) ) 
-                                    ) / std::pow(CgradNorm(i,j,k),4.0);
-                   if ( do_threshold && (progvar(i,j,k) < threshold || progvar(i,j,k) > 1.0-threshold) ) {
-                      gCurvFab(i,j,k) = 0.0;
-                   }
-               });
-           }
-           MultiFab::Copy(*state[lev], gCurv, 0, idKg, 1, 0);
+          // Copy in Hessian
+          MultiFab::Copy(Hessian, cell_avgg, 0, (idim) * 3, AMREX_SPACEDIM, 0);
         }
-        if (verbose) Print() << "Gaussian curvature has been computed on level " << lev << "\n";
+
+        // Get the adjugate of the Hessian
+        MultiFab AdjHessian(ba, dmap[lev], 9, 0);
+
+        for (MFIter mfi(Hessian); mfi.isValid(); ++mfi) {
+          const Box& bx = mfi.validbox();
+          const auto& HxiFab = Hessian.array(mfi, 0); // Cxx, Cxy, Cxz
+          const auto& HyiFab = Hessian.array(mfi, 3); // Cyx, Cyy, Cyz
+          const auto& HziFab = Hessian.array(mfi, 6); // Czx, Czy, Czz
+          const auto& AdjHxiFab = AdjHessian.array(mfi, 0);
+          const auto& AdjHyiFab = AdjHessian.array(mfi, 3);
+          const auto& AdjHziFab = AdjHessian.array(mfi, 6);
+          amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+              AdjHxiFab(i, j, k, 0) = HyiFab(i, j, k, 1) * HziFab(i, j, k, 2) -
+                                      HziFab(i, j, k, 1) * HyiFab(i, j, k, 2);
+              AdjHyiFab(i, j, k, 0) = HyiFab(i, j, k, 2) * HziFab(i, j, k, 0) -
+                                      HziFab(i, j, k, 2) * HyiFab(i, j, k, 0);
+              AdjHziFab(i, j, k, 0) = HyiFab(i, j, k, 0) * HziFab(i, j, k, 1) -
+                                      HziFab(i, j, k, 0) * HyiFab(i, j, k, 1);
+              AdjHxiFab(i, j, k, 1) = HxiFab(i, j, k, 2) * HziFab(i, j, k, 1) -
+                                      HziFab(i, j, k, 2) * HxiFab(i, j, k, 1);
+              AdjHyiFab(i, j, k, 1) = HxiFab(i, j, k, 0) * HziFab(i, j, k, 2) -
+                                      HziFab(i, j, k, 0) * HxiFab(i, j, k, 2);
+              AdjHziFab(i, j, k, 1) = HxiFab(i, j, k, 1) * HziFab(i, j, k, 0) -
+                                      HziFab(i, j, k, 1) * HxiFab(i, j, k, 0);
+              AdjHxiFab(i, j, k, 2) = HxiFab(i, j, k, 1) * HyiFab(i, j, k, 2) -
+                                      HyiFab(i, j, k, 1) * HxiFab(i, j, k, 2);
+              AdjHyiFab(i, j, k, 2) = HxiFab(i, j, k, 2) * HyiFab(i, j, k, 0) -
+                                      HyiFab(i, j, k, 2) * HxiFab(i, j, k, 0);
+              AdjHziFab(i, j, k, 2) = HxiFab(i, j, k, 0) * HyiFab(i, j, k, 1) -
+                                      HyiFab(i, j, k, 0) * HxiFab(i, j, k, 1);
+            });
+        }
+
+        // Now get the gausian curvature
+        MultiFab gCurv(ba, dmap[lev], 1, 0);
+        for (MFIter mfi(gCurv); mfi.isValid(); ++mfi) {
+          const Box& bx = mfi.validbox();
+          const auto& progvar = ProgVar.array(mfi);
+          const auto& gCurvFab = gCurv.array(mfi);
+          const auto& CgradNorm = cellnorm_gradient.array(mfi);
+          const auto& CxFab = cellavg_gradient.array(mfi, 0);
+          const auto& CyFab = cellavg_gradient.array(mfi, 1);
+          const auto& CzFab = cellavg_gradient.array(mfi, 2);
+          const auto& AdjHxiFab = AdjHessian.array(mfi, 0);
+          const auto& AdjHyiFab = AdjHessian.array(mfi, 3);
+          const auto& AdjHziFab = AdjHessian.array(mfi, 6);
+          amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+              gCurvFab(i, j, k) =
+                (CxFab(i, j, k) * (AdjHxiFab(i, j, k, 0) * CxFab(i, j, k) +
+                                   AdjHxiFab(i, j, k, 1) * CyFab(i, j, k) +
+                                   AdjHxiFab(i, j, k, 2) * CzFab(i, j, k)) +
+                 CyFab(i, j, k) * (AdjHyiFab(i, j, k, 0) * CxFab(i, j, k) +
+                                   AdjHyiFab(i, j, k, 1) * CyFab(i, j, k) +
+                                   AdjHyiFab(i, j, k, 2) * CzFab(i, j, k)) +
+                 CzFab(i, j, k) * (AdjHziFab(i, j, k, 0) * CxFab(i, j, k) +
+                                   AdjHziFab(i, j, k, 1) * CyFab(i, j, k) +
+                                   AdjHziFab(i, j, k, 2) * CzFab(i, j, k))) /
+                std::pow(CgradNorm(i, j, k), 4.0);
+              if (
+                do_threshold && (progvar(i, j, k) < threshold ||
+                                 progvar(i, j, k) > 1.0 - threshold)) {
+                gCurvFab(i, j, k) = 0.0;
+              }
+            });
+        }
+        MultiFab::Copy(*state[lev], gCurv, 0, idKg, 1, 0);
+      }
+      if (verbose)
+        Print() << "Gaussian curvature has been computed on level " << lev
+                << "\n";
 #endif
 
-        if (do_strain) { 
-           // Strain rate -nn:\nabla u + \nabla \cdot u
+      if (do_strain) {
+        // Strain rate -nn:\nabla u + \nabla \cdot u
 
-           // Start by building the strain tensor
-           MultiFab StrainT(ba, dmap[lev], AMREX_SPACEDIM * AMREX_SPACEDIM, 0);     
+        // Start by building the strain tensor
+        MultiFab StrainT(ba, dmap[lev], AMREX_SPACEDIM * AMREX_SPACEDIM, 0);
 
-           // Compute strain tensor with a MLMG in each direction
-           for (int idim = 0; idim< AMREX_SPACEDIM; idim++){
+        // Compute strain tensor with a MLMG in each direction
+        for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
 
-              MLPoisson poisson2({*geoms[lev]}, {ba}, {dmap[lev]}, info);
-              poisson2.setMaxOrder(4);
-              poisson2.setDomainBC(lo_bc, hi_bc);
-              if ( lev > 0 ) {
-                  MultiFab* velIdimCoarse = new MultiFab(state[lev-1]->boxArray(),
-                                                         state[lev-1]->DistributionMap(),
-                                                         1, 0); 
-                  MultiFab::Copy(*velIdimCoarse, *state[lev-1], idVst+idim, 0, 1, 0);
-                  poisson2.setCoarseFineBC(velIdimCoarse,2);
+          MLPoisson poisson2({*geoms[lev]}, {ba}, {dmap[lev]}, info);
+          poisson2.setMaxOrder(4);
+          poisson2.setDomainBC(lo_bc, hi_bc);
+          if (lev > 0) {
+            MultiFab* velIdimCoarse = new MultiFab(
+              state[lev - 1]->boxArray(), state[lev - 1]->DistributionMap(), 1,
+              0);
+            MultiFab::Copy(
+              *velIdimCoarse, *state[lev - 1], idVst + idim, 0, 1, 0);
+            poisson2.setCoarseFineBC(velIdimCoarse, 2);
+          }
+          MultiFab* velIdim = new MultiFab(ba, dmap[lev], 1, 1);
+          MultiFab::Copy(*velIdim, *state[lev], idVst + idim, 0, 1, 1);
+          poisson2.setLevelBC(0, velIdim);
+
+          MLMG mlmg2(poisson2);
+
+          std::array<MultiFab, AMREX_SPACEDIM> faceg;
+          AMREX_D_TERM(
+            faceg[0].define(
+              convert(ba, IntVect::TheDimensionVector(0)), dmap[lev], 1, 0);
+            , faceg[1].define(
+                convert(ba, IntVect::TheDimensionVector(1)), dmap[lev], 1, 0);
+            , faceg[2].define(
+                convert(ba, IntVect::TheDimensionVector(2)), dmap[lev], 1, 0););
+          mlmg2.getFluxes({amrex::GetArrOfPtrs(faceg)}, {velIdim});
+
+          // Get cell centered d u_idim / d _x_y(_z)
+          MultiFab cell_avgg(ba, dmap[lev], AMREX_SPACEDIM, 0);
+          average_face_to_cellcenter(
+            cell_avgg, 0, amrex::GetArrOfConstPtrs(faceg));
+          cell_avgg.mult(-1.0, 0, AMREX_SPACEDIM);
+
+          // Copy in strain tensor
+          MultiFab::Copy(
+            StrainT, cell_avgg, 0, (idim)*AMREX_SPACEDIM, AMREX_SPACEDIM, 0);
+        }
+
+        // Gather the components of strain rate
+        MultiFab strainrate(ba, dmap[lev], 1, 0);
+
+        for (MFIter mfi(strainrate); mfi.isValid(); ++mfi) {
+          const Box& bx = mfi.validbox();
+          const auto& progvar = ProgVar.array(mfi);
+          const auto& srFab = strainrate.array(mfi);
+          AMREX_D_TERM(const auto& NxFab = flame_normal[lev]->array(mfi, 0);
+                       , const auto& NyFab = flame_normal[lev]->array(mfi, 1);
+                       , const auto& NzFab = flame_normal[lev]->array(mfi, 2););
+          AMREX_D_TERM(
+            const auto& gradUx = StrainT.array(mfi, 0);
+            , const auto& gradUy = StrainT.array(mfi, AMREX_SPACEDIM);
+            , const auto& gradUz = StrainT.array(mfi, AMREX_SPACEDIM * 2););
+          amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+              srFab(i, j, k) = AMREX_D_TERM(
+                AMREX_D_TERM(
+                  -gradUx(i, j, k, 0) * NxFab(i, j, k) * NxFab(i, j, k),
+                  -gradUx(i, j, k, 1) * NxFab(i, j, k) * NyFab(i, j, k),
+                  -gradUx(i, j, k, 2) * NxFab(i, j, k) * NzFab(i, j, k)),
+                AMREX_D_TERM(
+                  -gradUy(i, j, k, 0) * NyFab(i, j, k) * NxFab(i, j, k),
+                  -gradUy(i, j, k, 1) * NyFab(i, j, k) * NyFab(i, j, k),
+                  -gradUy(i, j, k, 2) * NyFab(i, j, k) * NzFab(i, j, k)),
+                AMREX_D_TERM(
+                  -gradUz(i, j, k, 0) * NzFab(i, j, k) * NxFab(i, j, k),
+                  -gradUz(i, j, k, 1) * NzFab(i, j, k) * NyFab(i, j, k),
+                  -gradUz(i, j, k, 2) * NzFab(i, j, k) *
+                    NzFab(i, j, k))); //-nn:\nabla u
+              srFab(i, j, k) = AMREX_D_TERM(
+                +gradUx(i, j, k, 0), +gradUy(i, j, k, 1),
+                +gradUz(i, j, k, 2)); // + \nabla \cdot u
+            });
+        }
+
+        MultiFab::Copy(*state[lev], strainrate, 0, idSR, 1, 0);
+        if (verbose)
+          Print() << "Tangential strain rate has been computed on level " << lev
+                  << "\n";
+
+        // Store the strain rate tensor if required
+        if (getStrainTensor) {
+          MultiFab::Copy(
+            *state[lev], StrainT, 0, idROST, AMREX_SPACEDIM * AMREX_SPACEDIM,
+            0);
+        }
+      }
+
+      if (do_velnormal) {
+        // Velocity normal to the flame front
+        MultiFab velNormal(ba, dmap[lev], 1, 0);
+
+        for (MFIter mfi(velNormal); mfi.isValid(); ++mfi) {
+          const Box& bx = mfi.validbox();
+          const auto& progvar = ProgVar.array(mfi);
+          const auto& velNormFab = velNormal.array(mfi);
+          AMREX_D_TERM(const auto& NxFab = flame_normal[lev]->array(mfi, 0);
+                       , const auto& NyFab = flame_normal[lev]->array(mfi, 1);
+                       , const auto& NzFab = flame_normal[lev]->array(mfi, 2););
+          AMREX_D_TERM(const auto& Ux = state[lev]->array(mfi, idVst + 0);
+                       , const auto& Uy = state[lev]->array(mfi, idVst + 1);
+                       , const auto& Uz = state[lev]->array(mfi, idVst + 2););
+          amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+              velNormFab(i, j, k) = AMREX_D_TERM(
+                +Ux(i, j, k) * NxFab(i, j, k), +Uy(i, j, k) * NyFab(i, j, k),
+                +Uz(i, j, k) * NzFab(i, j, k));
+              if (
+                do_threshold && (progvar(i, j, k) < threshold ||
+                                 progvar(i, j, k) > 1.0 - threshold)) {
+                velNormFab(i, j, k) = 0.0;
               }
-              MultiFab* velIdim = new MultiFab(ba, dmap[lev], 1, 1); 
-              MultiFab::Copy(*velIdim, *state[lev], idVst+idim, 0, 1, 1);
-              poisson2.setLevelBC(0,velIdim);
-
-              MLMG mlmg2(poisson2);
-
-              std::array<MultiFab,AMREX_SPACEDIM> faceg;
-              AMREX_D_TERM(faceg[0].define(convert(ba,IntVect::TheDimensionVector(0)), dmap[lev], 1, 0); ,
-                           faceg[1].define(convert(ba,IntVect::TheDimensionVector(1)), dmap[lev], 1, 0); ,
-                           faceg[2].define(convert(ba,IntVect::TheDimensionVector(2)), dmap[lev], 1, 0); );
-              mlmg2.getFluxes({amrex::GetArrOfPtrs(faceg)},{velIdim});
-
-              // Get cell centered d u_idim / d _x_y(_z)
-              MultiFab cell_avgg(ba, dmap[lev], AMREX_SPACEDIM, 0);
-              average_face_to_cellcenter(cell_avgg, 0, amrex::GetArrOfConstPtrs(faceg));
-              cell_avgg.mult(-1.0,0,AMREX_SPACEDIM);
-
-              // Copy in strain tensor
-              MultiFab::Copy(StrainT,cell_avgg,0,(idim)*AMREX_SPACEDIM,AMREX_SPACEDIM,0);
-           } 
-
-           // Gather the components of strain rate
-           MultiFab strainrate(ba, dmap[lev], 1, 0);
-
-           for (MFIter mfi(strainrate); mfi.isValid(); ++mfi)
-           {
-               const Box& bx = mfi.validbox();
-               const auto& progvar    = ProgVar.array(mfi);
-               const auto& srFab      = strainrate.array(mfi); 
-               AMREX_D_TERM(const auto& NxFab  = flame_normal[lev]->array(mfi,0); ,
-                            const auto& NyFab  = flame_normal[lev]->array(mfi,1); ,
-                            const auto& NzFab  = flame_normal[lev]->array(mfi,2); );
-               AMREX_D_TERM(const auto& gradUx = StrainT.array(mfi,0); ,
-                            const auto& gradUy = StrainT.array(mfi,AMREX_SPACEDIM); ,
-                            const auto& gradUz = StrainT.array(mfi,AMREX_SPACEDIM*2); ); 
-               amrex::ParallelFor(bx,
-               [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-               {
-                  srFab(i,j,k) = AMREX_D_TERM ( AMREX_D_TERM( - gradUx(i,j,k,0) * NxFab(i,j,k) * NxFab(i,j,k) ,
-                                                              - gradUx(i,j,k,1) * NxFab(i,j,k) * NyFab(i,j,k) ,
-                                                              - gradUx(i,j,k,2) * NxFab(i,j,k) * NzFab(i,j,k) ),
-                                                AMREX_D_TERM( - gradUy(i,j,k,0) * NyFab(i,j,k) * NxFab(i,j,k) ,
-                                                              - gradUy(i,j,k,1) * NyFab(i,j,k) * NyFab(i,j,k) ,
-                                                              - gradUy(i,j,k,2) * NyFab(i,j,k) * NzFab(i,j,k) ),
-                                                AMREX_D_TERM( - gradUz(i,j,k,0) * NzFab(i,j,k) * NxFab(i,j,k) ,
-                                                              - gradUz(i,j,k,1) * NzFab(i,j,k) * NyFab(i,j,k) ,
-                                                              - gradUz(i,j,k,2) * NzFab(i,j,k) * NzFab(i,j,k) ) );   //-nn:\nabla u
-                  srFab(i,j,k) = AMREX_D_TERM ( + gradUx(i,j,k,0) ,
-                                                + gradUy(i,j,k,1) ,
-                                                + gradUz(i,j,k,2) );    // + \nabla \cdot u
-               });
-           }
-
-           MultiFab::Copy(*state[lev], strainrate, 0, idSR, 1, 0);
-           if (verbose) Print() << "Tangential strain rate has been computed on level " << lev << "\n";
-            
-           // Store the strain rate tensor if required 
-           if ( getStrainTensor ) {
-              MultiFab::Copy(*state[lev], StrainT, 0, idROST, AMREX_SPACEDIM*AMREX_SPACEDIM, 0);
-           } 
-
+            });
         }
-
-        if (do_velnormal) { 
-           // Velocity normal to the flame front
-           MultiFab velNormal(ba, dmap[lev], 1, 0);
-
-           for (MFIter mfi(velNormal); mfi.isValid(); ++mfi)
-           {
-               const Box& bx = mfi.validbox();
-               const auto& progvar    = ProgVar.array(mfi);
-               const auto& velNormFab = velNormal.array(mfi); 
-               AMREX_D_TERM(const auto& NxFab  = flame_normal[lev]->array(mfi,0); ,
-                            const auto& NyFab  = flame_normal[lev]->array(mfi,1); ,
-                            const auto& NzFab  = flame_normal[lev]->array(mfi,2); );
-               AMREX_D_TERM(const auto& Ux = state[lev]->array(mfi,idVst+0); ,
-                            const auto& Uy = state[lev]->array(mfi,idVst+1); ,
-                            const auto& Uz = state[lev]->array(mfi,idVst+2); ); 
-               amrex::ParallelFor(bx,
-               [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-               {
-                  velNormFab(i,j,k) = AMREX_D_TERM ( + Ux(i,j,k) * NxFab(i,j,k) ,
-                                                     + Uy(i,j,k) * NyFab(i,j,k) , 
-                                                     + Uz(i,j,k) * NzFab(i,j,k) ); 
-                  if ( do_threshold && (progvar(i,j,k) < threshold || progvar(i,j,k) > 1.0-threshold) ) {
-                     velNormFab(i,j,k) = 0.0;
-                  }
-               });
-           }
-           MultiFab::Copy(*state[lev], velNormal, 0, idVelNormal, 1, 0);
-           if (verbose) Print() << "Flow velocity normal to the flame has been computed on level " << lev << "\n";
-        }
-
+        MultiFab::Copy(*state[lev], velNormal, 0, idVelNormal, 1, 0);
+        if (verbose)
+          Print()
+            << "Flow velocity normal to the flame has been computed on level "
+            << lev << "\n";
+      }
     }
 
     // ---------------------------------------------------------------------
@@ -795,54 +844,51 @@ main (int   argc,
     Vector<std::string> nnames(nCompOut);
 
     // Plot file variables
-    for (int i=0; i<nCompIn; ++i) {
-        nnames[i] = inVarNames[i];
+    for (int i = 0; i < nCompIn; ++i) {
+      nnames[i] = inVarNames[i];
     }
 
     // Computed variables
-    nnames[idProg]   = "Progress";
+    nnames[idProg] = "Progress";
     nnames[idSmProg] = "SmoothedProgress";
-    nnames[idKm]     = "MeanCurvature_" + progressName;
-    nnames[idN]      = "FlameNormalX_" + progressName;
-    nnames[idN+1]    = "FlameNormalY_" + progressName;
+    nnames[idKm] = "MeanCurvature_" + progressName;
+    nnames[idN] = "FlameNormalX_" + progressName;
+    nnames[idN + 1] = "FlameNormalY_" + progressName;
 #if AMREX_SPACEDIM == 3
-    nnames[idN+2]    = "FlameNormalZ_" + progressName;
-    nnames[idKg]     = "GaussianCurvature_" + progressName;
+    nnames[idN + 2] = "FlameNormalZ_" + progressName;
+    nnames[idKg] = "GaussianCurvature_" + progressName;
 #endif
-    if (do_strain) nnames[idSR] = "StrainRate_" + progressName;
+    if (do_strain)
+      nnames[idSR] = "StrainRate_" + progressName;
 
-    if (getStrainTensor)
-    {
-        std::string dirChar[3] = {"x","y","z"}; 
-        for (int i=0; i<AMREX_SPACEDIM*AMREX_SPACEDIM; ++i)
-        {
-            int n=i%AMREX_SPACEDIM;
-            int m=i/AMREX_SPACEDIM;
-            nnames[idROST+i] = "ROST_dU"+dirChar[m]+"d"+dirChar[n];
-        }
+    if (getStrainTensor) {
+      std::string dirChar[3] = {"x", "y", "z"};
+      for (int i = 0; i < AMREX_SPACEDIM * AMREX_SPACEDIM; ++i) {
+        int n = i % AMREX_SPACEDIM;
+        int m = i / AMREX_SPACEDIM;
+        nnames[idROST + i] = "ROST_dU" + dirChar[m] + "d" + dirChar[n];
+      }
     }
-    
-    if (do_velnormal)
-    {
-        nnames[idVelNormal] = "VelFlameNormal";
+
+    if (do_velnormal) {
+      nnames[idVelNormal] = "VelFlameNormal";
     }
 
     // Write to plotfile
     // Remove GC from outstate
     Vector<MultiFab*> ostate(Nlev);
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-        const BoxArray ba = state[lev]->boxArray();
-        ostate[lev] = new MultiFab(ba,dmap[lev],nCompOut,0);
-        MultiFab::Copy(*ostate[lev],*state[lev],0,0,nCompOut,0);
+    for (int lev = 0; lev < Nlev; ++lev) {
+      const BoxArray ba = state[lev]->boxArray();
+      ostate[lev] = new MultiFab(ba, dmap[lev], nCompOut, 0);
+      MultiFab::Copy(*ostate[lev], *state[lev], 0, 0, nCompOut, 0);
     }
     Print() << "Writing new data to " << outfile << "\n";
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(ostate), nnames,
-                                   geomsOP, 0.0, isteps, refRatios);
-
-    }
-    amrex::Finalize();
-    return 0;
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(ostate), nnames, geomsOP, 0.0, isteps,
+      refRatios);
+  }
+  amrex::Finalize();
+  return 0;
 }

--- a/Src/decimateMEF.cpp
+++ b/Src/decimateMEF.cpp
@@ -5,7 +5,7 @@
   simplifies it, and writes out the results.  It couldn't be simpler.
 
   Copyright (C) 1998 Michael Garland.  See "COPYING.txt" for details.
-  
+
   $Id: qslim.cpp,v 1.1.1.1 2006/09/20 01:42:04 marc Exp $
 
  ************************************************************************/
@@ -16,38 +16,41 @@
 
 #include "AMReX.H"
 
-static ostream& vfcount(ostream& out, uint v, uint f)
+static ostream&
+vfcount(ostream& out, uint v, uint f)
 {
-    return out << "(" << v << "v/" << f << "f)";
+  return out << "(" << v << "v/" << f << "f)";
 }
 
-void startup_and_input(int argc, char **argv)
+void
+startup_and_input(int argc, char** argv)
 {
-    smf = new MxSMFReader;
+  smf = new MxSMFReader;
 
-    process_cmdline(argc, argv);
-    if( m->face_count() == 0 )
-    {
-	smf->read(cin, m);
-    }
+  process_cmdline(argc, argv);
+  if (m->face_count() == 0) {
+    smf->read(cin, m);
+  }
 
-    output_preamble();
+  output_preamble();
 }
 
 int
-main(int argc, char **argv)
+main(int argc, char** argv)
 {
   amrex::SetVerbose(0);
-    amrex::Initialize(argc,argv,false);
-    {
+  amrex::Initialize(argc, argv, false);
+  {
     double input_time, init_time, slim_time, output_time;
 
     // Process command line and read input model(s)
     //
     TIMING(input_time, startup_and_input(argc, argv));
 
-    if(!be_quiet) cerr << "+ Initial model    ";
-    if(!be_quiet) vfcount(cerr, m->vert_count(), m->face_count()) << endl;
+    if (!be_quiet)
+      cerr << "+ Initial model    ";
+    if (!be_quiet)
+      vfcount(cerr, m->vert_count(), m->face_count()) << endl;
 
     // Initial simplification process.  Collect contractions and build heap.
     //
@@ -57,32 +60,31 @@ main(int argc, char **argv)
     //
     TIMING(slim_time, slim->decimate(face_target));
 
-    if(!be_quiet) cerr << "+ Simplified model ";
-    if(!be_quiet) vfcount(cerr, slim->valid_verts, slim->valid_faces) << endl;
+    if (!be_quiet)
+      cerr << "+ Simplified model ";
+    if (!be_quiet)
+      vfcount(cerr, slim->valid_verts, slim->valid_faces) << endl;
 
     // Output the result
     //
     TIMING(output_time, output_final_model());
 
-    if( !be_quiet )
-    {
-	cerr << endl << endl;
-	cerr << "+ Running time" << endl;
-	cerr << "    Setup      : " << input_time << " sec" << endl;
-	cerr << "    QSlim init : " << init_time << " sec" << endl;
-	cerr << "    QSlim run  : " << slim_time << " sec" << endl;
-	cerr << "    Output     : " << output_time << " sec" << endl;
-	cerr << endl;
-	cerr << "    Total      : "
-	     << input_time+init_time+slim_time+output_time <<endl;
-    }
-    else
-    {
-	cerr << slim->valid_faces << " " << init_time+slim_time << endl;
+    if (!be_quiet) {
+      cerr << endl << endl;
+      cerr << "+ Running time" << endl;
+      cerr << "    Setup      : " << input_time << " sec" << endl;
+      cerr << "    QSlim init : " << init_time << " sec" << endl;
+      cerr << "    QSlim run  : " << slim_time << " sec" << endl;
+      cerr << "    Output     : " << output_time << " sec" << endl;
+      cerr << endl;
+      cerr << "    Total      : "
+           << input_time + init_time + slim_time + output_time << endl;
+    } else {
+      cerr << slim->valid_faces << " " << init_time + slim_time << endl;
     }
 
     slim_cleanup();
-    }
-    amrex::Finalize(); 
-    return 0;
+  }
+  amrex::Finalize();
+  return 0;
 }

--- a/Src/dumpFABslice.cpp
+++ b/Src/dumpFABslice.cpp
@@ -6,14 +6,13 @@
 
 using namespace amrex;
 
-static
-void
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=<s> [options] \n\tOptions:\n";
-  std::cerr << "\t     varNames=<s,s,...> variables to slice (will output individual planes), (OPT, will output all by default)\n";
+  std::cerr << "\t     varNames=<s,s,...> variables to slice (will output "
+               "individual planes), (OPT, will output all by default)\n";
   std::cerr << "\t     dir=<i> direction to take slice (only needed for 3D)\n";
   std::cerr << "\t     num=<i> slice number to take (only needed for 3D)\n";
 
@@ -23,61 +22,63 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
-    //declare ParmParse
+      print_usage(argc, argv);
+    // declare ParmParse
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
     std::string plotFileName;
-    pp.get("infile",plotFileName);
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
 #if AMREX_SPACEDIM == 2
     constexpr int dir = 2;
     constexpr int num = 0;
 #else
-    int dir,num;
-    pp.get("dir",dir);
-    pp.get("num",num);
+    int dir, num;
+    pp.get("dir", dir);
+    pp.get("num", num);
 #endif
 
     AmrData& amrData = dataServices.AmrDataRef();
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     Box domainBox = amrData.ProbDomain()[finestLevel];
     std::string fabName;
     int numVars = pp.countval("varNames");
     Vector<std::string> varNames;
     if (numVars > 0) {
       varNames.resize(numVars);
-      pp.getarr("varNames",varNames);
+      pp.getarr("varNames", varNames);
       for (int n = 0; n < numVars; n++) {
-	DataServices::Dispatch(DataServices::DumpSlicePlaneOneVar,&dataServices,dir,num,varNames[n]);	
+        DataServices::Dispatch(
+          DataServices::DumpSlicePlaneOneVar, &dataServices, dir, num,
+          varNames[n]);
       }
     } else {
-      DataServices::Dispatch(DataServices::DumpSlicePlaneAllVars,&dataServices,dir,num);	
-    }    
-  }  
+      DataServices::Dispatch(
+        DataServices::DumpSlicePlaneAllVars, &dataServices, dir, num);
+    }
+  }
   amrex::Finalize();
   return 0;
 }

--- a/Src/filterPlt.cpp
+++ b/Src/filterPlt.cpp
@@ -11,219 +11,243 @@
 #include <PltFileManager.H>
 #include <PltFileManagerBCFill.H>
 
-static
-void
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
-  std::cerr << "Utility to average pltfiles on same domain but with non-matching AMR";
+  std::cerr
+    << "Utility to average pltfiles on same domain but with non-matching AMR";
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile=<s> [options] \n\tOptions:\n";
   std::cerr << "\t     infile=<s> where s is a pltfile \n";
-  std::cerr << "\t     variables=<s1 s2 s3> where <s1> <s2> and <s3> are variable names to select for combined pltfile [DEF-> all possible]\n";
-  std::cerr << "\t     max_filter_level=<int> where <int> is the max refinement level to filter, zero-indexed [DEF->1000]\n";
-  std::cerr << "\t     filter_type=<int> where <int> is the filter type as defined in PeleC (1->box, 2->Gaussian, etc) [DEF->1000]\n";
-  std::cerr << "\t     base_fgr=<int> where <int> is the desired filter to grid ratio on the base level, must be even [DEF->2]\n";
-  std::cerr << "\t     same_fgr_all_levels=<bool> where if true the same filter to grid ratio is kept on all levels (rather than absolute filter width) [DEF->false]\n";
-  std::cerr << "\t     max_grid_size=<int> where <int> is the AMReX max_grid_size for the output [DEF->32]\n";
-  std::cerr << "\t     interp_type=<int> where this determines the type of interpolation when FillPatching: 0 -> piecewise constant, 1 -> cell cons linear [DEF->1]\n";
-exit(1);
+  std::cerr
+    << "\t     variables=<s1 s2 s3> where <s1> <s2> and <s3> are variable "
+       "names to select for combined pltfile [DEF-> all possible]\n";
+  std::cerr << "\t     max_filter_level=<int> where <int> is the max "
+               "refinement level to filter, zero-indexed [DEF->1000]\n";
+  std::cerr << "\t     filter_type=<int> where <int> is the filter type as "
+               "defined in PeleC (1->box, 2->Gaussian, etc) [DEF->1000]\n";
+  std::cerr << "\t     base_fgr=<int> where <int> is the desired filter to "
+               "grid ratio on the base level, must be even [DEF->2]\n";
+  std::cerr << "\t     same_fgr_all_levels=<bool> where if true the same "
+               "filter to grid ratio is kept on all levels (rather than "
+               "absolute filter width) [DEF->false]\n";
+  std::cerr << "\t     max_grid_size=<int> where <int> is the AMReX "
+               "max_grid_size for the output [DEF->32]\n";
+  std::cerr << "\t     interp_type=<int> where this determines the type of "
+               "interpolation when FillPatching: 0 -> piecewise constant, 1 -> "
+               "cell cons linear [DEF->1]\n";
+  exit(1);
 }
 
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = amrex::Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = amrex::Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
-
-void write_plotfile (const std::string &plotfilename,
-                              int nlevels,
-                              const amrex::Vector<const amrex::MultiFab*> &mf,
-                              const amrex::Vector<std::string> &varnames,
-                              const amrex::Vector<amrex::Geometry> &geom,
-                              amrex::Real time,
-                              const amrex::Vector<int> &level_steps)
+void
+write_plotfile(
+  const std::string& plotfilename,
+  int nlevels,
+  const amrex::Vector<const amrex::MultiFab*>& mf,
+  const amrex::Vector<std::string>& varnames,
+  const amrex::Vector<amrex::Geometry>& geom,
+  amrex::Real time,
+  const amrex::Vector<int>& level_steps)
 {
 
-  amrex::Vector<amrex::IntVect> ref_ratio(nlevels-1,{AMREX_D_DECL(2, 2, 2)});
-  amrex::WriteMultiLevelPlotfile(plotfilename, nlevels, mf, varnames,
-                            geom, time, level_steps,ref_ratio);
+  amrex::Vector<amrex::IntVect> ref_ratio(nlevels - 1, {AMREX_D_DECL(2, 2, 2)});
+  amrex::WriteMultiLevelPlotfile(
+    plotfilename, nlevels, mf, varnames, geom, time, level_steps, ref_ratio);
 }
 
 int
 main(int argc, char** argv)
 {
 
-    amrex::Initialize(argc,argv);
-    // ---------------------------------------------------------------------
-    // ParmParse
-    // ---------------------------------------------------------------------
-    amrex::ParmParse pp;
+  amrex::Initialize(argc, argv);
+  // ---------------------------------------------------------------------
+  // ParmParse
+  // ---------------------------------------------------------------------
+  amrex::ParmParse pp;
 
-    if (argc < 2 || pp.contains("help")) {
-       print_usage(argc,argv);
-     }
+  if (argc < 2 || pp.contains("help")) {
+    print_usage(argc, argv);
+  }
 
-    std::string infile        = "";
-    int finestLevel           = 1000;
-    amrex::Vector<Filter> les_filter;
-    int les_filter_type = 1;
-    int les_filter_fgr  = 2;
-    bool same_fgr_all_levels = false;
-    int interp_type = 1;
+  std::string infile = "";
+  int finestLevel = 1000;
+  amrex::Vector<Filter> les_filter;
+  int les_filter_type = 1;
+  int les_filter_fgr = 2;
+  bool same_fgr_all_levels = false;
+  int interp_type = 1;
 
-    pp.get("infile",infile);
-    pp.query("max_filter_level",finestLevel);
-    pp.query("filter_type",les_filter_type);
-    pp.query("base_fgr",les_filter_fgr); // filter to grid ratio
-    pp.query("same_fgr_all_levels", same_fgr_all_levels);
-    int max_grid_size = 32;
-    pp.query("max_grid_size",max_grid_size);
-    pp.query("interp_type",interp_type);
+  pp.get("infile", infile);
+  pp.query("max_filter_level", finestLevel);
+  pp.query("filter_type", les_filter_type);
+  pp.query("base_fgr", les_filter_fgr); // filter to grid ratio
+  pp.query("same_fgr_all_levels", same_fgr_all_levels);
+  int max_grid_size = 32;
+  pp.query("max_grid_size", max_grid_size);
+  pp.query("interp_type", interp_type);
 
-    // use PltFileManager to load data
-    amrex::Vector<pele::physics::pltfilemanager::PltFileManager*> plt_file_data(1);
-    plt_file_data[0] = new pele::physics::pltfilemanager::PltFileManager(infile);
-    // Plotfile global infos
-    int Nlev = std::min(finestLevel + 1, plt_file_data[0]->getNlev());
+  // use PltFileManager to load data
+  amrex::Vector<pele::physics::pltfilemanager::PltFileManager*> plt_file_data(
+    1);
+  plt_file_data[0] = new pele::physics::pltfilemanager::PltFileManager(infile);
+  // Plotfile global infos
+  int Nlev = std::min(finestLevel + 1, plt_file_data[0]->getNlev());
 
-    // Variable names
-    int ncomp_filter;
-    amrex::Vector<std::string> variableNames;
-    amrex::Vector<int> var_idxs;
-    int nvar = pp.countval("variables");
-    bool all_vars = nvar > 0 ? false : true;
-    if (!all_vars) {
-      ncomp_filter = nvar;
-      pp.getarr("variables",variableNames);
-      const amrex::Vector<std::string>& plotVarNames = plt_file_data[0]->getVariableList();
+  // Variable names
+  int ncomp_filter;
+  amrex::Vector<std::string> variableNames;
+  amrex::Vector<int> var_idxs;
+  int nvar = pp.countval("variables");
+  bool all_vars = nvar > 0 ? false : true;
+  if (!all_vars) {
+    ncomp_filter = nvar;
+    pp.getarr("variables", variableNames);
+    const amrex::Vector<std::string>& plotVarNames =
+      plt_file_data[0]->getVariableList();
+    for (int var = 0; var < nvar; ++var) {
+      int pvar;
+      for (pvar = 0; pvar < plotVarNames.size(); ++pvar) {
+        if (variableNames[var] == plotVarNames[pvar]) {
+          var_idxs.push_back(pvar);
+          break;
+        }
+      }
+      if (pvar == plotVarNames.size()) {
+        amrex::Abort("Variable '" + variableNames[var] + "' not found in file");
+      }
+    }
+  } else {
+    variableNames = plt_file_data[0]->getVariableList();
+    ncomp_filter = variableNames.size();
+  }
+
+  amrex::Vector<amrex::MultiFab> indata(Nlev);
+  amrex::Vector<amrex::MultiFab> outdata(Nlev);
+  amrex::Vector<amrex::Geometry> level_geometries;
+
+  // Load the data from the Pltfile
+  amrex::Print() << "Reading data..." << std::endl;
+  int les_filter_fgr_lev = les_filter_fgr;
+  for (int lev = 0; lev < Nlev; ++lev) {
+    amrex::Print() << "on level " << lev << std::endl;
+
+    // Initialize filter stuff
+    if ((!same_fgr_all_levels) && (lev > 0)) {
+      les_filter_fgr_lev *= plt_file_data[0]->getRefRatio(lev - 1);
+    }
+
+    les_filter.push_back(Filter(les_filter_type, les_filter_fgr_lev));
+    int nGrowF = les_filter[lev].get_filter_ngrow();
+    int nGrow = 0;
+
+    amrex::BoxArray ba(plt_file_data[0]->getGrid(lev));
+    ba.maxSize(max_grid_size);
+    const amrex::DistributionMapping dm = amrex::DistributionMapping(ba);
+    level_geometries.push_back(plt_file_data[0]->getGeom(lev));
+    indata[lev].define(ba, dm, ncomp_filter, nGrowF);
+    outdata[lev].define(ba, dm, ncomp_filter, nGrow);
+
+    if (all_vars) {
+      plt_file_data[0]->fillPatchFromPlt(
+        lev, level_geometries[lev], 0, 0, ncomp_filter, indata[lev],
+        interp_type);
+    } else {
       for (int var = 0; var < nvar; ++var) {
-        int pvar;
-        for (pvar = 0; pvar < plotVarNames.size(); ++pvar) {
-          if (variableNames[var] == plotVarNames[pvar]) {
-            var_idxs.push_back(pvar);
-            break;
-          }
-        }
-        if (pvar == plotVarNames.size()) {
-          amrex::Abort("Variable '" + variableNames[var] + "' not found in file");
-        }
+        plt_file_data[0]->fillPatchFromPlt(
+          lev, level_geometries[lev], var_idxs[var], var, 1, indata[lev],
+          interp_type);
+      }
+    }
+  }
+  amrex::Print() << "Done!" << std::endl;
+
+  // fillPatchFromPlt doesn't fill ghost cells, so fill those now
+  // Note: domain boundary cells will be FOExtraped because we don't know
+  // anything better to do
+  amrex::Print() << "FillPatching data..." << std::endl;
+  amrex::Vector<amrex::BCRec> dummyBCRec(ncomp_filter);
+  for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+    if (level_geometries[0].isPeriodic(idim)) {
+      for (int n = 0; n < ncomp_filter; n++) {
+        dummyBCRec[n].setLo(idim, amrex::BCType::int_dir);
+        dummyBCRec[n].setHi(idim, amrex::BCType::int_dir);
       }
     } else {
-      variableNames = plt_file_data[0]->getVariableList();
-      ncomp_filter = variableNames.size();
-    }
-
-    amrex::Vector<amrex::MultiFab> indata(Nlev);
-    amrex::Vector<amrex::MultiFab> outdata(Nlev);
-    amrex::Vector<amrex::Geometry> level_geometries;
-
-    // Load the data from the Pltfile
-    amrex::Print() << "Reading data..." << std::endl;
-    int les_filter_fgr_lev = les_filter_fgr;
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-      amrex::Print() << "on level "<< lev << std::endl;
-
-      // Initialize filter stuff
-      if ((!same_fgr_all_levels) && (lev > 0)) {
-        les_filter_fgr_lev *= plt_file_data[0]->getRefRatio(lev - 1);
+      for (int n = 0; n < ncomp_filter; n++) {
+        dummyBCRec[n].setLo(idim, amrex::BCType::foextrap);
+        dummyBCRec[n].setHi(idim, amrex::BCType::foextrap);
       }
-
-      les_filter.push_back(Filter(les_filter_type, les_filter_fgr_lev));
-      int nGrowF = les_filter[lev].get_filter_ngrow();
-      int nGrow  = 0;
-
-      amrex::BoxArray ba(plt_file_data[0]->getGrid(lev));
-      ba.maxSize(max_grid_size);
-      const amrex::DistributionMapping dm = amrex::DistributionMapping(ba);
-      level_geometries.push_back(plt_file_data[0]->getGeom(lev));
-      indata[lev].define(ba,dm,ncomp_filter,nGrowF);
-      outdata[lev].define(ba,dm,ncomp_filter,nGrow);
-
-      if (all_vars) {
-        plt_file_data[0]->fillPatchFromPlt(lev, level_geometries[lev], 0, 0, ncomp_filter, indata[lev], interp_type);
+    }
+  }
+  for (int lev = 0; lev < Nlev; ++lev) {
+    amrex::Print() << "on level " << lev << std::endl;
+    if (lev == 0) {
+      amrex::PhysBCFunct<
+        amrex::GpuBndryFuncFab<pele::physics::pltfilemanager::FillExtDirDummy>>
+        bndry_func(
+          level_geometries[lev], {dummyBCRec},
+          pele::physics::pltfilemanager::FillExtDirDummy{});
+      amrex::FillPatchSingleLevel(
+        indata[lev], indata[lev].nGrowVect(), 0.0, {&(indata[lev])}, {0.0}, 0,
+        0, ncomp_filter, level_geometries[lev], bndry_func, 0);
+    } else {
+      amrex::InterpBase* mapper;
+      if (interp_type == 1) {
+        mapper = &amrex::mf_cell_cons_interp;
       } else {
-        for (int var = 0; var < nvar; ++var) {
-          plt_file_data[0]->fillPatchFromPlt(lev, level_geometries[lev], var_idxs[var], var, 1, indata[lev], interp_type);
-        }
+        mapper = &amrex::mf_pc_interp;
       }
+      amrex::PhysBCFunct<
+        amrex::GpuBndryFuncFab<pele::physics::pltfilemanager::FillExtDirDummy>>
+        crse_bndry_func(
+          level_geometries[lev - 1], {dummyBCRec},
+          pele::physics::pltfilemanager::FillExtDirDummy{});
+      amrex::PhysBCFunct<
+        amrex::GpuBndryFuncFab<pele::physics::pltfilemanager::FillExtDirDummy>>
+        fine_bndry_func(
+          level_geometries[lev], {dummyBCRec},
+          pele::physics::pltfilemanager::FillExtDirDummy{});
+      FillPatchTwoLevels(
+        indata[lev], indata[lev].nGrowVect(), 0.0, {&(indata[lev - 1])}, {0.0},
+        {&(indata[lev])}, {0.0}, 0, 0, ncomp_filter, level_geometries[lev - 1],
+        level_geometries[lev], crse_bndry_func, 0, fine_bndry_func, 0,
+        amrex::IntVect(plt_file_data[0]->getRefRatio(lev - 1)), mapper,
+        {dummyBCRec}, 0);
     }
-    amrex::Print() << "Done!" << std::endl;
+  }
+  amrex::Print() << "Done!" << std::endl;
 
-    // fillPatchFromPlt doesn't fill ghost cells, so fill those now
-    // Note: domain boundary cells will be FOExtraped because we don't know anything better to do
-    amrex::Print() << "FillPatching data..." << std::endl;
-    amrex::Vector<amrex::BCRec> dummyBCRec(ncomp_filter);
-    for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
-      if (level_geometries[0].isPeriodic(idim)) {
-        for (int n = 0; n < ncomp_filter; n++) {
-          dummyBCRec[n].setLo(idim, amrex::BCType::int_dir);
-          dummyBCRec[n].setHi(idim, amrex::BCType::int_dir);
-        }
-      } else {
-        for (int n = 0; n < ncomp_filter; n++) {
-          dummyBCRec[n].setLo(idim, amrex::BCType::foextrap);
-          dummyBCRec[n].setHi(idim, amrex::BCType::foextrap);
-        }
-      }
+  amrex::Print() << "Filtering data..." << std::endl;
+  for (int lev = 0; lev < Nlev; ++lev) {
+    amrex::Print() << "on level " << lev << std::endl;
+
+    for (amrex::MFIter mfi(indata[lev], amrex::TilingIfNotGPU()); mfi.isValid();
+         ++mfi) {
+
+      amrex::FArrayBox& fab_in = (indata[lev])[mfi];
+      amrex::FArrayBox& fab_out = (outdata[lev])[mfi];
+      const amrex::Box& box = mfi.validbox();
+
+      les_filter[lev].apply_filter(box, fab_in, fab_out);
     }
-    for (int lev=0; lev<Nlev; ++lev) {
-      amrex::Print() << "on level "<< lev << std::endl;
-      if (lev == 0) {
-        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<pele::physics::pltfilemanager::FillExtDirDummy>> bndry_func(
-        level_geometries[lev], {dummyBCRec}, pele::physics::pltfilemanager::FillExtDirDummy{});
-        amrex::FillPatchSingleLevel(indata[lev], indata[lev].nGrowVect(), 0.0,
-                             {&(indata[lev])},
-                             {0.0}, 0, 0, ncomp_filter, level_geometries[lev], bndry_func, 0);
-      } else {
-        amrex::InterpBase* mapper;
-        if (interp_type == 1) {
-          mapper = &amrex::mf_cell_cons_interp;
-        } else {
-          mapper = &amrex::mf_pc_interp;
-        }
-        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<pele::physics::pltfilemanager::FillExtDirDummy>> crse_bndry_func(
-          level_geometries[lev-1], {dummyBCRec}, pele::physics::pltfilemanager::FillExtDirDummy{});
-        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<pele::physics::pltfilemanager::FillExtDirDummy>> fine_bndry_func(
-          level_geometries[lev], {dummyBCRec}, pele::physics::pltfilemanager::FillExtDirDummy{});
-        FillPatchTwoLevels(indata[lev], indata[lev].nGrowVect(), 0.0,
-                           {&(indata[lev-1])},
-                           {0.0},
-                           {&(indata[lev])},
-                           {0.0},
-                           0, 0, ncomp_filter,
-                           level_geometries[lev - 1], level_geometries[lev],
-                           crse_bndry_func, 0, fine_bndry_func, 0, amrex::IntVect(plt_file_data[0]->getRefRatio(lev - 1)), mapper,
-                           {dummyBCRec}, 0);
-      }
-    }
-    amrex::Print() << "Done!" << std::endl;
+  }
+  amrex::Print() << "Done!" << std::endl;
 
-    amrex::Print() << "Filtering data..." << std::endl;
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-      amrex::Print() << "on level " << lev << std::endl;
+  amrex::Print() << "Saving filtered data..." << std::endl;
+  std::string outfile(getFileRoot(infile) + "_filtered");
 
-      for (amrex::MFIter mfi(indata[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+  write_plotfile(
+    outfile, Nlev, amrex::GetVecOfConstPtrs(outdata), variableNames,
+    level_geometries, plt_file_data[0]->getTime(), amrex::Vector<int>(Nlev, 0));
+  amrex::Print() << "Done!" << std::endl;
 
-        amrex::FArrayBox& fab_in  = (indata[lev])[mfi];
-        amrex::FArrayBox& fab_out = (outdata[lev])[mfi];
-        const amrex::Box& box = mfi.validbox();
-
-        les_filter[lev].apply_filter(box, fab_in, fab_out);
-      }
-    }
-    amrex::Print() << "Done!" << std::endl;
-
-    amrex::Print() << "Saving filtered data..." << std::endl;
-    std::string outfile(getFileRoot(infile) + "_filtered");
-
-    write_plotfile(outfile,Nlev,amrex::GetVecOfConstPtrs(outdata),variableNames,level_geometries,plt_file_data[0]->getTime(),amrex::Vector<int>(Nlev, 0));
-    amrex::Print() << "Done!" << std::endl;
-
-    amrex::Finalize();
-    return 0;
+  amrex::Finalize();
+  return 0;
 }

--- a/Src/flattenAMRFile.cpp
+++ b/Src/flattenAMRFile.cpp
@@ -5,98 +5,97 @@
 
 using namespace amrex;
 
-static
-void
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile=<s> [options] \n\tOptions:\n";
   std::cerr << "\t     infile=<s> where <s> is a pltfile\n";
   std::cerr << "\t     output_file=<s> where <s> is the flatten pltfile\n";
-  std::cerr << "\t     output_level=<s> where <s> is the level of infile kept in output_file [DEF->0]\n";
-  std::cerr << "\t     output_max_grid_size=<s> where <s> is the flatten max_grid_size [DEF->64]\n";
-exit(1);
+  std::cerr << "\t     output_level=<s> where <s> is the level of infile kept "
+               "in output_file [DEF->0]\n";
+  std::cerr << "\t     output_max_grid_size=<s> where <s> is the flatten "
+               "max_grid_size [DEF->64]\n";
+  exit(1);
 }
 
 std::string
 getFileRoot(const std::string& infile)
 {
-    std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-    return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-   amrex::Initialize(argc,argv);
-   {
-     if (argc < 2) {
-       print_usage(argc,argv);
-     }
-     // ---------------------------------------------------------------------
-     // ParmParse
-     // ---------------------------------------------------------------------
-     ParmParse pp;
+  amrex::Initialize(argc, argv);
+  {
+    if (argc < 2) {
+      print_usage(argc, argv);
+    }
+    // ---------------------------------------------------------------------
+    // ParmParse
+    // ---------------------------------------------------------------------
+    ParmParse pp;
 
-     if (pp.contains("help")) {
-       print_usage(argc,argv);
-     }
+    if (pp.contains("help")) {
+      print_usage(argc, argv);
+    }
 
-     int verbose = 0;
-     pp.query("verbose",verbose);
-     std::string plotFileName;
-     pp.get("infile",plotFileName);
-     std::string outfile(getFileRoot(plotFileName) + "_flatten");
-     pp.query("output_file",outfile);
-     int output_level = 0;
-     pp.query("output_level",output_level);
-     int output_mgs = 64;
-     pp.query("output_max_grid_size",output_mgs);
+    int verbose = 0;
+    pp.query("verbose", verbose);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
+    std::string outfile(getFileRoot(plotFileName) + "_flatten");
+    pp.query("output_file", outfile);
+    int output_level = 0;
+    pp.query("output_level", output_level);
+    int output_mgs = 64;
+    pp.query("output_max_grid_size", output_mgs);
 
-     // ---------------------------------------------------------------------
-     // Initiate PelePhysics PltFileManager
-     // ---------------------------------------------------------------------
-     if (verbose) {
-       Print() << " Reading data from pltfile " << plotFileName << "\n";
-     }
-     pele::physics::pltfilemanager::PltFileManager pltData(plotFileName);
-     Vector<std::string> plt_vars = pltData.getVariableList();
-     int nvars = plt_vars.size();
+    // ---------------------------------------------------------------------
+    // Initiate PelePhysics PltFileManager
+    // ---------------------------------------------------------------------
+    if (verbose) {
+      Print() << " Reading data from pltfile " << plotFileName << "\n";
+    }
+    pele::physics::pltfilemanager::PltFileManager pltData(plotFileName);
+    Vector<std::string> plt_vars = pltData.getVariableList();
+    int nvars = plt_vars.size();
 
-     // Check
-     AMREX_ALWAYS_ASSERT(output_level < pltData.getNlev());
+    // Check
+    AMREX_ALWAYS_ASSERT(output_level < pltData.getNlev());
 
-     // ---------------------------------------------------------------------
-     // Set the outgoing geom/grid/dmap/MF
-     // ---------------------------------------------------------------------
-     if (verbose) {
-       Print() << " Setting outgoing container \n";
-     }
-     auto geom = pltData.getGeom(output_level);
-     BoxArray grid{geom.Domain()};
-     grid.maxSize(output_mgs);
-     const DistributionMapping dmap{grid};
-     MultiFab output(grid,dmap,nvars,0);
-         
-     // ---------------------------------------------------------------------
-     // Interpolate data
-     // ---------------------------------------------------------------------
-     if (verbose) {
-       Print() << " Interpolate data \n";
-     }
-     pltData.fillPatchFromPlt(0, geom, 0, 0, nvars, output);
-     
-     // ---------------------------------------------------------------------
-     // Write standard pltfile
-     // ---------------------------------------------------------------------
-     if (verbose) {
-       Print() << " Writting data \n";
-     }
-     WriteSingleLevelPlotfile(outfile, output, plt_vars, geom, pltData.getTime(), 0);
+    // ---------------------------------------------------------------------
+    // Set the outgoing geom/grid/dmap/MF
+    // ---------------------------------------------------------------------
+    if (verbose) {
+      Print() << " Setting outgoing container \n";
+    }
+    auto geom = pltData.getGeom(output_level);
+    BoxArray grid{geom.Domain()};
+    grid.maxSize(output_mgs);
+    const DistributionMapping dmap{grid};
+    MultiFab output(grid, dmap, nvars, 0);
 
-   }
-   amrex::Finalize();
-   return 0;
+    // ---------------------------------------------------------------------
+    // Interpolate data
+    // ---------------------------------------------------------------------
+    if (verbose) {
+      Print() << " Interpolate data \n";
+    }
+    pltData.fillPatchFromPlt(0, geom, 0, 0, nvars, output);
+
+    // ---------------------------------------------------------------------
+    // Write standard pltfile
+    // ---------------------------------------------------------------------
+    if (verbose) {
+      Print() << " Writting data \n";
+    }
+    WriteSingleLevelPlotfile(
+      outfile, output, plt_vars, geom, pltData.getTime(), 0);
+  }
+  amrex::Finalize();
+  return 0;
 }

--- a/Src/grad.cpp
+++ b/Src/grad.cpp
@@ -12,40 +12,39 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
-  std::cerr << argv[0] << " infile=<plotfilename> \n\tOptions:\n\tis_per=<L M N> gradVar=<name>\n";
+  std::cerr
+    << argv[0]
+    << " infile=<plotfilename> \n\tOptions:\n\tis_per=<L M N> gradVar=<name>\n";
   exit(1);
 }
 
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
   {
     if (argc < 2) {
-      print_usage(argc,argv);
+      print_usage(argc, argv);
     }
 
     // ---------------------------------------------------------------------
     // Set defaults input values
     // ---------------------------------------------------------------------
-    std::string gradVar       = "temp";
-    std::string infile        = "";  
-    int finestLevel           = 1000;
-    int nAuxVar               = 0;
+    std::string gradVar = "temp";
+    std::string infile = "";
+    int finestLevel = 1000;
+    int nAuxVar = 0;
 
     // ---------------------------------------------------------------------
     // ParmParse
@@ -53,44 +52,43 @@ main (int   argc,
     ParmParse pp;
 
     if (pp.contains("help")) {
-      print_usage(argc,argv);
+      print_usage(argc, argv);
     }
 
-    pp.get("infile",infile);
-    pp.query("gradVar",gradVar);
-    pp.query("finestLevel",finestLevel);
+    pp.get("infile", infile);
+    pp.query("gradVar", gradVar);
+    pp.query("finestLevel", finestLevel);
 
     // Initialize DataService
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(infile, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     // Plotfile global infos
-    finestLevel = std::min(finestLevel,amrData.FinestLevel());
+    finestLevel = std::min(finestLevel, amrData.FinestLevel());
     int Nlev = finestLevel + 1;
     const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    RealBox rb(&(amrData.ProbLo()[0]), 
-               &(amrData.ProbHi()[0]));
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
 
     // Gradient variable
     int idC = -1;
-    for (int i=0; i<plotVarNames.size(); ++i)
-    {
-      if (plotVarNames[i] == gradVar) idC = i;
+    for (int i = 0; i < plotVarNames.size(); ++i) {
+      if (plotVarNames[i] == gradVar)
+        idC = i;
     }
-    if (idC<0) {
+    if (idC < 0) {
       Print() << "Cannot find " << gradVar << " data in pltfile \n";
     }
 
     // Auxiliary variables
     nAuxVar = pp.countval("Aux_Variables");
     Vector<std::string> AuxVar(nAuxVar);
-    for(int ivar = 0; ivar < nAuxVar; ++ivar) { 
-         pp.get("Aux_Variables", AuxVar[ivar],ivar);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      pp.get("Aux_Variables", AuxVar[ivar], ivar);
     }
 
     // ---------------------------------------------------------------------
@@ -101,45 +99,45 @@ main (int   argc,
     Vector<std::string> inVarNames(nCompIn);
     inVarNames[idCst] = plotVarNames[idC];
 
-    if (nAuxVar>0)
-    {
-        inVarNames.resize(nCompIn+nAuxVar);
-        for (int ivar=0; ivar<nAuxVar; ++ivar) {
-            if ( amrData.StateNumber(AuxVar[ivar]) < 0 ) {
-               amrex::Abort("Unknown auxiliary variable name: "+AuxVar[ivar]);
-            }
-            inVarNames[nCompIn] = AuxVar[ivar];
-            nCompIn ++;
-        } 
+    if (nAuxVar > 0) {
+      inVarNames.resize(nCompIn + nAuxVar);
+      for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+        if (amrData.StateNumber(AuxVar[ivar]) < 0) {
+          amrex::Abort("Unknown auxiliary variable name: " + AuxVar[ivar]);
+        }
+        inVarNames[nCompIn] = AuxVar[ivar];
+        nCompIn++;
+      }
     }
 
     Vector<int> destFillComps(nCompIn);
-    for (int i=0; i<nCompIn; ++i) {
+    for (int i = 0; i < nCompIn; ++i) {
       destFillComps[i] = i;
     }
 
     const int idGr = nCompIn;
-    const int nCompOut = idGr + AMREX_SPACEDIM +1 ; // 1 component stores the ||gradT||
+    const int nCompOut =
+      idGr + AMREX_SPACEDIM + 1; // 1 component stores the ||gradT||
 
     // Check symmetry/periodicity in given coordinate direction
-    Vector<int> sym_dir(AMREX_SPACEDIM,0);
-    pp.queryarr("sym_dir",sym_dir,0,AMREX_SPACEDIM);  
+    Vector<int> sym_dir(AMREX_SPACEDIM, 0);
+    pp.queryarr("sym_dir", sym_dir, 0, AMREX_SPACEDIM);
 
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     Print() << "Periodicity assumed for this case: ";
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        Print() << is_per[idim] << " ";
+      Print() << is_per[idim] << " ";
     }
     Print() << "\n";
     BCRec gradVarBC;
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        gradVarBC.setLo(idim,BCType::foextrap);
-        gradVarBC.setHi(idim,BCType::foextrap);
-        if ( is_per[idim] ) {
-            gradVarBC.setLo(idim, BCType::int_dir);
-            gradVarBC.setHi(idim, BCType::int_dir);
-        }
+      gradVarBC.setLo(idim, BCType::foextrap);
+      gradVarBC.setHi(idim, BCType::foextrap);
+      if (is_per[idim]) {
+        gradVarBC.setLo(idim, BCType::int_dir);
+        gradVarBC.setHi(idim, BCType::int_dir);
+      }
     }
 
     int coord = 0;
@@ -154,18 +152,19 @@ main (int   argc,
     const int nGrow = 1;
 
     // Read data on all the levels
-    for (int lev=0; lev<Nlev; ++lev) {
+    for (int lev = 0; lev < Nlev; ++lev) {
 
       const BoxArray ba = amrData.boxArray(lev);
       grids[lev] = ba;
       dmap[lev] = DistributionMapping(ba);
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb,coord,&(is_per[0]));
+      geoms[lev] =
+        Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
       state[lev].define(grids[lev], dmap[lev], nCompOut, nGrow);
 
       Print() << "Reading data for level: " << lev << std::endl;
       amrData.FillVar(state[lev], lev, inVarNames, destFillComps);
 
-      state[lev].FillBoundary(idCst,1,geoms[lev].periodicity());
+      state[lev].FillBoundary(idCst, 1, geoms[lev].periodicity());
     }
 
     // Get face-centered gradients from MLMG
@@ -178,82 +177,86 @@ main (int   argc,
     poisson.setMaxOrder(4);
     std::array<LinOpBCType, AMREX_SPACEDIM> lo_bc;
     std::array<LinOpBCType, AMREX_SPACEDIM> hi_bc;
-    for (int idim = 0; idim< AMREX_SPACEDIM; idim++){
-       if (is_per[idim] == 1) {
-          lo_bc[idim] = hi_bc[idim] = LinOpBCType::Periodic;
-       } else {
-          if (sym_dir[idim] == 1) {
-             lo_bc[idim] = hi_bc[idim] = LinOpBCType::reflect_odd;
-          } else {
-             lo_bc[idim] = hi_bc[idim] = LinOpBCType::Neumann;
-          }
-       }
+    for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+      if (is_per[idim] == 1) {
+        lo_bc[idim] = hi_bc[idim] = LinOpBCType::Periodic;
+      } else {
+        if (sym_dir[idim] == 1) {
+          lo_bc[idim] = hi_bc[idim] = LinOpBCType::reflect_odd;
+        } else {
+          lo_bc[idim] = hi_bc[idim] = LinOpBCType::Neumann;
+        }
+      }
     }
     poisson.setDomainBC(lo_bc, hi_bc);
 
     // Need to apply the operator to ensure CF consistency with composite solve
-    int nGrowGrad = 0;                   // No need for ghost face on gradient
-    Vector<Array<MultiFab,AMREX_SPACEDIM> > grad(Nlev);
+    int nGrowGrad = 0; // No need for ghost face on gradient
+    Vector<Array<MultiFab, AMREX_SPACEDIM>> grad(Nlev);
     Vector<std::unique_ptr<MultiFab>> phi;
     Vector<MultiFab> laps;
     for (int lev = 0; lev < Nlev; ++lev) {
-      for (int idim = 0; idim <AMREX_SPACEDIM; idim++) {
-         const auto& ba = grids[lev];
-         grad[lev][idim].define(amrex::convert(ba,IntVect::TheDimensionVector(idim)),
-                                dmap[lev], 1, nGrowGrad);
-      }    
-      phi.push_back(std::make_unique<MultiFab> (state[lev],amrex::make_alias,idCst,1));
+      for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+        const auto& ba = grids[lev];
+        grad[lev][idim].define(
+          amrex::convert(ba, IntVect::TheDimensionVector(idim)), dmap[lev], 1,
+          nGrowGrad);
+      }
+      phi.push_back(
+        std::make_unique<MultiFab>(state[lev], amrex::make_alias, idCst, 1));
       poisson.setLevelBC(lev, phi[lev].get());
       laps.emplace_back(grids[lev], dmap[lev], 1, 1);
     }
 
     MLMG mlmg(poisson);
     mlmg.apply(GetVecOfPtrs(laps), GetVecOfPtrs(phi));
-    mlmg.getFluxes(GetVecOfArrOfPtrs(grad), GetVecOfPtrs(phi), MLMG::Location::FaceCenter);
+    mlmg.getFluxes(
+      GetVecOfArrOfPtrs(grad), GetVecOfPtrs(phi), MLMG::Location::FaceCenter);
 
     for (int lev = 0; lev < Nlev; ++lev) {
-        // Convert to cell avg gradient
-        MultiFab gradAlias(state[lev], amrex::make_alias, idGr, AMREX_SPACEDIM);
-        average_face_to_cellcenter(gradAlias, 0, GetArrOfConstPtrs(grad[lev]));
-        gradAlias.mult(-1.0);
+      // Convert to cell avg gradient
+      MultiFab gradAlias(state[lev], amrex::make_alias, idGr, AMREX_SPACEDIM);
+      average_face_to_cellcenter(gradAlias, 0, GetArrOfConstPtrs(grad[lev]));
+      gradAlias.mult(-1.0);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-        for (MFIter mfi(state[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-        {    
-           const Box& bx = mfi.tilebox();
-           auto const& grad_a   = gradAlias.const_array(mfi);
-           auto const& gradMag  = state[lev].array(mfi,idGr+AMREX_SPACEDIM);
-           amrex::ParallelFor(bx, [=]
-           AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-           {    
-              gradMag(i,j,k) = std::sqrt(AMREX_D_TERM(  grad_a(i,j,k,0) * grad_a(i,j,k,0),
-                                                      + grad_a(i,j,k,1) * grad_a(i,j,k,1),
-                                                      + grad_a(i,j,k,2) * grad_a(i,j,k,2)));
-           });  
-        } 
+      for (MFIter mfi(state[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.tilebox();
+        auto const& grad_a = gradAlias.const_array(mfi);
+        auto const& gradMag = state[lev].array(mfi, idGr + AMREX_SPACEDIM);
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            gradMag(i, j, k) = std::sqrt(AMREX_D_TERM(
+              grad_a(i, j, k, 0) * grad_a(i, j, k, 0),
+              +grad_a(i, j, k, 1) * grad_a(i, j, k, 1),
+              +grad_a(i, j, k, 2) * grad_a(i, j, k, 2)));
+          });
+      }
     }
 
     // ---------------------------------------------------------------------
     // Write the results
     // ---------------------------------------------------------------------
     Vector<std::string> nnames(nCompOut);
-    for (int i=0; i<nCompIn; ++i) {
+    for (int i = 0; i < nCompIn; ++i) {
       nnames[i] = inVarNames[i];
     }
-    nnames[idGr+0] = gradVar + "_gx";
-    nnames[idGr+1] = gradVar + "_gy";
-#if AMREX_SPACEDIM==3
-    nnames[idGr+2] = gradVar + "_gz";
+    nnames[idGr + 0] = gradVar + "_gx";
+    nnames[idGr + 1] = gradVar + "_gy";
+#if AMREX_SPACEDIM == 3
+    nnames[idGr + 2] = gradVar + "_gz";
 #endif
-    nnames[idGr+AMREX_SPACEDIM] = "||grad"+ gradVar+ "||";
-    std::string outfile(getFileRoot(infile) + "_gt"); pp.query("outfile",outfile);
+    nnames[idGr + AMREX_SPACEDIM] = "||grad" + gradVar + "||";
+    std::string outfile(getFileRoot(infile) + "_gt");
+    pp.query("outfile", outfile);
 
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(state), nnames,
-                                   geoms, 0.0, isteps, refRatios);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(state), nnames, geoms, 0.0, isteps,
+      refRatios);
   }
   amrex::Finalize();
   return 0;

--- a/Src/integral.cpp
+++ b/Src/integral.cpp
@@ -7,8 +7,24 @@
 #include <AMReX_PlotFileUtil.H>
 
 using namespace amrex;
-#if AMREX_SPACEDIM==3
-void integrate1d(int dir, int dir1, int dir2, Vector<Vector<Vector<Real>>>& outdata, Vector<Real>& x, Vector<Real>& y, AmrData& amrData, Vector<MultiFab*> indata, int nVars, int finestLevel, int cComp, Real cMin, Real cMax, int avg) {
+#if AMREX_SPACEDIM == 3
+void
+integrate1d(
+  int dir,
+  int dir1,
+  int dir2,
+  Vector<Vector<Vector<Real>>>& outdata,
+  Vector<Real>& x,
+  Vector<Real>& y,
+  AmrData& amrData,
+  Vector<MultiFab*> indata,
+  int nVars,
+  int finestLevel,
+  int cComp,
+  Real cMin,
+  Real cMax,
+  int avg)
+{
 
   Box probDomain = amrData.ProbDomain()[finestLevel];
   int ldir1 = probDomain.length(dir1);
@@ -17,41 +33,47 @@ void integrate1d(int dir, int dir1, int dir2, Vector<Vector<Vector<Real>>>& outd
   int refRatio = 1;
   for (int lev = finestLevel; lev >= 0; lev--) {
     Real dzLev = amrData.DxLevel()[lev][dir];
-    if (lev < finestLevel) refRatio *= amrData.RefRatio()[lev];
-    Print() << "Integrating level "<< lev << std::endl;
+    if (lev < finestLevel)
+      refRatio *= amrData.RefRatio()[lev];
+    Print() << "Integrating level " << lev << std::endl;
     for (MFIter mfi(*indata[lev]); mfi.isValid(); ++mfi) {
       const Box& bx = mfi.tilebox();
-      Array4<Real> const& inbox  = (*indata[lev]).array(mfi);
+      Array4<Real> const& inbox = (*indata[lev]).array(mfi);
       AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
-	  if (inbox(i,j,k,nVars) > 1e-8 && (cComp < 0 || (inbox(i,j,k,cComp) >= cMin && inbox(i,j,k,cComp) < cMax))) {
-	    d[0] = i;
-	    d[1] = j;
-	    d[2] = k;
-	    for (int rx = 0; rx < refRatio; rx++) {
-	      for (int ry = 0; ry < refRatio; ry++) {
-		outdata[0][refRatio*d[dir1]+rx][refRatio*d[dir2]+ry] += dzLev;
-		for (int n = 1; n < nVars+1; n++) {
-		  outdata[n][refRatio*d[dir1]+rx][refRatio*d[dir2]+ry] += dzLev*inbox(i,j,k,n-1);
-		}
-	      }
-	    }
-	  });
+        if (
+          inbox(i, j, k, nVars) > 1e-8 &&
+          (cComp < 0 ||
+           (inbox(i, j, k, cComp) >= cMin && inbox(i, j, k, cComp) < cMax))) {
+          d[0] = i;
+          d[1] = j;
+          d[2] = k;
+          for (int rx = 0; rx < refRatio; rx++) {
+            for (int ry = 0; ry < refRatio; ry++) {
+              outdata[0][refRatio * d[dir1] + rx][refRatio * d[dir2] + ry] +=
+                dzLev;
+              for (int n = 1; n < nVars + 1; n++) {
+                outdata[n][refRatio * d[dir1] + rx][refRatio * d[dir2] + ry] +=
+                  dzLev * inbox(i, j, k, n - 1);
+              }
+            }
+          }
+        });
 	
 	}
-	
     }
   }
   for (int i = 0; i < ldir1; i++) {
-    for (int n = 0; n<nVars+1; n++) {
-      ParallelDescriptor::ReduceRealSum(outdata[n][i].data(),ldir2);
+    for (int n = 0; n < nVars + 1; n++) {
+      ParallelDescriptor::ReduceRealSum(outdata[n][i].data(), ldir2);
     }
   }
   if (avg) {
-    for (int n = 1; n<nVars+1; n++) {
+    for (int n = 1; n < nVars + 1; n++) {
       for (int i = 0; i < ldir1; i++) {
-	for (int j = 0; j < ldir2; j++) {
-	  if (outdata[0][i][j] > 0.0) outdata[n][i][j] /= outdata[0][i][j];
-	}
+        for (int j = 0; j < ldir2; j++) {
+          if (outdata[0][i][j] > 0.0)
+            outdata[n][i][j] /= outdata[0][i][j];
+        }
       }
     }
   }
@@ -61,15 +83,30 @@ void integrate1d(int dir, int dir1, int dir2, Vector<Vector<Vector<Real>>>& outd
   Real dxFine = amrData.DxLevel()[finestLevel][dir1];
   Real dyFine = amrData.DxLevel()[finestLevel][dir2];
   for (int i = 0; i < ldir1; i++) {
-    x[i] = plo[dir1] + (i+0.5)*dxFine;
+    x[i] = plo[dir1] + (i + 0.5) * dxFine;
   }
   for (int i = 0; i < ldir2; i++) {
-    y[i] = plo[dir2] + (i+0.5)*dyFine;
-  }  
+    y[i] = plo[dir2] + (i + 0.5) * dyFine;
+  }
   return;
 }
 
-void integrate2d(int dir, int dir1, int dir2, Vector<Vector<Real>>& outdata, Vector<Real>& x, AmrData& amrData, Vector<MultiFab*> indata,int nVars, int finestLevel, int cComp, Real cMin, Real cMax, int avg) {
+void
+integrate2d(
+  int dir,
+  int dir1,
+  int dir2,
+  Vector<Vector<Real>>& outdata,
+  Vector<Real>& x,
+  AmrData& amrData,
+  Vector<MultiFab*> indata,
+  int nVars,
+  int finestLevel,
+  int cComp,
+  Real cMin,
+  Real cMax,
+  int avg)
+{
   Box probDomain = amrData.ProbDomain()[finestLevel];
   int ldir = probDomain.length(dir);
   IntVect d;
@@ -77,164 +114,224 @@ void integrate2d(int dir, int dir1, int dir2, Vector<Vector<Real>>& outdata, Vec
   for (int lev = finestLevel; lev >= 0; lev--) {
     Real dxLev = amrData.DxLevel()[lev][dir1];
     Real dyLev = amrData.DxLevel()[lev][dir2];
-    Real areaLev = dxLev*dyLev;
-    if (lev < finestLevel) refRatio *= amrData.RefRatio()[lev];
-    Print() << "Integrating level "<< lev << std::endl;
+    Real areaLev = dxLev * dyLev;
+    if (lev < finestLevel)
+      refRatio *= amrData.RefRatio()[lev];
+    Print() << "Integrating level " << lev << std::endl;
     for (MFIter mfi(*indata[lev]); mfi.isValid(); ++mfi) {
       const Box& bx = mfi.tilebox();
-      Array4<Real> const& inbox  = (*indata[lev]).array(mfi);
+      Array4<Real> const& inbox = (*indata[lev]).array(mfi);
       AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
-	  if (inbox(i,j,k,nVars) > 1e-8 &&  (cComp < 0 || (inbox(i,j,k,cComp) >= cMin && inbox(i,j,k,cComp) < cMax))) {
-	    d[0] = i;
-	    d[1] = j;
-	    d[2] = k;
-	    for (int rx = 0; rx < refRatio; rx++) {
-	      outdata[0][refRatio*d[dir]+rx] += areaLev;
-	      for (int n = 1; n < nVars+1; n++) {
-		outdata[n][refRatio*d[dir]+rx] += areaLev*inbox(i,j,k,n-1);
-	      }
-	    }
-	  }
-	});
+        if (
+          inbox(i, j, k, nVars) > 1e-8 &&
+          (cComp < 0 ||
+           (inbox(i, j, k, cComp) >= cMin && inbox(i, j, k, cComp) < cMax))) {
+          d[0] = i;
+          d[1] = j;
+          d[2] = k;
+          for (int rx = 0; rx < refRatio; rx++) {
+            outdata[0][refRatio * d[dir] + rx] += areaLev;
+            for (int n = 1; n < nVars + 1; n++) {
+              outdata[n][refRatio * d[dir] + rx] +=
+                areaLev * inbox(i, j, k, n - 1);
+            }
+          }
+        }
+      });
     }
   }
-  for (int n = 0; n < nVars+1; n++) {
-    ParallelDescriptor::ReduceRealSum(outdata[n].data(),ldir);
+  for (int n = 0; n < nVars + 1; n++) {
+    ParallelDescriptor::ReduceRealSum(outdata[n].data(), ldir);
   }
   Real dzFine = amrData.DxLevel()[finestLevel][dir];
   if (avg) {
-    for (int n = 1; n<nVars+1; n++) {
+    for (int n = 1; n < nVars + 1; n++) {
       for (int i = 0; i < ldir; i++) {
-	if (outdata[0][i] > 0.0) outdata[n][i] /=  outdata[0][i];
+        if (outdata[0][i] > 0.0)
+          outdata[n][i] /= outdata[0][i];
       }
     }
   }
   Vector<Real> plo = amrData.ProbLo();
   Vector<Real> phi = amrData.ProbHi();
   for (int i = 0; i < ldir; i++) {
-    x[i] = plo[dir] + (i+0.5)*dzFine;
+    x[i] = plo[dir] + (i + 0.5) * dzFine;
   }
   return;
 }
-  
-void integrate3d(Vector<Real>& outdata, AmrData& amrData, Vector<MultiFab*> indata, int nVars, int finestLevel, int cComp, Real cMin, Real cMax, int avg) {
+
+void
+integrate3d(
+  Vector<Real>& outdata,
+  AmrData& amrData,
+  Vector<MultiFab*> indata,
+  int nVars,
+  int finestLevel,
+  int cComp,
+  Real cMin,
+  Real cMax,
+  int avg)
+{
   for (int lev = 0; lev <= finestLevel; lev++) {
     Real dxLev = amrData.DxLevel()[lev][0];
     Real dyLev = amrData.DxLevel()[lev][1];
     Real dzLev = amrData.DxLevel()[lev][2];
-    Real volLev = dxLev*dyLev*dzLev;
-    Print() << "Integrating level "<< lev << std::endl;
+    Real volLev = dxLev * dyLev * dzLev;
+    Print() << "Integrating level " << lev << std::endl;
     for (MFIter mfi(*indata[lev]); mfi.isValid(); ++mfi) {
       const Box& bx = mfi.tilebox();
-      Array4<Real> const& inbox  = (*indata[lev]).array(mfi);
+      Array4<Real> const& inbox = (*indata[lev]).array(mfi);
       AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
-	  if (inbox(i,j,k,nVars) > 1e-8 &&  (cComp < 0 || (inbox(i,j,k,cComp) >= cMin && inbox(i,j,k,cComp) < cMax))) {
-	    outdata[0] += volLev;
-	    for (int n = 1; n < nVars+1; n++) {
-	      outdata[n] += volLev*inbox(i,j,k,n-1);
-	    }
-	  }
-	});
+        if (
+          inbox(i, j, k, nVars) > 1e-8 &&
+          (cComp < 0 ||
+           (inbox(i, j, k, cComp) >= cMin && inbox(i, j, k, cComp) < cMax))) {
+          outdata[0] += volLev;
+          for (int n = 1; n < nVars + 1; n++) {
+            outdata[n] += volLev * inbox(i, j, k, n - 1);
+          }
+        }
+      });
     }
   }
-  ParallelDescriptor::ReduceRealSum(outdata.data(),nVars+1);
+  ParallelDescriptor::ReduceRealSum(outdata.data(), nVars + 1);
   if (avg) {
-    for (int n = 1; n<nVars+1; n++) {
-      if(outdata[0]> 0.0) outdata[n] /= outdata[0];
+    for (int n = 1; n < nVars + 1; n++) {
+      if (outdata[0] > 0.0)
+        outdata[n] /= outdata[0];
     }
   }
   return;
 }
-#elif AMREX_SPACEDIM==2
-void integrate1d(int dirInt, int dir, Vector<Vector<Real>>& outdata, Vector<Real>& x, AmrData& amrData, Vector<MultiFab*> indata,int nVars, int finestLevel, int cComp, Real cMin, Real cMax, int avg) {
+#elif AMREX_SPACEDIM == 2
+void
+integrate1d(
+  int dirInt,
+  int dir,
+  Vector<Vector<Real>>& outdata,
+  Vector<Real>& x,
+  AmrData& amrData,
+  Vector<MultiFab*> indata,
+  int nVars,
+  int finestLevel,
+  int cComp,
+  Real cMin,
+  Real cMax,
+  int avg)
+{
   Box probDomain = amrData.ProbDomain()[finestLevel];
   int ldir = probDomain.length(dir);
   IntVect d;
   int refRatio = 1;
   for (int lev = finestLevel; lev >= 0; lev--) {
     Real dxLev = amrData.DxLevel()[lev][dirInt];
-    if (lev < finestLevel) refRatio *= amrData.RefRatio()[lev];
-    Print() << "Integrating level "<< lev << std::endl;
+    if (lev < finestLevel)
+      refRatio *= amrData.RefRatio()[lev];
+    Print() << "Integrating level " << lev << std::endl;
     for (MFIter mfi(*indata[lev]); mfi.isValid(); ++mfi) {
       const Box& bx = mfi.tilebox();
-      Array4<Real> const& inbox  = (*indata[lev]).array(mfi);
+      Array4<Real> const& inbox = (*indata[lev]).array(mfi);
       AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
-	  if (inbox(i,j,k,nVars) > 1e-8 &&  (cComp < 0 || (inbox(i,j,k,cComp) >= cMin && inbox(i,j,k,cComp) < cMax))) {
-	    d[0] = i;
-	    d[1] = j;
-	    d[2] = k;
-	    for (int rx = 0; rx < refRatio; rx++) {
-	      outdata[0][refRatio*d[dir]+rx] += dxLev;
-	      for (int n = 1; n < nVars+1; n++) {
-		outdata[n][refRatio*d[dir]+rx] += dxLev*inbox(i,j,k,n-1);
-	      }
-	    }
-	  }
-	});
+        if (
+          inbox(i, j, k, nVars) > 1e-8 &&
+          (cComp < 0 ||
+           (inbox(i, j, k, cComp) >= cMin && inbox(i, j, k, cComp) < cMax))) {
+          d[0] = i;
+          d[1] = j;
+          d[2] = k;
+          for (int rx = 0; rx < refRatio; rx++) {
+            outdata[0][refRatio * d[dir] + rx] += dxLev;
+            for (int n = 1; n < nVars + 1; n++) {
+              outdata[n][refRatio * d[dir] + rx] +=
+                dxLev * inbox(i, j, k, n - 1);
+            }
+          }
+        }
+      });
     }
   }
-  for (int n = 0; n < nVars+1; n++) {
-    ParallelDescriptor::ReduceRealSum(outdata[n].data(),ldir);
+  for (int n = 0; n < nVars + 1; n++) {
+    ParallelDescriptor::ReduceRealSum(outdata[n].data(), ldir);
   }
   Real dyFine = amrData.DxLevel()[finestLevel][dir];
   if (avg) {
-    for (int n = 1; n<nVars+1; n++) {
+    for (int n = 1; n < nVars + 1; n++) {
       for (int i = 0; i < ldir; i++) {
-	if (outdata[0][i] > 0.0) outdata[n][i] /=  outdata[0][i];
+        if (outdata[0][i] > 0.0)
+          outdata[n][i] /= outdata[0][i];
       }
     }
   }
   Vector<Real> plo = amrData.ProbLo();
   Vector<Real> phi = amrData.ProbHi();
   for (int i = 0; i < ldir; i++) {
-    x[i] = plo[dir] + (i+0.5)*dyFine;
+    x[i] = plo[dir] + (i + 0.5) * dyFine;
   }
   return;
 }
-  
-void integrate2d(Vector<Real>& outdata, AmrData& amrData, Vector<MultiFab*> indata, int nVars, int finestLevel, int cComp, Real cMin, Real cMax, int avg) {
+
+void
+integrate2d(
+  Vector<Real>& outdata,
+  AmrData& amrData,
+  Vector<MultiFab*> indata,
+  int nVars,
+  int finestLevel,
+  int cComp,
+  Real cMin,
+  Real cMax,
+  int avg)
+{
   for (int lev = 0; lev <= finestLevel; lev++) {
     Real dxLev = amrData.DxLevel()[lev][0];
     Real dyLev = amrData.DxLevel()[lev][1];
-    Real areaLev = dxLev*dyLev;
-    Print() << "Integrating level "<< lev << std::endl;
+    Real areaLev = dxLev * dyLev;
+    Print() << "Integrating level " << lev << std::endl;
     for (MFIter mfi(*indata[lev]); mfi.isValid(); ++mfi) {
       const Box& bx = mfi.tilebox();
-      Array4<Real> const& inbox  = (*indata[lev]).array(mfi);
+      Array4<Real> const& inbox = (*indata[lev]).array(mfi);
       AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
-	  if (inbox(i,j,k,nVars) > 1e-8 &&  (cComp < 0 || (inbox(i,j,k,cComp) >= cMin && inbox(i,j,k,cComp) < cMax))) {
-	    outdata[0] += areaLev;
-	    for (int n = 1; n < nVars+1; n++) {
-	      outdata[n] += areaLev*inbox(i,j,k,n-1);
-	    }
-	  }
-	});
+        if (
+          inbox(i, j, k, nVars) > 1e-8 &&
+          (cComp < 0 ||
+           (inbox(i, j, k, cComp) >= cMin && inbox(i, j, k, cComp) < cMax))) {
+          outdata[0] += areaLev;
+          for (int n = 1; n < nVars + 1; n++) {
+            outdata[n] += areaLev * inbox(i, j, k, n - 1);
+          }
+        }
+      });
     }
   }
-  ParallelDescriptor::ReduceRealSum(outdata.data(),nVars+1);
+  ParallelDescriptor::ReduceRealSum(outdata.data(), nVars + 1);
   if (avg) {
-    for (int n = 1; n<nVars+1; n++) {
-      if(outdata[0]> 0.0) outdata[n] /= outdata[0];
+    for (int n = 1; n < nVars + 1; n++) {
+      if (outdata[0] > 0.0)
+        outdata[n] /= outdata[0];
     }
   }
   return;
 }
 #endif
 
-void writeDat1D(Vector<Real> vect, std::string filename, int dim) {
-  FILE *file = fopen(filename.c_str(),"w");
+void
+writeDat1D(Vector<Real> vect, std::string filename, int dim)
+{
+  FILE* file = fopen(filename.c_str(), "w");
   for (int i = 0; i < dim; i++) {
-    fprintf(file,"%e ",vect[i]);
+    fprintf(file, "%e ", vect[i]);
   }
   fclose(file);
   return;
 }
 
-void writeDat2D(Vector<Vector<Real>> vect, std::string filename, int dim1, int dim2) {
-  FILE *file = fopen(filename.c_str(),"w");
+void
+writeDat2D(Vector<Vector<Real>> vect, std::string filename, int dim1, int dim2)
+{
+  FILE* file = fopen(filename.c_str(), "w");
   for (int i = 0; i < dim1; i++) {
     for (int j = 0; j < dim2; j++) {
-      fprintf(file,"%e ",vect[i][j]);
+      fprintf(file, "%e ", vect[i][j]);
     }
     fprintf(file, "\n");
   }
@@ -242,345 +339,353 @@ void writeDat2D(Vector<Vector<Real>> vect, std::string filename, int dim1, int d
   return;
 }
 
-void writePPM(Vector<Vector<Real>> vect, std::string filename, int dim1, int dim2, int goPastMax, Real vMin, Real vMax) {
-  unsigned char *buff=(unsigned char*)malloc(3*dim1*dim2*sizeof(char));
-  for (int i=0; i<dim1; i++) {
-    for (int j=0; j<dim2; j++) {
-      int bc   = ((dim1-i-1)*dim2+j)*3;
+void
+writePPM(
+  Vector<Vector<Real>> vect,
+  std::string filename,
+  int dim1,
+  int dim2,
+  int goPastMax,
+  Real vMin,
+  Real vMax)
+{
+  unsigned char* buff = (unsigned char*)malloc(3 * dim1 * dim2 * sizeof(char));
+  for (int i = 0; i < dim1; i++) {
+    for (int j = 0; j < dim2; j++) {
+      int bc = ((dim1 - i - 1) * dim2 + j) * 3;
       Real val = vect[i][j];
-      Real colour = fmax(0.,fmin(1.5,(val-vMin)/(vMax-vMin)));
-      if (colour<0.125) {
-	buff[bc]   = 0;
-	buff[bc+1] = 0;
-	buff[bc+2] = (int)((colour+0.125)*1020.);
-      } else if (colour<0.375)  {
-	buff[bc]   = 0;
-	buff[bc+1] = (int)((colour-0.125)*1020.);
-	buff[bc+2] = 255;
-      } else if (colour<0.625)  {
-	buff[bc]   = (int)((colour-0.375)*1020.);
-	buff[bc+1] = 255;
-	buff[bc+2] = (int)((0.625-colour)*1020.);
-      } else if (colour<0.875)  {
-	buff[bc]   = 255;
-	buff[bc+1] = (int)((0.875-colour)*1020.);
-	buff[bc+2] = 0;
-      } else if (colour<1.000)  {
-	buff[bc]   = (int)((1.125-colour)*1020.);
-	buff[bc+1] = 0;
-	buff[bc+2] = 0;
-      } else if (goPastMax==1) {
-	if (colour<1.125)  {
-	  buff[bc]   = (int)((colour-0.875)*1020.);
-	  buff[bc+1] = 0;
-	  buff[bc+2] = (int)((colour-1.000)*1020.);
-	} else if (colour<1.250) {
-	  buff[bc]   = 255;
-	  buff[bc+1] = 0;
-	  buff[bc+2] = (int)((colour-1.000)*1020.);
-	} else if (colour<1.500)  {
-	  buff[bc]   = 255;
-	  buff[bc+1] = (int)((colour-1.250)*1020.);
-	  buff[bc+2] = 255;
-	} else { // default if above 1.5 with goPastMax==1
-	  buff[bc]   = 255;
-	  buff[bc+1] = 255;
-	  buff[bc+2] = 255;
-	}
+      Real colour = fmax(0., fmin(1.5, (val - vMin) / (vMax - vMin)));
+      if (colour < 0.125) {
+        buff[bc] = 0;
+        buff[bc + 1] = 0;
+        buff[bc + 2] = (int)((colour + 0.125) * 1020.);
+      } else if (colour < 0.375) {
+        buff[bc] = 0;
+        buff[bc + 1] = (int)((colour - 0.125) * 1020.);
+        buff[bc + 2] = 255;
+      } else if (colour < 0.625) {
+        buff[bc] = (int)((colour - 0.375) * 1020.);
+        buff[bc + 1] = 255;
+        buff[bc + 2] = (int)((0.625 - colour) * 1020.);
+      } else if (colour < 0.875) {
+        buff[bc] = 255;
+        buff[bc + 1] = (int)((0.875 - colour) * 1020.);
+        buff[bc + 2] = 0;
+      } else if (colour < 1.000) {
+        buff[bc] = (int)((1.125 - colour) * 1020.);
+        buff[bc + 1] = 0;
+        buff[bc + 2] = 0;
+      } else if (goPastMax == 1) {
+        if (colour < 1.125) {
+          buff[bc] = (int)((colour - 0.875) * 1020.);
+          buff[bc + 1] = 0;
+          buff[bc + 2] = (int)((colour - 1.000) * 1020.);
+        } else if (colour < 1.250) {
+          buff[bc] = 255;
+          buff[bc + 1] = 0;
+          buff[bc + 2] = (int)((colour - 1.000) * 1020.);
+        } else if (colour < 1.500) {
+          buff[bc] = 255;
+          buff[bc + 1] = (int)((colour - 1.250) * 1020.);
+          buff[bc + 2] = 255;
+        } else { // default if above 1.5 with goPastMax==1
+          buff[bc] = 255;
+          buff[bc + 1] = 255;
+          buff[bc + 2] = 255;
+        }
       } else { // default if above 1 with goPastMax==0
-	buff[bc]   = 128;
-	buff[bc+1] = 0;
-	buff[bc+2] = 0;
+        buff[bc] = 128;
+        buff[bc + 1] = 0;
+        buff[bc + 2] = 0;
       }
     }
   }
-  FILE *file = fopen(filename.c_str(),"w");
-  fprintf(file,"P6\n%i %i\n255\n",dim2,dim1);
-  fwrite(buff,dim1*dim2*3,sizeof(unsigned char),file);
+  FILE* file = fopen(filename.c_str(), "w");
+  fprintf(file, "P6\n%i %i\n255\n", dim2, dim1);
+  fwrite(buff, dim1 * dim2 * 3, sizeof(unsigned char), file);
   fclose(file);
   return;
 }
 
-void findMinMax(Vector<Vector<Real>> vect, int dim1, int dim2, Real &min, Real &max) {
+void
+findMinMax(Vector<Vector<Real>> vect, int dim1, int dim2, Real& min, Real& max)
+{
   min = vect[0][0];
   max = vect[0][0];
   for (int i = 0; i < dim1; i++) {
     for (int j = 0; j < dim2; j++) {
-      if (vect[i][j] < min) min = vect[i][j];
-      if (vect[i][j] > max) max = vect[i][j];
+      if (vect[i][j] < min)
+        min = vect[i][j];
+      if (vect[i][j] > max)
+        max = vect[i][j];
     }
   }
   return;
 }
 
-int main(int argc, char *argv[])
+int
+main(int argc, char* argv[])
 {
   amrex::Initialize(argc, argv);
   {
-  ParmParse pp;
-  
-  std::string infile;
-  pp.get("infile",infile);
-  Print() << "infile = " << infile << std::endl; 
-  
-  DataServices::SetBatchMode();
-  Amrvis::FileType fileType(Amrvis::NEWPLT);
+    ParmParse pp;
 
-  DataServices dataServices(infile, fileType);
-  if( ! dataServices.AmrDataOk()) {
-    DataServices::Dispatch(DataServices::ExitRequest, NULL);
-    // ^^^ this calls ParallelDescriptor::EndParallel() and exit()
-  }
-  AmrData& amrData = dataServices.AmrDataRef();
+    std::string infile;
+    pp.get("infile", infile);
+    Print() << "infile = " << infile << std::endl;
 
-  // read in the variable names to use
-  int nVars= pp.countval("vars");
-  Vector<std::string> vars(nVars);
-  pp.getarr("vars", vars);
-  Vector<int> destFillComps(nVars);
-  Print() << "nVars= " << nVars << std::endl;
-  for (int n = 0; n<nVars; n++) {
-    destFillComps[n] = n;
-    Print() << "var[" << n << "]= " << vars[n] << std::endl;
-  }
-  
-  int integralDimension;
-  pp.get("integralDimension",integralDimension);
-  AMREX_ALWAYS_ASSERT(integralDimension<=AMREX_SPACEDIM);
-  int finestLevel = amrData.FinestLevel();
-  pp.query("finestLevel", finestLevel);
-  int Nlev = finestLevel + 1;
-  std::string cVar;
-  Real cMin,cMax;
-  int cComp=-1;
-  pp.query("cVar",cVar);
-  pp.query("cMin",cMin);
-  pp.query("cMax",cMax);
-  if (!cVar.empty()) {
-    for (int n = 0; n<nVars; n++) {
-      if (vars[n] == cVar) {
-	cComp = n;
-	break;
+    DataServices::SetBatchMode();
+    Amrvis::FileType fileType(Amrvis::NEWPLT);
+
+    DataServices dataServices(infile, fileType);
+    if (!dataServices.AmrDataOk()) {
+      DataServices::Dispatch(DataServices::ExitRequest, NULL);
+      // ^^^ this calls ParallelDescriptor::EndParallel() and exit()
+    }
+    AmrData& amrData = dataServices.AmrDataRef();
+
+    // read in the variable names to use
+    int nVars = pp.countval("vars");
+    Vector<std::string> vars(nVars);
+    pp.getarr("vars", vars);
+    Vector<int> destFillComps(nVars);
+    Print() << "nVars= " << nVars << std::endl;
+    for (int n = 0; n < nVars; n++) {
+      destFillComps[n] = n;
+      Print() << "var[" << n << "]= " << vars[n] << std::endl;
+    }
+
+    int integralDimension;
+    pp.get("integralDimension", integralDimension);
+    AMREX_ALWAYS_ASSERT(integralDimension <= AMREX_SPACEDIM);
+    int finestLevel = amrData.FinestLevel();
+    pp.query("finestLevel", finestLevel);
+    int Nlev = finestLevel + 1;
+    std::string cVar;
+    Real cMin, cMax;
+    int cComp = -1;
+    pp.query("cVar", cVar);
+    pp.query("cMin", cMin);
+    pp.query("cMax", cMax);
+    if (!cVar.empty()) {
+      for (int n = 0; n < nVars; n++) {
+        if (vars[n] == cVar) {
+          cComp = n;
+          break;
+        }
+      }
+      if (cComp < 0) {
+        Abort("cVar not in list of vars!");
       }
     }
-    if (cComp < 0) {
-      Abort("cVar not in list of vars!");
-    }
-  }
-  int avg = 0;
-  pp.query("avg",avg); //integral average, or just integral?
-  int dir, dir1, dir2;
-  std::string format="dat";
-  Print() << "integralDimension = " << integralDimension << std::endl;
-#if AMREX_SPACEDIM==3
-  switch(integralDimension) {
-  case 1:
-    {
-      pp.get("dir",dir);
-      dir1 = (dir+1)%3;
-      dir2 = (dir+2)%3;
-      pp.query("format",format);
-      AMREX_ALWAYS_ASSERT(format=="ppm" || format=="dat");
+    int avg = 0;
+    pp.query("avg", avg); // integral average, or just integral?
+    int dir, dir1, dir2;
+    std::string format = "dat";
+    Print() << "integralDimension = " << integralDimension << std::endl;
+#if AMREX_SPACEDIM == 3
+    switch (integralDimension) {
+    case 1: {
+      pp.get("dir", dir);
+      dir1 = (dir + 1) % 3;
+      dir2 = (dir + 2) % 3;
+      pp.query("format", format);
+      AMREX_ALWAYS_ASSERT(format == "ppm" || format == "dat");
       break;
     }
-  case 2:
-    {
-      pp.get("dir1",dir1);
-      pp.get("dir2",dir2);
-      dir = 3-dir1-dir2;
+    case 2: {
+      pp.get("dir1", dir1);
+      pp.get("dir2", dir2);
+      dir = 3 - dir1 - dir2;
       break;
     }
-    //case 3 doesn't care about directions
-  }
-#elif AMREX_SPACEDIM==2
-  if (integralDimension == 1) {
-    pp.get("dir",dir);
-    dir1 = (dir+1)%2;
-  }
+      // case 3 doesn't care about directions
+    }
+#elif AMREX_SPACEDIM == 2
+    if (integralDimension == 1) {
+      pp.get("dir", dir);
+      dir1 = (dir + 1) % 2;
+    }
 #endif
-  std::string outfile= infile+"_integral";
-  if(integralDimension < AMREX_SPACEDIM) {
-    outfile += "_dir"+std::to_string(dir);
-  }
-  if(!cVar.empty()) {
-    outfile+="_c"+cVar+"_"+std::to_string(cMin)+"_"+std::to_string(cMax);
-  }
-  if(avg) {
-    outfile+= "_avg";
-  }
-    
+    std::string outfile = infile + "_integral";
+    if (integralDimension < AMREX_SPACEDIM) {
+      outfile += "_dir" + std::to_string(dir);
+    }
+    if (!cVar.empty()) {
+      outfile +=
+        "_c" + cVar + "_" + std::to_string(cMin) + "_" + std::to_string(cMax);
+    }
+    if (avg) {
+      outfile += "_avg";
+    }
 
-  Vector<MultiFab*> indata(Nlev);
-  for (int lev = 0; lev < Nlev; lev++) {
-    BoxArray probBoxArray = amrData.boxArray(lev);
-    indata[lev] = new MultiFab(probBoxArray,DistributionMapping(probBoxArray),nVars+1,0);
-    Print() << "Loading data on level " << lev << std::endl;
-    amrData.FillVar(*indata[lev],lev,vars,destFillComps);
-    Print() << "Data loaded" << std::endl;
-    indata[lev]->setVal(1.0,nVars,1);
-  }
-  Print() << "Determining intersects..." << std::endl;
-  for (int lev = 0; lev < finestLevel; lev++) {
-    BoxArray baf = (*indata[lev+1]).boxArray();
-    baf.coarsen(amrData.RefRatio()[lev]);	  
-    for (MFIter mfi(*indata[lev]); mfi.isValid(); ++mfi) {
-      FArrayBox& myFab = (*indata[lev])[mfi];
-      int idx = mfi.index();      
-      std::vector< std::pair<int,Box> > isects = baf.intersections((*indata[lev]).boxArray()[idx]);
-      for (int ii = 0; ii < isects.size(); ii++) {
-	myFab.setVal(0.0,isects[ii].second,nVars,1);
+    Vector<MultiFab*> indata(Nlev);
+    for (int lev = 0; lev < Nlev; lev++) {
+      BoxArray probBoxArray = amrData.boxArray(lev);
+      indata[lev] = new MultiFab(
+        probBoxArray, DistributionMapping(probBoxArray), nVars + 1, 0);
+      Print() << "Loading data on level " << lev << std::endl;
+      amrData.FillVar(*indata[lev], lev, vars, destFillComps);
+      Print() << "Data loaded" << std::endl;
+      indata[lev]->setVal(1.0, nVars, 1);
+    }
+    Print() << "Determining intersects..." << std::endl;
+    for (int lev = 0; lev < finestLevel; lev++) {
+      BoxArray baf = (*indata[lev + 1]).boxArray();
+      baf.coarsen(amrData.RefRatio()[lev]);
+      for (MFIter mfi(*indata[lev]); mfi.isValid(); ++mfi) {
+        FArrayBox& myFab = (*indata[lev])[mfi];
+        int idx = mfi.index();
+        std::vector<std::pair<int, Box>> isects =
+          baf.intersections((*indata[lev]).boxArray()[idx]);
+        for (int ii = 0; ii < isects.size(); ii++) {
+          myFab.setVal(0.0, isects[ii].second, nVars, 1);
+        }
       }
     }
-  }
-  Print() << "Intersects determined" << std::endl;
-#if AMREX_SPACEDIM==3  
-  switch(integralDimension) {
-  case 1: //1D integral, results in 2D data (assuming 3D plotfile), output either dat or ppm
+    Print() << "Intersects determined" << std::endl;
+#if AMREX_SPACEDIM == 3
+    switch (integralDimension) {
+    case 1: // 1D integral, results in 2D data (assuming 3D plotfile), output
+            // either dat or ppm
     {
       Box probDomain = amrData.ProbDomain()[finestLevel];
       int ldir1 = probDomain.length(dir1);
       int ldir2 = probDomain.length(dir2);
       Vector<Real> x(ldir1);
       Vector<Real> y(ldir2);
-      Vector<Real> tmp1(ldir2,0.0);
-      Vector<Vector<Real>> tmp2(ldir1,tmp1);
-      Vector<Vector<Vector<Real>>> outdata(nVars+1,tmp2);
-      //do 1d integration
-      integrate1d(dir,dir1,dir2,outdata,x,y,amrData,indata,nVars,finestLevel,cComp,cMin,cMax,avg);
+      Vector<Real> tmp1(ldir2, 0.0);
+      Vector<Vector<Real>> tmp2(ldir1, tmp1);
+      Vector<Vector<Vector<Real>>> outdata(nVars + 1, tmp2);
+      // do 1d integration
+      integrate1d(
+        dir, dir1, dir2, outdata, x, y, amrData, indata, nVars, finestLevel,
+        cComp, cMin, cMax, avg);
       Print() << "Integration completed" << std::endl;
-      //output data in desired format
-      Print() << "Writing data as "+format << std::endl;
+      // output data in desired format
+      Print() << "Writing data as " + format << std::endl;
       if (ParallelDescriptor::IOProcessor()) {
-	if (format == "dat") {
-	  writeDat1D(x,outfile+"_x.dat",ldir1);
-	  writeDat1D(y,outfile+"_y.dat",ldir2);
-	  writeDat2D(outdata[0],outfile+"_length.dat",ldir1,ldir2);
-	  for (int n = 1; n < nVars+1; n++) {
-	    writeDat2D(outdata[n],outfile+"_"+vars[n-1]+".dat",ldir1,ldir2);
-	  }
-	} else if (format == "ppm") {
-	  int goPastMax = 1;
-	  pp.query("goPastMax",goPastMax);
-	  Vector<Real> vMin(nVars+1);
-	  Vector<Real> vMax(nVars+1);
-	  findMinMax(outdata[0],ldir1,ldir2,vMin[0],vMax[0]);
-	  for (int n=1; n<nVars+1; n++) {
-	    char argName[12];
-	    sprintf(argName,"useminmax%i",n);
-	    int nMinMax = pp.countval(argName);
-	    if (nMinMax > 0) {
-	      Print() << "Reading min/max from command line" << std::endl;
-	      if (nMinMax != 2) {
-		Abort("Need to specify 2 values for useMinMax");
-	      } else {
-		pp.get(argName, vMin[n], 0);
-		pp.get(argName, vMax[n], 1);
-	      }
-	    } else {
-	      Print() << "Using file values for min/max" << std::endl;
-	      findMinMax(outdata[n],ldir1,ldir2,vMin[n],vMax[n]);
-	    }
-	  }
-	  
-	  writePPM(outdata[0],outfile+"_length.ppm",ldir1,ldir2,goPastMax,vMin[0],vMax[0]);
-	  for (int n = 1; n < nVars+1; n++) { 
-	    writePPM(outdata[n],outfile+"_"+vars[n-1]+".ppm",ldir1,ldir2,goPastMax,vMin[n],vMax[n]);
-	  }
-	} //can add more formats here if we want - add to assert above
+        if (format == "dat") {
+          writeDat1D(x, outfile + "_x.dat", ldir1);
+          writeDat1D(y, outfile + "_y.dat", ldir2);
+          writeDat2D(outdata[0], outfile + "_length.dat", ldir1, ldir2);
+          for (int n = 1; n < nVars + 1; n++) {
+            writeDat2D(
+              outdata[n], outfile + "_" + vars[n - 1] + ".dat", ldir1, ldir2);
+          }
+        } else if (format == "ppm") {
+          int goPastMax = 1;
+          pp.query("goPastMax", goPastMax);
+          Vector<Real> vMin(nVars + 1);
+          Vector<Real> vMax(nVars + 1);
+          findMinMax(outdata[0], ldir1, ldir2, vMin[0], vMax[0]);
+          for (int n = 1; n < nVars + 1; n++) {
+            char argName[12];
+            sprintf(argName, "useminmax%i", n);
+            int nMinMax = pp.countval(argName);
+            if (nMinMax > 0) {
+              Print() << "Reading min/max from command line" << std::endl;
+              if (nMinMax != 2) {
+                Abort("Need to specify 2 values for useMinMax");
+              } else {
+                pp.get(argName, vMin[n], 0);
+                pp.get(argName, vMax[n], 1);
+              }
+            } else {
+              Print() << "Using file values for min/max" << std::endl;
+              findMinMax(outdata[n], ldir1, ldir2, vMin[n], vMax[n]);
+            }
+          }
+
+          writePPM(
+            outdata[0], outfile + "_length.ppm", ldir1, ldir2, goPastMax,
+            vMin[0], vMax[0]);
+          for (int n = 1; n < nVars + 1; n++) {
+            writePPM(
+              outdata[n], outfile + "_" + vars[n - 1] + ".ppm", ldir1, ldir2,
+              goPastMax, vMin[n], vMax[n]);
+          }
+        } // can add more formats here if we want - add to assert above
       }
       break;
     }
-  case 2:
-    {
+    case 2: {
       Box probDomain = amrData.ProbDomain()[finestLevel];
       int ldir = probDomain.length(dir);
       Vector<Real> x(ldir);
-      Vector<Real> tmp(ldir,0.0);
-      Vector<Vector<Real>> outdata(nVars+1,tmp);
-      integrate2d(dir,dir1,dir2,outdata,x,amrData,indata,nVars,finestLevel,cComp,cMin,cMax,avg);
+      Vector<Real> tmp(ldir, 0.0);
+      Vector<Vector<Real>> outdata(nVars + 1, tmp);
+      integrate2d(
+        dir, dir1, dir2, outdata, x, amrData, indata, nVars, finestLevel, cComp,
+        cMin, cMax, avg);
       Print() << "Integration completed" << std::endl;
-      Print() << "Writing data as "+format << std::endl;
+      Print() << "Writing data as " + format << std::endl;
       if (ParallelDescriptor::IOProcessor()) {
-	if (format == "dat") {
-	  writeDat1D(x,outfile+"_x.dat",ldir);
-	  writeDat2D(outdata,outfile+"_allVars.dat",nVars+1,ldir);
-	  //writeDat1D(outdata[0],outfile+"_area.dat",ldir);
-	  //for (int n = 1; n < nVars+1; n++) {
-	  //  writeDat1D(outdata[n],outfile+"_"+vars[n-1]+".dat",ldir);
-	  //}
-	} //can add more formats here if we want
+        if (format == "dat") {
+          writeDat1D(x, outfile + "_x.dat", ldir);
+          writeDat2D(outdata, outfile + "_allVars.dat", nVars + 1, ldir);
+          // writeDat1D(outdata[0],outfile+"_area.dat",ldir);
+          // for (int n = 1; n < nVars+1; n++) {
+          //   writeDat1D(outdata[n],outfile+"_"+vars[n-1]+".dat",ldir);
+          // }
+        } // can add more formats here if we want
       }
       break;
     }
-  case 3:
-    {
-      format="dat"; //probably add an option for binary output
-      Vector<Real> outdata(nVars+1,0.0);
-      integrate3d(outdata,amrData,indata,nVars,finestLevel,cComp,cMin,cMax,avg);
+    case 3: {
+      format = "dat"; // probably add an option for binary output
+      Vector<Real> outdata(nVars + 1, 0.0);
+      integrate3d(
+        outdata, amrData, indata, nVars, finestLevel, cComp, cMin, cMax, avg);
       Print() << "Integration completed" << std::endl;
-      Print() << "Writing data as "+format << std::endl;
+      Print() << "Writing data as " + format << std::endl;
       if (ParallelDescriptor::IOProcessor()) {
-	if (format == "dat") {
-	  writeDat1D(outdata,outfile+"_allVars.dat",nVars+1);
-	} //can add more formats here
+        if (format == "dat") {
+          writeDat1D(outdata, outfile + "_allVars.dat", nVars + 1);
+        } // can add more formats here
       }
       break;
     }
-  }
-#elif AMREX_SPACEDIM==2
-  switch(integralDimension) {
-  case 1:
-    {
+    }
+#elif AMREX_SPACEDIM == 2
+    switch (integralDimension) {
+    case 1: {
       Box probDomain = amrData.ProbDomain()[finestLevel];
       int ldir = probDomain.length(dir1);
       Vector<Real> x(ldir);
-      Vector<Real> tmp(ldir,0.0);
-      Vector<Vector<Real>> outdata(nVars+1,tmp);
-      integrate1d(dir,dir1,outdata,x,amrData,indata,nVars,finestLevel,cComp,cMin,cMax,avg);
+      Vector<Real> tmp(ldir, 0.0);
+      Vector<Vector<Real>> outdata(nVars + 1, tmp);
+      integrate1d(
+        dir, dir1, outdata, x, amrData, indata, nVars, finestLevel, cComp, cMin,
+        cMax, avg);
       Print() << "Integration completed" << std::endl;
-      Print() << "Writing data as "+format << std::endl;
+      Print() << "Writing data as " + format << std::endl;
       if (ParallelDescriptor::IOProcessor()) {
-	if (format == "dat") {
-	  writeDat1D(x,outfile+"_x.dat",ldir);
-	  writeDat2D(outdata,outfile+"_allVars.dat",nVars+1,ldir);
-	} //can add more formats here if we want
+        if (format == "dat") {
+          writeDat1D(x, outfile + "_x.dat", ldir);
+          writeDat2D(outdata, outfile + "_allVars.dat", nVars + 1, ldir);
+        } // can add more formats here if we want
       }
       break;
     }
-  case 2:
-    {
-      format="dat"; //probably add an option for binary output
-      Vector<Real> outdata(nVars+1,0.0);
-      integrate2d(outdata,amrData,indata,nVars,finestLevel,cComp,cMin,cMax,avg);
+    case 2: {
+      format = "dat"; // probably add an option for binary output
+      Vector<Real> outdata(nVars + 1, 0.0);
+      integrate2d(
+        outdata, amrData, indata, nVars, finestLevel, cComp, cMin, cMax, avg);
       Print() << "Integration completed" << std::endl;
-      Print() << "Writing data as "+format << std::endl;
+      Print() << "Writing data as " + format << std::endl;
       if (ParallelDescriptor::IOProcessor()) {
-	if (format == "dat") {
-	  writeDat1D(outdata,outfile+"_allVars.dat",nVars+1);
-	} //can add more formats here
+        if (format == "dat") {
+          writeDat1D(outdata, outfile + "_allVars.dat", nVars + 1);
+        } // can add more formats here
       }
       break;
     }
-  }
+    }
 #endif
   }
 
   Finalize();
-  return 0;  
+  return 0;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/Src/interp.cpp
+++ b/Src/interp.cpp
@@ -3,14 +3,15 @@
 struct distFuncInterp
 {
   distFuncInterp(const MultiFab& a_distance) : distanct(a_distance) {}
-  Real operator() (Real x[AMREX_SPACEDIM]) {
+  Real operator()(Real x[AMREX_SPACEDIM])
+  {
     IntVect iv;
-    for (int i=0; i<AMREX_SPACEDIM; ++i) {
-      iv[i] = index(x[i],i);
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+      iv[i] = index(x[i], i);
     }
     const auto& ba = distanceMF.boxArray();
     int boxID = -1;
-    for (int i=0; i<ba.size() && boxID<0; ++i) {
+    for (int i = 0; i < ba.size() && boxID < 0; ++i) {
       if (ba[i].contains(iv)) {
         boxID = i;
       }
@@ -19,21 +20,17 @@ struct distFuncInterp
     Real result;
     if (boxID < 0) {
       // Get distance from coarser representation
-    }
-    else
-    {
-      // Using the FArrayBox in distanceMF[boxID], interpolate between iv and iv+IntVect(1,1,1)
+    } else {
+      // Using the FArrayBox in distanceMF[boxID], interpolate between iv and
+      // iv+IntVect(1,1,1)
     }
     return result;
   }
 
-  int index(Real loc, int dir) {
-    return floor((loc - dlo[dir])/dx[dir]);
-  }
+  int index(Real loc, int dir) { return floor((loc - dlo[dir]) / dx[dir]); }
+
 protected:
   Real dx[AMREX_SPACEDIM];
   Real dlo[AMREX_SPACEDIM];
   const MultiFab& distanceMF;
 };
-
-  

--- a/Src/isoMEF.cpp
+++ b/Src/isoMEF.cpp
@@ -8,19 +8,19 @@
 #include <iterator>
 #include <iomanip>
 
-using std::cout;
 using std::cerr;
+using std::cout;
 using std::endl;
-using std::list;
-using std::vector;
-using std::set;
-using std::map;
-using std::pair;
-using std::string;
-using std::istream;
-using std::ostream;
-using std::ofstream;
 using std::ifstream;
+using std::istream;
+using std::list;
+using std::map;
+using std::ofstream;
+using std::ostream;
+using std::pair;
+using std::set;
+using std::string;
+using std::vector;
 
 #include "AMReX_ParmParse.H"
 #include "AMReX_ParallelDescriptor.H"
@@ -32,8 +32,8 @@ using namespace amrex;
 typedef Vector<Real> Point;
 typedef list<Point> PointList;
 typedef Vector<Point> PointVec;
-typedef pair<int,int> Edge;
-typedef map<Edge, pair<Point,int> > PMap;
+typedef pair<int, int> Edge;
+typedef map<Edge, pair<Point, int>> PMap;
 typedef PMap::iterator PMapIt;
 static PMap vertCache;
 
@@ -46,15 +46,15 @@ static string rootName(const string in);
 struct Segment
 {
   Segment() : p(2), mLength(-1) {}
-  Real Length ();
-  const PMapIt& operator[] (int n) const { return p[n]; }
-  PMapIt& operator[] (int n) { return p[n]; }
-  int ID_l () const {return (*p[0]).second.second;}
-  int ID_r () const {return (*p[1]).second.second;}
-  void flip ();
-  static int xComp,yComp,zComp;
+  Real Length();
+  const PMapIt& operator[](int n) const { return p[n]; }
+  PMapIt& operator[](int n) { return p[n]; }
+  int ID_l() const { return (*p[0]).second.second; }
+  int ID_r() const { return (*p[1]).second.second; }
+  void flip();
+  static int xComp, yComp, zComp;
   Vector<PMapIt> p;
-    
+
 private:
   void my_length();
   Real mLength;
@@ -62,74 +62,79 @@ private:
 
 typedef list<Segment> SegList;
 
-bool operator<(const Edge& lhs, const Edge& rhs)
+bool
+operator<(const Edge& lhs, const Edge& rhs)
 {
-    if (std::min(lhs.first,lhs.second) != std::min(rhs.first,rhs.second))
-    {
-        return (std::min(lhs.first,lhs.second) < std::min(rhs.first,rhs.second));
-    }
-    return std::max(lhs.first,lhs.second) < std::max(rhs.first,rhs.second);
+  if (std::min(lhs.first, lhs.second) != std::min(rhs.first, rhs.second)) {
+    return (std::min(lhs.first, lhs.second) < std::min(rhs.first, rhs.second));
+  }
+  return std::max(lhs.first, lhs.second) < std::max(rhs.first, rhs.second);
 }
 
 struct EdgeLess
 {
-    bool operator()(const Edge& lhs, const Edge& rhs) const
-        { return operator<(lhs,rhs); }
+  bool operator()(const Edge& lhs, const Edge& rhs) const
+  {
+    return operator<(lhs, rhs);
+  }
 };
 
-bool operator==(const Edge& lhs, const Edge& rhs)
+bool
+operator==(const Edge& lhs, const Edge& rhs)
 {
-    return (lhs.first == rhs.first && lhs.second == rhs.second) ||
-        (lhs.first == rhs.second && lhs.second == rhs.first);
+  return (lhs.first == rhs.first && lhs.second == rhs.second) ||
+         (lhs.first == rhs.second && lhs.second == rhs.first);
 }
 
-bool operator!=(const Edge& lhs, const Edge& rhs)
+bool
+operator!=(const Edge& lhs, const Edge& rhs)
 {
-    return !operator==(lhs,rhs);
+  return !operator==(lhs, rhs);
 }
 
-
-bool operator==(const Segment& lhs, const Segment& rhs)
+bool
+operator==(const Segment& lhs, const Segment& rhs)
 {
-    return lhs.ID_l() == rhs.ID_l() && lhs.ID_r() == rhs.ID_r();
+  return lhs.ID_l() == rhs.ID_l() && lhs.ID_r() == rhs.ID_r();
 }
 
-bool operator!=(const Segment& lhs, const Segment& rhs)
+bool
+operator!=(const Segment& lhs, const Segment& rhs)
 {
-    return !operator==(lhs,rhs);
+  return !operator==(lhs, rhs);
 }
 
-PMapIt VertexInterp(Real isoVal,int isoComp,const Vector<Point>& pts,int p1,int p2);
+PMapIt VertexInterp(
+  Real isoVal, int isoComp, const Vector<Point>& pts, int p1, int p2);
 
-Vector<Segment> Segmentise(const Vector<Point>&  pts,
-                          const Vector<int>&    elt,
-                          Real                  isoVal,
-                          int                   isoComp);
+Vector<Segment> Segmentise(
+  const Vector<Point>& pts, const Vector<int>& elt, Real isoVal, int isoComp);
 
-
-SegList::iterator FindMySeg(SegList& segs, int idx, Vector<PMapIt>& vertVec)
+SegList::iterator
+FindMySeg(SegList& segs, int idx, Vector<PMapIt>& vertVec)
 {
-    const PMapIt& vertToFind = vertVec[idx];
-    for (SegList::iterator it=segs.begin(); it!=segs.end(); ++it)
-    {
-        if ( ((*it)[0] == vertToFind) || ((*it)[1] == vertToFind) )
-            return it;
-    }
-    return segs.end();
+  const PMapIt& vertToFind = vertVec[idx];
+  for (SegList::iterator it = segs.begin(); it != segs.end(); ++it) {
+    if (((*it)[0] == vertToFind) || ((*it)[1] == vertToFind))
+      return it;
+  }
+  return segs.end();
 }
 
-
-int main (int argc,
-	  char* argv[])
+int
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     ParmParse pp;
 
-    string infile; pp.get("infile",infile);
+    string infile;
+    pp.get("infile", infile);
 
-    int isoComp; pp.get("isoComp",isoComp);
-    Real isoVal; pp.get("isoVal",isoVal);
+    int isoComp;
+    pp.get("isoComp", isoComp);
+    Real isoVal;
+    pp.get("isoVal", isoVal);
 
     ifstream is(infile.c_str());
 
@@ -144,45 +149,43 @@ int main (int argc,
 
     FArrayBox nodeFab;
     nodeFab.readFrom(is);
-    AMREX_ALWAYS_ASSERT(nComp==nodeFab.nComp());
+    AMREX_ALWAYS_ASSERT(nComp == nodeFab.nComp());
     Real* nodeData = nodeFab.dataPtr();
     const int nNodes = nodeFab.box().length(0);
     Vector<Point> GridPts(nNodes);
-    for (int i=0; i<nNodes; ++i) {
+    for (int i = 0; i < nNodes; ++i) {
       GridPts[i].resize(nComp);
-      for (int j=0; j<nComp; ++j) {
-        GridPts[i][j] = nodeData[i*nComp+j];
+      for (int j = 0; j < nComp; ++j) {
+        GridPts[i][j] = nodeData[i * nComp + j];
       }
     }
     nodeFab.clear(); // Reclaim uneeded space
-    cerr << nNodes << " nodes read in with "
-         << nComp << " states per node" << endl;
+    cerr << nNodes << " nodes read in with " << nComp << " states per node"
+         << endl;
 
-    Vector<int> connData(nElts*MYLEN,0);
-    is.read((char*)connData.dataPtr(),sizeof(int)*connData.size());
-    Vector<Vector<int> > GridElts(nElts);
+    Vector<int> connData(nElts * MYLEN, 0);
+    is.read((char*)connData.dataPtr(), sizeof(int) * connData.size());
+    Vector<Vector<int>> GridElts(nElts);
 
-    for (int i=0; i<nElts; ++i)
-    {
+    for (int i = 0; i < nElts; ++i) {
       GridElts[i].resize(MYLEN);
-      for (int j=0; j<MYLEN; ++j)
-        GridElts[i][j] = connData[i*MYLEN+j] - 1;
+      for (int j = 0; j < MYLEN; ++j)
+        GridElts[i][j] = connData[i * MYLEN + j] - 1;
     }
     connData.clear(); // Reclaim uneeded space
-    cerr << nElts << " elements read in with "
-         << MYLEN << " nodes per element" << endl;
+    cerr << nElts << " elements read in with " << MYLEN << " nodes per element"
+         << endl;
 
     Real Length = 0;
     SegList segments;
 
-    for (int i=0; i<nElts; ++i) {
+    for (int i = 0; i < nElts; ++i) {
 
-      Vector<Segment> eltSegs = Segmentise(GridPts,GridElts[i],isoVal,isoComp);
+      Vector<Segment> eltSegs =
+        Segmentise(GridPts, GridElts[i], isoVal, isoComp);
       if (eltSegs.size() > 0) {
-    
 
-        for (int j=0; j<eltSegs.size(); ++j)
-        {
+        for (int j = 0; j < eltSegs.size(); ++j) {
           Length += eltSegs[j].Length();
           segments.push_back(eltSegs[j]);
         }
@@ -190,17 +193,17 @@ int main (int argc,
     }
 
     int nSegments = segments.size();
-    cout << "Found " << nSegments << " segments "  << endl;
+    cout << "Found " << nSegments << " segments " << endl;
 
     // Number the isosurface vertices
-    int cnt=0;
-    for (PMapIt it=vertCache.begin(); it!=vertCache.end(); ++it)
+    int cnt = 0;
+    for (PMapIt it = vertCache.begin(); it != vertCache.end(); ++it)
       (*it).second.second = cnt++;
 
     // Build a reverse Vector into the vertCache
     Vector<PMapIt> vertVec(vertCache.size());
-    cnt=0;
-    for (PMapIt it=vertCache.begin(); it!=vertCache.end(); ++it)
+    cnt = 0;
+    for (PMapIt it = vertCache.begin(); it != vertCache.end(); ++it)
       vertVec[cnt++] = it;
 
     // Find a segment with the specified vertex as one of its endpoints,
@@ -208,87 +211,74 @@ int main (int argc,
     // we finish, and segments remain, start a new line.
     SegList segList = segments;
     list<SegList> cLines;
-    if (segList.size()>0)
-    {
+    if (segList.size() > 0) {
       int idx = segList.front().ID_l();
       int newIdx;
       cLines.push_back(SegList());
-        
-      while (segList.begin() != segList.end())
-      {
-        SegList::iterator segIt = FindMySeg(segList,idx,vertVec);
-        if (segIt != segList.end())
-        {
+
+      while (segList.begin() != segList.end()) {
+        SegList::iterator segIt = FindMySeg(segList, idx, vertVec);
+        if (segIt != segList.end()) {
           int idx_l = (*segIt).ID_l();
           int idx_r = (*segIt).ID_r();
-          if ( idx_l == idx )
-          {
+          if (idx_l == idx) {
             newIdx = idx_r;
             cLines.back().push_back(*segIt);
-          }
-          else
-          {
+          } else {
             newIdx = idx_l;
-            Segment newSeg = Segment(*segIt); newSeg.flip();
+            Segment newSeg = Segment(*segIt);
+            newSeg.flip();
             cLines.back().push_back(newSeg);
           }
-                
+
           segList.erase(segIt);
-        }
-        else
-        {
+        } else {
           cLines.push_back(SegList());
           newIdx = segList.front().ID_l();
         }
-            
+
         idx = newIdx;
       }
-        
+
       // Connect up the line fragments as much as possible
       bool changed;
-      do
-      {
+      do {
         changed = false;
-        for (std::list<SegList>::iterator it = cLines.begin(); it!=cLines.end(); ++it)
-        {
-          if (!(*it).empty())
-          {
+        for (std::list<SegList>::iterator it = cLines.begin();
+             it != cLines.end(); ++it) {
+          if (!(*it).empty()) {
             const int idx_l = (*it).front().ID_l();
             const int idx_r = (*it).back().ID_r();
-            for (std::list<SegList>::iterator it1 = cLines.begin(); it1!=cLines.end(); ++it1)
-            {
-              if (!(*it1).empty() && (*it).front()!=(*it1).front())
-              {
-                if (idx_r == (*it1).front().ID_l())
-                {
-                  (*it).splice((*it).end(),*it1);
+            for (std::list<SegList>::iterator it1 = cLines.begin();
+                 it1 != cLines.end(); ++it1) {
+              if (!(*it1).empty() && (*it).front() != (*it1).front()) {
+                if (idx_r == (*it1).front().ID_l()) {
+                  (*it).splice((*it).end(), *it1);
                   changed = true;
-                }
-                else if (idx_r == (*it1).back().ID_r())
-                {
+                } else if (idx_r == (*it1).back().ID_r()) {
                   (*it1).reverse();
-                  for (SegList::iterator it2=(*it1).begin(); it2!=(*it1).end(); ++it2)
+                  for (SegList::iterator it2 = (*it1).begin();
+                       it2 != (*it1).end(); ++it2)
                     (*it2).flip();
-                  (*it).splice((*it).end(),*it1);
+                  (*it).splice((*it).end(), *it1);
                   changed = true;
-                }
-                else if (idx_l == (*it1).front().ID_l())
-                {
+                } else if (idx_l == (*it1).front().ID_l()) {
                   (*it1).reverse();
-                  for (SegList::iterator it2=(*it1).begin(); it2!=(*it1).end(); ++it2)
+                  for (SegList::iterator it2 = (*it1).begin();
+                       it2 != (*it1).end(); ++it2)
                     (*it2).flip();
-                  (*it).splice((*it).begin(),*it1);
+                  (*it).splice((*it).begin(), *it1);
                   changed = true;
                 }
               }
             }
           }
         }
-      } while(changed);
+      } while (changed);
     }
-    
-    for (std::list<SegList>::iterator it = cLines.begin(); it!=cLines.end();)
-    {
+
+    for (std::list<SegList>::iterator it = cLines.begin();
+         it != cLines.end();) {
       if ((*it).empty())
         cLines.erase(it++);
       else
@@ -298,28 +288,30 @@ int main (int argc,
 
     ofstream os("out.dat");
     os << "VARIABLES =";
-    for (int i=0; i<names.size(); ++i) {
+    for (int i = 0; i < names.size(); ++i) {
       os << " " << names[i];
     }
     os << '\n';
 
     // One zone per contour line
-    for (std::list<SegList>::iterator it = cLines.begin(); it!=cLines.end(); ++it) {
+    for (std::list<SegList>::iterator it = cLines.begin(); it != cLines.end();
+         ++it) {
       int nSegNodes = it->size() + 1;
-      os << "ZONE ZONETYPE=FELINESEG DATAPACKING=POINT N=" << nSegNodes << " E=" << it->size() << "\n";
-      for (SegList::iterator it2=it->begin(); it2!=it->end(); ++it2) {
-	const Point& p0 = (*it2)[0]->second.first;
-        for (int n=0 ; n <nComp ; ++n )
+      os << "ZONE ZONETYPE=FELINESEG DATAPACKING=POINT N=" << nSegNodes
+         << " E=" << it->size() << "\n";
+      for (SegList::iterator it2 = it->begin(); it2 != it->end(); ++it2) {
+        const Point& p0 = (*it2)[0]->second.first;
+        for (int n = 0; n < nComp; ++n)
           os << p0[n] << " ";
-        os << "\n" ;
+        os << "\n";
       }
       const auto& p1 = (*it).back()[1]->second.first;
-      for (int n=0 ; n <nComp ; ++n )
+      for (int n = 0; n < nComp; ++n)
         os << p1[n] << " ";
-      os << "\n" ;
+      os << "\n";
 
-      int cnt=1;
-      for (SegList::iterator it2=it->begin(); it2!=it->end(); ++it2) {
+      int cnt = 1;
+      for (SegList::iterator it2 = it->begin(); it2 != it->end(); ++it2) {
         os << cnt++ << " " << cnt << '\n'; // local numbering
       }
     }
@@ -329,134 +321,136 @@ int main (int argc,
   return 0;
 }
 
-static
-vector<string> parseVarNames(istream& is)
+static vector<string>
+parseVarNames(istream& is)
 {
-    string line;
-    std::getline(is,line);
-    return Tokenize(line,string(", "));
+  string line;
+  std::getline(is, line);
+  return Tokenize(line, string(", "));
 }
 
-static string parseTitle(istream& is)
+static string
+parseTitle(istream& is)
 {
-    string line;
-    std::getline(is,line);
-    return line;
+  string line;
+  std::getline(is, line);
+  return line;
 }
 
-static string rootName(const string inStr)
+static string
+rootName(const string inStr)
 {
-    const string dirSep("/");
-    const vector<string>& res  = Tokenize(inStr,dirSep);
-    const vector<string>& nres = Tokenize(res[res.size()-1],string("."));
-    string result = nres[0];
-    for (int i=1; i<nres.size()-1; ++i)
-        result = result + string(".") + nres[i];
-    return result;
+  const string dirSep("/");
+  const vector<string>& res = Tokenize(inStr, dirSep);
+  const vector<string>& nres = Tokenize(res[res.size() - 1], string("."));
+  string result = nres[0];
+  for (int i = 1; i < nres.size() - 1; ++i)
+    result = result + string(".") + nres[i];
+  return result;
 }
-
-
 
 /*
    Given a grid cell and an isoVal, calculate the line segments
    required to represent the contour through the cell.
    Return an array of (at most 2) line segments
 */
-Vector<Segment> Segmentise(const Vector<Point>&  pts,
-                          const Vector<int>&    elt,
-                          Real                  isoVal,
-                          int                   isoComp)
+Vector<Segment>
+Segmentise(
+  const Vector<Point>& pts, const Vector<int>& elt, Real isoVal, int isoComp)
 {
-   AMREX_ASSERT(elt.size()==3);
-   Vector<PMapIt> vertlist(3);
+  AMREX_ASSERT(elt.size() == 3);
+  Vector<PMapIt> vertlist(3);
 
-   const int p0 = elt[0];
-   const int p1 = elt[1];
-   const int p2 = elt[2];
+  const int p0 = elt[0];
+  const int p1 = elt[1];
+  const int p2 = elt[2];
 
-   bool lo_0 = pts[p0][isoComp] < isoVal;
-   bool lo_1 = pts[p1][isoComp] < isoVal;
-   bool lo_2 = pts[p2][isoComp] < isoVal;
+  bool lo_0 = pts[p0][isoComp] < isoVal;
+  bool lo_1 = pts[p1][isoComp] < isoVal;
+  bool lo_2 = pts[p2][isoComp] < isoVal;
 
-   int count = 0;
-   if (lo_0 ^ lo_1) {
-     vertlist[count++] = VertexInterp(isoVal,isoComp,pts,p0,p1);
-   }
-   if (lo_1 ^ lo_2) {
-     vertlist[count++] = VertexInterp(isoVal,isoComp,pts,p1,p2);
-   }
-   if (lo_2 ^ lo_0) {
-     vertlist[count++] = VertexInterp(isoVal,isoComp,pts,p2,p0);
-   }
+  int count = 0;
+  if (lo_0 ^ lo_1) {
+    vertlist[count++] = VertexInterp(isoVal, isoComp, pts, p0, p1);
+  }
+  if (lo_1 ^ lo_2) {
+    vertlist[count++] = VertexInterp(isoVal, isoComp, pts, p1, p2);
+  }
+  if (lo_2 ^ lo_0) {
+    vertlist[count++] = VertexInterp(isoVal, isoComp, pts, p2, p0);
+  }
 
-   Vector<Segment> segments(0);
-   if (count > 0) {
-     AMREX_ASSERT(count == 2);
-     segments.resize(1);
-     segments[0][0] = vertlist[0];
-     segments[0][1] = vertlist[1];
-   }
+  Vector<Segment> segments(0);
+  if (count > 0) {
+    AMREX_ASSERT(count == 2);
+    segments.resize(1);
+    segments[0][0] = vertlist[0];
+    segments[0][1] = vertlist[1];
+  }
 
-   return segments;
+  return segments;
 }
 
 /*
    Linearly interpolate the position where an isosurface cuts
    an edge between two vertices, each with their own scalar value
 */
-Point VI_doIt(Real isoVal,int isoComp,const Vector<Point>& pts,int p1,int p2)
+Point
+VI_doIt(Real isoVal, int isoComp, const Vector<Point>& pts, int p1, int p2)
 {
-    AMREX_ASSERT(p1<pts.size() && p2<pts.size());
-    const Point& pt1 = pts[p1];
-    const Point& pt2 = pts[p2];
+  AMREX_ASSERT(p1 < pts.size() && p2 < pts.size());
+  const Point& pt1 = pts[p1];
+  const Point& pt2 = pts[p2];
 
-    AMREX_ASSERT(isoComp!=pts.size() && isoComp<pt1.size() && pt1.size()==pt2.size());
+  AMREX_ASSERT(
+    isoComp != pts.size() && isoComp < pt1.size() && pt1.size() == pt2.size());
 
-    const Real valp1 = pt1[isoComp];
-    const Real valp2 = pt2[isoComp];
-    
-    if (std::abs(isoVal-valp1) < epsilon_DEF)
-        return pt1;
-    if (std::abs(isoVal-valp2) < epsilon_DEF)
-        return pt2;
-    if (std::abs(valp1-valp2) < epsilon_DEF)
-        return pt1;
-    
-    Point res(pt1.size()+2);
-//      Point res(pt1.size());
-    const Real mu = (isoVal - valp1) / (valp2 - valp1);
-    for (int j=0; j<res.size()-2; ++j)
-        res[j] = pt1[j] + mu * (pt2[j] - pt1[j]);
-    res[pt1.size()] = std::pow(res[0]*res[0] +res[1]*res[1],0.5);
-    Real tmp = atan(std::abs(res[1]/(res[0]+1e-5)))*180/3.14;
-    res[pt1.size()+1] = tmp;
-    if (res[0]<0.0 && res[1] >0.0) res[pt1.size()+1] = 90+tmp;
-    if (res[0]<0.0 && res[1] <0.0) res[pt1.size()+1] = 180+tmp;
-    if (res[0]>0.0 && res[1] <0.0) res[pt1.size()+1] = 270+tmp;
-    return res;
+  const Real valp1 = pt1[isoComp];
+  const Real valp2 = pt2[isoComp];
+
+  if (std::abs(isoVal - valp1) < epsilon_DEF)
+    return pt1;
+  if (std::abs(isoVal - valp2) < epsilon_DEF)
+    return pt2;
+  if (std::abs(valp1 - valp2) < epsilon_DEF)
+    return pt1;
+
+  Point res(pt1.size() + 2);
+  //      Point res(pt1.size());
+  const Real mu = (isoVal - valp1) / (valp2 - valp1);
+  for (int j = 0; j < res.size() - 2; ++j)
+    res[j] = pt1[j] + mu * (pt2[j] - pt1[j]);
+  res[pt1.size()] = std::pow(res[0] * res[0] + res[1] * res[1], 0.5);
+  Real tmp = atan(std::abs(res[1] / (res[0] + 1e-5))) * 180 / 3.14;
+  res[pt1.size() + 1] = tmp;
+  if (res[0] < 0.0 && res[1] > 0.0)
+    res[pt1.size() + 1] = 90 + tmp;
+  if (res[0] < 0.0 && res[1] < 0.0)
+    res[pt1.size() + 1] = 180 + tmp;
+  if (res[0] > 0.0 && res[1] < 0.0)
+    res[pt1.size() + 1] = 270 + tmp;
+  return res;
 }
 
-PMapIt VertexInterp(Real isoVal,int isoComp,const Vector<Point>& pts,int p1,int p2)
+PMapIt
+VertexInterp(Real isoVal, int isoComp, const Vector<Point>& pts, int p1, int p2)
 {
-    Edge ppair(p1,p2);
-    PMapIt fwd,rev;
-    fwd = vertCache.find(ppair);
-    if (fwd == vertCache.end())
-    {
-        rev = vertCache.find(Edge(p2,p1));
-        
-        if (rev == vertCache.end())
-        {
-            return vertCache.insert(
-                std::make_pair(ppair,
-                std::make_pair(VI_doIt(isoVal,isoComp,pts,p1,p2),0))).first;
-        }
-        else
-        {
-            return rev;
-        }
+  Edge ppair(p1, p2);
+  PMapIt fwd, rev;
+  fwd = vertCache.find(ppair);
+  if (fwd == vertCache.end()) {
+    rev = vertCache.find(Edge(p2, p1));
+
+    if (rev == vertCache.end()) {
+      return vertCache
+        .insert(std::make_pair(
+          ppair, std::make_pair(VI_doIt(isoVal, isoComp, pts, p1, p2), 0)))
+        .first;
+    } else {
+      return rev;
     }
-    return fwd;
+  }
+  return fwd;
 }
 
 int Segment::xComp = 0;
@@ -466,9 +460,9 @@ int Segment::zComp = 2;
 Real
 Segment::Length()
 {
-    if (mLength<0)
-        my_length();
-    return mLength;
+  if (mLength < 0)
+    my_length();
+  return mLength;
 }
 
 void
@@ -476,16 +470,16 @@ Segment::my_length()
 {
   const Point& p0 = (*p[0]).second.first;
   const Point& p1 = (*p[1]).second.first;
-  mLength = std::sqrt(((p1[xComp] - p0[xComp])*(p1[xComp] - p0[xComp]))
-		      +((p1[yComp] - p0[yComp])*(p1[yComp] - p0[yComp]))
-		      +((p1[zComp] - p0[zComp])*(p1[zComp] - p0[zComp])));
-}    
+  mLength = std::sqrt(
+    ((p1[xComp] - p0[xComp]) * (p1[xComp] - p0[xComp])) +
+    ((p1[yComp] - p0[yComp]) * (p1[yComp] - p0[yComp])) +
+    ((p1[zComp] - p0[zComp]) * (p1[zComp] - p0[zComp])));
+}
 
 void
 Segment::flip()
 {
-    PMapIt ptmp = p[0];
-    p[0] = p[1];
-    p[1] = ptmp;
-}    
-
+  PMapIt ptmp = p[0];
+  p[0] = p[1];
+  p[1] = ptmp;
+}

--- a/Src/jpdf.cpp
+++ b/Src/jpdf.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <iostream>
-using std::cout;
 using std::cerr;
+using std::cout;
 using std::endl;
 
 #include <AMReX_ParmParse.H>
@@ -10,104 +10,109 @@ using std::endl;
 
 using namespace amrex;
 
-static
-std::string
-ProtectSlashes (const std::string str)
+static std::string
+ProtectSlashes(const std::string str)
 {
-    std::string s = str;
+  std::string s = str;
 
-    std::vector<int> where;
+  std::vector<int> where;
 
-    const char* cstr = s.c_str();
+  const char* cstr = s.c_str();
 
-    for (int i = 0; i < s.size(); i++)
-        if (cstr[i] == '/')
-            where.push_back(i);
+  for (int i = 0; i < s.size(); i++)
+    if (cstr[i] == '/')
+      where.push_back(i);
 
-    for (int i = where.size() - 1; i >= 0; i--)
-        s.replace(where[i], 1, "_");
+  for (int i = where.size() - 1; i >= 0; i--)
+    s.replace(where[i], 1, "_");
 
-    return s;
+  return s;
 }
 
-
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
-    std::cerr << "usage:\n";
-    std::cerr << argv[0] << " infile=<filename>\n"
-              << "   output_gnuplot=[0/1] : Output JPDFs for gnuplot             (default=0)\n"
-              << "   output_matlab =[0/1] : Output JPDFs for matlab              (default=0)\n"
-              << "   output_tecplot=[0/1] : Output JPDFs for tecplot             (default=0)\n"
-              << "   output_scatter=[0/1] : Output scatter plot of non-zero bins (default=0)\n"
-              << "   output_fab=[0/1]     : Output JPDFs in fab format           (default=0)\n"
-              << "   output_plotfile=[0/1]: Output JPDFs in plotfile format      (default=1)\n"
-              << "   vars= var1 var2 var3 : Variable list; JPDF will be evaluated for each pair\n"
-              << "   useminmax%i= min max : Use min/max for var %i\n"
-              << "   nBins=n              : Number of bins in each direction for JPDF (default=64)\n"
-              << "   finestLevel=n        : Finest level at which to evaluate JPDFs\n"
-              << "   outSuffix=str        : Suffix to add to the plfile name as an alt dir for results (default="")\n"
-              << "   do_stoichimetry=[0/1]: Add stoichiometry as a variable (assumes H2 and requires Hlist and Olist)\n"
-              << "   Hlist= var1 var2 etc : Contribution to stoichiometry from H atoms\n"
-              << "   Olist= var1 var2 etc : Contribution to stoichiometry from O atoms\n"
-              << "   infile= plt1 plt2    : List of plot files" << std::endl;
-    exit(1);
+  std::cerr << "usage:\n";
+  std::cerr
+    << argv[0] << " infile=<filename>\n"
+    << "   output_gnuplot=[0/1] : Output JPDFs for gnuplot             "
+       "(default=0)\n"
+    << "   output_matlab =[0/1] : Output JPDFs for matlab              "
+       "(default=0)\n"
+    << "   output_tecplot=[0/1] : Output JPDFs for tecplot             "
+       "(default=0)\n"
+    << "   output_scatter=[0/1] : Output scatter plot of non-zero bins "
+       "(default=0)\n"
+    << "   output_fab=[0/1]     : Output JPDFs in fab format           "
+       "(default=0)\n"
+    << "   output_plotfile=[0/1]: Output JPDFs in plotfile format      "
+       "(default=1)\n"
+    << "   vars= var1 var2 var3 : Variable list; JPDF will be evaluated for "
+       "each pair\n"
+    << "   useminmax%i= min max : Use min/max for var %i\n"
+    << "   nBins=n              : Number of bins in each direction for JPDF "
+       "(default=64)\n"
+    << "   finestLevel=n        : Finest level at which to evaluate JPDFs\n"
+    << "   outSuffix=str        : Suffix to add to the plfile name as an alt "
+       "dir for results (default="
+       ")\n"
+    << "   do_stoichimetry=[0/1]: Add stoichiometry as a variable (assumes H2 "
+       "and requires Hlist and Olist)\n"
+    << "   Hlist= var1 var2 etc : Contribution to stoichiometry from H atoms\n"
+    << "   Olist= var1 var2 etc : Contribution to stoichiometry from O atoms\n"
+    << "   infile= plt1 plt2    : List of plot files" << std::endl;
+  exit(1);
 }
-
-
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    Initialize(argc,argv);
-    {
+  Initialize(argc, argv);
+  {
     if (argc < 2)
-        print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-        print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
-        AmrData::SetVerbose(true);
+      AmrData::SetVerbose(true);
 
     bool verbose = false;
     if (ParallelDescriptor::IOProcessor())
-        verbose = true;
+      verbose = true;
 
     // Get output file types
     if (verbose)
-        std::cout << "Output types:" << std::endl;
+      std::cout << "Output types:" << std::endl;
     int output_gnuplot(0);
-    pp.query("output_gnuplot",output_gnuplot);
-    if (output_gnuplot&&verbose)
-        std::cout << "   + gnuplot" << std::endl;
+    pp.query("output_gnuplot", output_gnuplot);
+    if (output_gnuplot && verbose)
+      std::cout << "   + gnuplot" << std::endl;
     int output_matlab(0);
-    pp.query("output_matlab",output_matlab);
-    if (output_matlab&&verbose)
-        std::cout << "   + matlab" << std::endl;
+    pp.query("output_matlab", output_matlab);
+    if (output_matlab && verbose)
+      std::cout << "   + matlab" << std::endl;
     int output_tecplot(0);
-    pp.query("output_tecplot",output_tecplot);
-    if (output_tecplot&&verbose)
-        std::cout << "   + tecplot" << std::endl;
+    pp.query("output_tecplot", output_tecplot);
+    if (output_tecplot && verbose)
+      std::cout << "   + tecplot" << std::endl;
     int output_fab(0);
-    pp.query("output_fab",output_fab);
-    if (output_fab&&verbose)
-        std::cout << "   + fab" << std::endl;
+    pp.query("output_fab", output_fab);
+    if (output_fab && verbose)
+      std::cout << "   + fab" << std::endl;
     int output_plotfile(1);
-    pp.query("output_plotfile",output_plotfile);
-    if (output_plotfile&&verbose)
-        std::cout << "   + plotfile" << std::endl;
+    pp.query("output_plotfile", output_plotfile);
+    if (output_plotfile && verbose)
+      std::cout << "   + plotfile" << std::endl;
     int output_scatter(0);
-    pp.query("output_scatter",output_scatter);
-    if (output_scatter&&verbose)
-        std::cout << "   + scatter" << std::endl;
-    
-    // Do conditioning                                                                                                                                                                                 
+    pp.query("output_scatter", output_scatter);
+    if (output_scatter && verbose)
+      std::cout << "   + scatter" << std::endl;
+
+    // Do conditioning
     int do_conditioning(0);
     int cVar(0);
     int norm_cVal(0);
@@ -115,961 +120,1049 @@ main (int   argc,
     Real cMax(1.0);
     Real cNormMin(0.0);
     Real cNormMax(1.0);
-    
-    pp.query("do_conditioning",do_conditioning);
+
+    pp.query("do_conditioning", do_conditioning);
     if (verbose)
-        std::cout << "do_conditioning = " << do_conditioning << std::endl;
-    
-    if (do_conditioning>0) {
-        pp.query("cVar",cVar);
-        if (verbose)
-            std::cout << "cVar = " << cVar << std::endl;
-      
-        pp.query("norm_cVal",norm_cVal);
-        if (verbose)
-            std::cout << "norm_cVal = " << norm_cVal << std::endl;
+      std::cout << "do_conditioning = " << do_conditioning << std::endl;
 
-        if (do_conditioning==2)
-            norm_cVal=1; // Force normalisation for c(1-c) evaluation
+    if (do_conditioning > 0) {
+      pp.query("cVar", cVar);
+      if (verbose)
+        std::cout << "cVar = " << cVar << std::endl;
 
-        if (norm_cVal==1) { // Get min max for c normalisation
-            pp.query("cNormMin",cNormMin);
-            if (verbose)
-                std::cout << "cNormMin = " << cNormMin << std::endl;
-            pp.query("cNormMax",cNormMax);
-            if (verbose)
-                std::cout << "cNormMax = " << cNormMax << std::endl;
-        }
+      pp.query("norm_cVal", norm_cVal);
+      if (verbose)
+        std::cout << "norm_cVal = " << norm_cVal << std::endl;
 
-        pp.query("cMin",cMin);
+      if (do_conditioning == 2)
+        norm_cVal = 1; // Force normalisation for c(1-c) evaluation
+
+      if (norm_cVal == 1) { // Get min max for c normalisation
+        pp.query("cNormMin", cNormMin);
         if (verbose)
-            std::cout << "cMin = " << cMin << std::endl;
-      
-        pp.query("cMax",cMax);
+          std::cout << "cNormMin = " << cNormMin << std::endl;
+        pp.query("cNormMax", cNormMax);
         if (verbose)
-            std::cout << "cMax = " << cMax << std::endl;
+          std::cout << "cNormMax = " << cNormMax << std::endl;
+      }
 
+      pp.query("cMin", cMin);
+      if (verbose)
+        std::cout << "cMin = " << cMin << std::endl;
+
+      pp.query("cMax", cMax);
+      if (verbose)
+        std::cout << "cMax = " << cMax << std::endl;
     }
-    
+
     int do_average(0);
-    pp.query("do_average",do_average);
-    if (do_average&&verbose)
-        std::cout << "   + forming average" << std::endl;
+    pp.query("do_average", do_average);
+    if (do_average && verbose)
+      std::cout << "   + forming average" << std::endl;
 
     // Get plot file
     int nPlotFiles(pp.countval("infile"));
-    if(nPlotFiles <= 0) {
-        std::cerr << "Bad nPlotFiles:  " << nPlotFiles << std::endl;
-        std::cerr << "Exiting." << std::endl;
-        DataServices::Dispatch(DataServices::ExitRequest, NULL);
+    if (nPlotFiles <= 0) {
+      std::cerr << "Bad nPlotFiles:  " << nPlotFiles << std::endl;
+      std::cerr << "Exiting." << std::endl;
+      DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     if (verbose)
-        std::cout << "Processing " << nPlotFiles << " plotfiles..." << std::endl;
+      std::cout << "Processing " << nPlotFiles << " plotfiles..." << std::endl;
 
-    std::string outSuffix = ""; pp.query("outSuffix",outSuffix);
+    std::string outSuffix = "";
+    pp.query("outSuffix", outSuffix);
 
     // Make an array of srings containing paths of input plot files
     Vector<std::string> plotFileNames(nPlotFiles);
-    for(int iPlot = 0; iPlot < nPlotFiles; ++iPlot) {
-        pp.get("infile", plotFileNames[iPlot], iPlot);
-        if (verbose)
-            std::cout << "   " << plotFileNames[iPlot] << std::endl;
+    for (int iPlot = 0; iPlot < nPlotFiles; ++iPlot) {
+      pp.get("infile", plotFileNames[iPlot], iPlot);
+      if (verbose)
+        std::cout << "   " << plotFileNames[iPlot] << std::endl;
     }
 
     // Get finest level argument
     int inFinestLevel(-1);
-    pp.query("finestLevel",inFinestLevel);
+    pp.query("finestLevel", inFinestLevel);
 
     // Number of bins in each direction
     int nBins(64);
-    pp.query("nBins",nBins);
+    pp.query("nBins", nBins);
 
     // Variables to load; a joint pdf of each pair will be evaluated
     int nVars(pp.countval("vars"));
-    int lVars(nVars);  // number of variables to load from the plot file
-    if (nVars<2)
-        Error("Need to specify at least two variables.");
+    int lVars(nVars); // number of variables to load from the plot file
+    if (nVars < 2)
+      Error("Need to specify at least two variables.");
 
     // Use "stoichiometry" as one of the variables - requires all species
     int do_stoichiometry(0);
-    pp.query("do_stoichiometry",do_stoichiometry);
+    pp.query("do_stoichiometry", do_stoichiometry);
 
     // If so, increment the number of variables
     int sVar(-1);
     if (do_stoichiometry) {
-        do_stoichiometry=1; // Let's make sure it's 1
-        sVar=nVars;
-        nVars++;
+      do_stoichiometry = 1; // Let's make sure it's 1
+      sVar = nVars;
+      nVars++;
     }
 
     // Intersect variable number (must come after stoichiometry)
-    int isVar=nVars;
+    int isVar = nVars;
 
     Vector<std::string> whichVar(nVars);
     if (verbose)
-        std::cout << "Variable list:" << std::endl;
+      std::cout << "Variable list:" << std::endl;
     // Read in variable list - adjusting for stoichiometry
-    for(int v=0; v<lVars; v++) {
-        pp.get("vars", whichVar[v], v);
-        if (verbose)
-            std::cout << "   " << whichVar[v] << std::endl;
+    for (int v = 0; v < lVars; v++) {
+      pp.get("vars", whichVar[v], v);
+      if (verbose)
+        std::cout << "   " << whichVar[v] << std::endl;
     }
     if (do_stoichiometry)
-        whichVar[sVar] = "Stoichiometry";
+      whichVar[sVar] = "Stoichiometry";
 
-    // Copy the names of the variable for output filenames, replacing dodgy characters
+    // Copy the names of the variable for output filenames, replacing dodgy
+    // characters
     Vector<std::string> whichVarOut(nVars);
-    for (int iVar=0; iVar<nVars; iVar++) {
-        whichVarOut[iVar] = ProtectSlashes(whichVar[iVar]);
-        if (verbose)
-            std::cout << whichVar[iVar] << " -> " << whichVarOut[iVar] << std::endl;
+    for (int iVar = 0; iVar < nVars; iVar++) {
+      whichVarOut[iVar] = ProtectSlashes(whichVar[iVar]);
+      if (verbose)
+        std::cout << whichVar[iVar] << " -> " << whichVarOut[iVar] << std::endl;
     }
-    
+
     Vector<int> hList(lVars);
     Vector<int> oList(lVars);
     if (do_stoichiometry) {
-        if (pp.countval("Hlist")!=lVars) Error("Need to specify one Hlist entry per variable");
-        if (pp.countval("Olist")!=lVars) Error("Need to specify one Olist entry per variable");
+      if (pp.countval("Hlist") != lVars)
+        Error("Need to specify one Hlist entry per variable");
+      if (pp.countval("Olist") != lVars)
+        Error("Need to specify one Olist entry per variable");
 
+      if (verbose)
+        std::cout << "Doing stoichiometry:" << std::endl;
+
+      for (int v = 0; v < lVars; v++) {
+        pp.get("Hlist", hList[v], v);
+        pp.get("Olist", oList[v], v);
         if (verbose)
-            std::cout << "Doing stoichiometry:" << std::endl;
-
-        for(int v=0; v<lVars; v++) {
-            pp.get("Hlist", hList[v], v);
-            pp.get("Olist", oList[v], v);
-            if (verbose)
-                std::cout << "   " << whichVar[v] << " : #H=" << hList[v] << " : #O=" << oList[v] << std::endl;
-        }      
+          std::cout << "   " << whichVar[v] << " : #H=" << hList[v]
+                    << " : #O=" << oList[v] << std::endl;
+      }
     }
 
     // Initialise some stuff here for average later
-    int nPairs(nVars*(nVars-1)/2);
+    int nPairs(nVars * (nVars - 1) / 2);
     Real domainVol;
-    Vector< Vector<Real> > binAvArray(nPairs);
-    Vector< Vector<Real> > binAvX1Array(nPairs);
-    Vector< Vector<Real> > binAvX2Array(nPairs);
+    Vector<Vector<Real>> binAvArray(nPairs);
+    Vector<Vector<Real>> binAvX1Array(nPairs);
+    Vector<Vector<Real>> binAvX2Array(nPairs);
     Vector<Real> vMin(nVars);
     Vector<Real> vMax(nVars);
 
     // Loop over files
-    for (int iPlot=0; iPlot<nPlotFiles; iPlot++) {
+    for (int iPlot = 0; iPlot < nPlotFiles; iPlot++) {
 
-        // Open file and get an amrData pointer
-        std::string infile = plotFileNames[iPlot];
-        if (verbose)
-            std::cout << "\nOpening " << infile << "..." << std::endl;
-        DataServices::SetBatchMode();
-        Amrvis::FileType fileType(Amrvis::NEWPLT);
-        DataServices dataServices(infile, fileType);
-        if (!dataServices.AmrDataOk())
-            DataServices::Dispatch(DataServices::ExitRequest, NULL);
-        AmrData& amrData = dataServices.AmrDataRef();
-        if (verbose)
-            std::cout << "   ...done." << std::endl;
-    
-        // Check the names of the variables are present in the plotfile
-        Vector<int> destFills(lVars);
-        for (int v=0; v<lVars; v++) {
-            destFills[v] = v;
-            if (amrData.StateNumber(whichVar[v])<0) {
-                std::string message="Bad variable name ("+whichVar[v]+")";
-                Error(message.c_str());
-            }
+      // Open file and get an amrData pointer
+      std::string infile = plotFileNames[iPlot];
+      if (verbose)
+        std::cout << "\nOpening " << infile << "..." << std::endl;
+      DataServices::SetBatchMode();
+      Amrvis::FileType fileType(Amrvis::NEWPLT);
+      DataServices dataServices(infile, fileType);
+      if (!dataServices.AmrDataOk())
+        DataServices::Dispatch(DataServices::ExitRequest, NULL);
+      AmrData& amrData = dataServices.AmrDataRef();
+      if (verbose)
+        std::cout << "   ...done." << std::endl;
+
+      // Check the names of the variables are present in the plotfile
+      Vector<int> destFills(lVars);
+      for (int v = 0; v < lVars; v++) {
+        destFills[v] = v;
+        if (amrData.StateNumber(whichVar[v]) < 0) {
+          std::string message = "Bad variable name (" + whichVar[v] + ")";
+          Error(message.c_str());
         }
-    
-        // Get finest level
-        int finestLevel = amrData.FinestLevel();    
-        if (inFinestLevel>-1 && inFinestLevel<finestLevel) {
-            finestLevel = inFinestLevel;
+      }
+
+      // Get finest level
+      int finestLevel = amrData.FinestLevel();
+      if (inFinestLevel > -1 && inFinestLevel < finestLevel) {
+        finestLevel = inFinestLevel;
+        if (verbose)
+          std::cout << "Finest level: " << finestLevel << std::endl;
+      }
+      int nLevels = finestLevel + 1;
+
+      // Get domain size
+      Vector<Real> probLo = amrData.ProbLo();
+      Vector<Real> probHi = amrData.ProbHi();
+
+      // Get probDomain
+      Vector<Box> probDomain = amrData.ProbDomain();
+
+      // Get min/max for each component
+      for (int iVar = 0; iVar < lVars; iVar++) {
+        vMin[iVar] = 1e100;
+        vMax[iVar] = -vMin[iVar];
+        for (int iLevel = 0; iLevel < nLevels; iLevel++) {
+          Real min, max;
+          amrData.MinMax(probDomain[iLevel], whichVar[iVar], iLevel, min, max);
+          if (vMin[iVar] > min)
+            vMin[iVar] = min;
+          if (vMax[iVar] < max)
+            vMax[iVar] = max;
+        }
+      }
+      if (do_stoichiometry) {
+        vMin[sVar] = 0.0;
+        vMax[sVar] = 2.0;
+      }
+
+      for (int iVar = 0; iVar < nVars;
+           iVar++) { // Include stoichiometry here (nVars not lVars)
+        char argName[12];
+        sprintf(argName, "useminmax%i", iVar + 1);
+        int nMinMax = pp.countval(argName);
+        if (nMinMax > 0) {
+          if (nMinMax != 2) {
+            Abort("Need to specify 2 values for useMinMax");
+          } else {
+            pp.get(argName, vMin[iVar], 0);
+            pp.get(argName, vMax[iVar], 1);
             if (verbose)
-                std::cout << "Finest level: " << finestLevel << std::endl;
+              std::cout << "Var" << iVar + 1 << " (" << whichVar[iVar]
+                        << ") using min/max: " << vMin[iVar] << " / "
+                        << vMax[iVar] << std::endl;
+          }
         }
-        int nLevels = finestLevel+1;
+      }
 
-        // Get domain size
-        Vector<Real> probLo=amrData.ProbLo();
-        Vector<Real> probHi=amrData.ProbHi();
+      // Declare space for a joint pdf for each variable pair
+      Vector<Vector<Real>> binArray(nPairs);
+      Vector<Vector<Real>> binX1Array(nPairs);
+      Vector<Vector<Real>> binX2Array(nPairs);
 
-        // Get probDomain
-        Vector<Box> probDomain = amrData.ProbDomain();
+      for (int iPair = 0; iPair < nPairs; iPair++) {
+        binArray[iPair].resize(nBins * nBins, 0);
+        binX1Array[iPair].resize(nBins * nBins, 0);
+        binX2Array[iPair].resize(nBins * nBins, 0);
+      }
 
-        // Get min/max for each component
-        for (int iVar=0; iVar<lVars; iVar++) {
-            vMin[iVar]=1e100;
-            vMax[iVar]=-vMin[iVar];
-            for (int iLevel=0; iLevel<nLevels; iLevel++) {
-                Real min,max;
-                amrData.MinMax(probDomain[iLevel], whichVar[iVar], iLevel, min, max);
-                if (vMin[iVar]>min) vMin[iVar]=min;
-                if (vMax[iVar]<max) vMax[iVar]=max;
-            }
+      if (do_average && iPlot == 0) {
+        for (int iPair = 0; iPair < nPairs; iPair++) {
+          binAvArray[iPair].resize(nBins * nBins, 0);
+          binAvX1Array[iPair].resize(nBins * nBins, 0);
+          binAvX2Array[iPair].resize(nBins * nBins, 0);
         }
-        if (do_stoichiometry) {
-            vMin[sVar]=0.0;
-            vMax[sVar]=2.0;
-        }
+      }
 
-        for (int iVar=0; iVar<nVars; iVar++) { // Include stoichiometry here (nVars not lVars)
-            char argName[12];
-            sprintf(argName,"useminmax%i",iVar+1);
-            int nMinMax = pp.countval(argName);
-            if (nMinMax>0) {
-                if (nMinMax != 2) {
-                    Abort("Need to specify 2 values for useMinMax");
-                } else {
-                    pp.get(argName, vMin[iVar], 0);
-                    pp.get(argName, vMax[iVar], 1);
-                    if (verbose)
-                        std::cout << "Var" << iVar+1 << " (" << whichVar[iVar] << ") using min/max: " << vMin[iVar] << " / " << vMax[iVar] << std::endl;
-                }
-            }
-        }
- 
-        // Declare space for a joint pdf for each variable pair
-        Vector< Vector<Real> > binArray(nPairs);
-        Vector< Vector<Real> > binX1Array(nPairs);
-        Vector< Vector<Real> > binX2Array(nPairs);
-
-        for (int iPair=0; iPair<nPairs; iPair++) {
-            binArray[iPair].resize(nBins*nBins,0);
-            binX1Array[iPair].resize(nBins*nBins,0);
-            binX2Array[iPair].resize(nBins*nBins,0);
-        }
-
-        if (do_average && iPlot==0) {
-            for (int iPair=0; iPair<nPairs; iPair++) {
-                binAvArray[iPair].resize(nBins*nBins,0);
-                binAvX1Array[iPair].resize(nBins*nBins,0);
-                binAvX2Array[iPair].resize(nBins*nBins,0);
-            }
-        }
-
-        // Load the data
+      // Load the data
+      if (verbose)
+        std::cout << "Loading data..." << std::endl;
+      Vector<std::unique_ptr<MultiFab>> mf(nLevels);
+      for (int iLevel = 0; iLevel < nLevels; iLevel++) {
         if (verbose)
-            std::cout << "Loading data..." << std::endl;
-        Vector<std::unique_ptr<MultiFab>> mf(nLevels);
-        for (int iLevel=0; iLevel<nLevels; iLevel++) {
-            if (verbose)
-                std::cout << "   Level " << iLevel << "..." << std::endl;
-            int ngrow(0);
+          std::cout << "   Level " << iLevel << "..." << std::endl;
+        int ngrow(0);
 
-            // Make space for each component and one for the intersect flag
-            DistributionMapping dm(amrData.boxArray(iLevel));
-            mf[iLevel].reset(new MultiFab(amrData.boxArray(iLevel), dm, nVars+1, ngrow));
+        // Make space for each component and one for the intersect flag
+        DistributionMapping dm(amrData.boxArray(iLevel));
+        mf[iLevel].reset(
+          new MultiFab(amrData.boxArray(iLevel), dm, nVars + 1, ngrow));
 
-            // Put the value 1 in the intersect flag
-            mf[iLevel]->setVal(1.,isVar,1);
+        // Put the value 1 in the intersect flag
+        mf[iLevel]->setVal(1., isVar, 1);
 
-            // Load the data (make a copy of whichVar to make sure it's the same size as destFills)
-            Vector<std::string> loadWhichVar(lVars);
-            for (int v=0; v<lVars; v++)
-                loadWhichVar[v] = whichVar[v];
-            amrData.FillVar(*mf[iLevel], iLevel, loadWhichVar, destFills);
+        // Load the data (make a copy of whichVar to make sure it's the same
+        // size as destFills)
+        Vector<std::string> loadWhichVar(lVars);
+        for (int v = 0; v < lVars; v++)
+          loadWhichVar[v] = whichVar[v];
+        amrData.FillVar(*mf[iLevel], iLevel, loadWhichVar, destFills);
+      }
+      if (verbose)
+        std::cout << "      ...done." << std::endl;
+
+      // Set the intersect flag to zero if necessary
+      for (int iLevel = 0; iLevel < finestLevel; iLevel++) {
+        BoxArray baf = mf[iLevel + 1]->boxArray();
+        baf.coarsen(amrData.RefRatio()[iLevel]);
+
+        for (MFIter mfi(*mf[iLevel]); mfi.isValid(); ++mfi) {
+          FArrayBox& myFab = (*mf[iLevel])[mfi];
+
+          int idx = mfi.index();
+
+          std::vector<std::pair<int, Box>> isects =
+            baf.intersections(mf[iLevel]->boxArray()[idx]);
+
+          for (int ii = 0; ii < isects.size(); ii++)
+            myFab.setVal(0, isects[ii].second, isVar, 1);
         }
-        if (verbose)
-            std::cout << "      ...done." << std::endl;
+      }
 
-        // Set the intersect flag to zero if necessary
-        for (int iLevel=0; iLevel<finestLevel; iLevel++) {
-            BoxArray baf = mf[iLevel+1]->boxArray();
-            baf.coarsen(amrData.RefRatio()[iLevel]);   
- 
-            for (MFIter mfi(*mf[iLevel]); mfi.isValid(); ++mfi) {
-                FArrayBox& myFab = (*mf[iLevel])[mfi];
-     
-                int idx = mfi.index();
+      // Populate the stoichiometry variable
+      if (do_stoichiometry) {
 
-                std::vector< std::pair<int,Box> > isects = baf.intersections(mf[iLevel]->boxArray()[idx]);
+        for (int iLevel = 0; iLevel < nLevels; iLevel++) {
+          if (verbose)
+            std::cout << "      Level " << iLevel << std::endl;
 
-                for (int ii = 0; ii < isects.size(); ii++)
-                    myFab.setVal(0,isects[ii].second,isVar,1);
-            }
-        }
- 
-        // Populate the stoichiometry variable
-        if (do_stoichiometry) {
-   
-            for (int iLevel=0; iLevel<nLevels; iLevel++) {
-                if (verbose)
-                    std::cout << "      Level " << iLevel << std::endl;
-
-                for(MFIter ntmfi(*mf[iLevel]); ntmfi.isValid(); ++ntmfi) {
-                    FArrayBox &myFab = (*mf[iLevel])[ntmfi];
-                    Real *sPtr = myFab.dataPtr(sVar);
-		    const Box&  bx    = ntmfi.validbox();
-                    const int  *lo    = bx.loVect();
-                    const int  *hi    = bx.hiVect(); 
-                    const int   ix    = hi[0]-lo[0]+1;
-                    const int   jx    = hi[1]-lo[1]+1;
-#if (AMREX_SPACEDIM==3)
-                    const int   kx    = hi[2]-lo[2]+1;
-                    const int  nCells = ix*jx*kx;
+          for (MFIter ntmfi(*mf[iLevel]); ntmfi.isValid(); ++ntmfi) {
+            FArrayBox& myFab = (*mf[iLevel])[ntmfi];
+            Real* sPtr = myFab.dataPtr(sVar);
+            const Box& bx = ntmfi.validbox();
+            const int* lo = bx.loVect();
+            const int* hi = bx.hiVect();
+            const int ix = hi[0] - lo[0] + 1;
+            const int jx = hi[1] - lo[1] + 1;
+#if (AMREX_SPACEDIM == 3)
+            const int kx = hi[2] - lo[2] + 1;
+            const int nCells = ix * jx * kx;
 #else
-                    const int  nCells = ix*jx;
+            const int nCells = ix * jx;
 #endif
-                    for (int cell=0; cell<nCells; cell++) {
-                        Real sumH(0.0), sumO(0.0);
-                        for (int v=0; v<lVars; v++) {
-                            Real X = myFab.dataPtr(v)[cell];
-                            sumH += X*(Real)(hList[v]);
-                            sumO += X*(Real)(oList[v]);
-                        }
-                        sPtr[cell] = 0.5*sumH/sumO; // The 0.5 is 2.0/4.0, 2.0 for H2O and 4.0 for stoichiometric scaling
-                    }
-                }
+            for (int cell = 0; cell < nCells; cell++) {
+              Real sumH(0.0), sumO(0.0);
+              for (int v = 0; v < lVars; v++) {
+                Real X = myFab.dataPtr(v)[cell];
+                sumH += X * (Real)(hList[v]);
+                sumO += X * (Real)(oList[v]);
+              }
+              sPtr[cell] =
+                0.5 * sumH / sumO; // The 0.5 is 2.0/4.0, 2.0 for H2O and 4.0
+                                   // for stoichiometric scaling
             }
+          }
+        }
+      }
+
+      // Evaluate the pdf for each pair
+      if (verbose)
+        std::cout << "Evaluating pdfs..." << std::endl;
+      int iPair = 0;
+      for (int var1 = 0; var1 < nVars; var1++) {
+        for (int var2 = var1 + 1; var2 < nVars; var2++) {
+          if (verbose)
+            std::cout << "   + " << whichVar[var1] << "-" << whichVar[var2]
+                      << std::endl;
+          Real* bin = binArray[iPair].dataPtr();
+          Real* binX1 = binX1Array[iPair].dataPtr();
+          Real* binX2 = binX2Array[iPair].dataPtr();
+          Real *binAv, *binAvX1, *binAvX2;
+          if (do_average) {
+            binAv = binAvArray[iPair].dataPtr();
+            binAvX1 = binAvX1Array[iPair].dataPtr();
+            binAvX2 = binAvX2Array[iPair].dataPtr();
+          }
+          for (int iLevel = 0; iLevel < nLevels; iLevel++) {
+            if (verbose)
+              std::cout << "      Level " << iLevel << std::endl;
+            int v1l = 0;
+            int v1g = 0;
+            int v2l = 0;
+            int v2g = 0;
+            for (MFIter ntmfi(*mf[iLevel]); ntmfi.isValid(); ++ntmfi) {
+              const FArrayBox& myFab = (*mf[iLevel])[ntmfi];
+              const Real* dx = amrData.DxLevel()[iLevel].dataPtr();
+              const Real* cPtr = myFab.dataPtr(cVar); // Conditioning
+              const Real* v1Ptr = myFab.dataPtr(var1);
+              const Real* v2Ptr = myFab.dataPtr(var2);
+              const Real* isPtr = myFab.dataPtr(nVars); // Intersect
+              const Box& bx = ntmfi.validbox();
+              const int* lo = bx.loVect();
+              const int* hi = bx.hiVect();
+              const int ix = hi[0] - lo[0] + 1;
+              const int jx = hi[1] - lo[1] + 1;
+              Real Vol = dx[0] * dx[1];
+#if (AMREX_SPACEDIM == 3)
+              const int kx = hi[2] - lo[2] + 1;
+              ;
+              Vol *= dx[2];
+              for (int k = 0; k < kx; k++) {
+                Real z = probLo[2] + dx[2] * (0.5 + (Real)(k + lo[2]));
+#endif
+                for (int j = 0; j < jx; j++) {
+                  Real y = probLo[1] + dx[1] * (0.5 + (Real)(j + lo[1]));
+                  for (int i = 0; i < ix; i++) {
+                    Real x = probLo[0] + dx[0] * (0.5 + (Real)(i + lo[0]));
+#if (AMREX_SPACEDIM == 3)
+                    int cell = (k * jx + j) * ix + i;
+#else
+                  int cell = j * ix + i;
+#endif
+                    if (isPtr[cell] > 0) { // Intersect
+
+                      int contribute = 1;
+
+                      if (do_conditioning > 0) {
+
+                        double cVal = cPtr[cell];
+
+                        if (norm_cVal == 1)
+                          cVal = (cVal - cNormMin) / (cNormMax - cNormMin);
+
+                        if (do_conditioning == 2)
+                          cVal = cVal * (1. - cVal);
+
+                        if (cVal < cMin || cVal > cMax)
+                          contribute = 0;
+                      }
+
+                      if (contribute == 1) {
+                        int v1i = (int)(nBins * (v1Ptr[cell] - vMin[var1]) /
+                                        (vMax[var1] - vMin[var1]));
+                        if (v1i < 0) {
+                          v1l++;
+                          v1i = 0;
+                        }
+                        if (v1i >= nBins) {
+                          v1g++;
+                          v1i = nBins - 1;
+                        }
+                        int v2i = (int)(nBins * (v2Ptr[cell] - vMin[var2]) /
+                                        (vMax[var2] - vMin[var2]));
+                        if (v2i < 0) {
+                          v2l++;
+                          v2i = 0;
+                        }
+                        if (v2i >= nBins) {
+                          v2g++;
+                          v2i = nBins - 1;
+                        }
+                        bin[v1i * nBins + v2i] += Vol;
+                        binX1[v1i * nBins + v2i] += Vol * v1Ptr[cell];
+                        binX2[v1i * nBins + v2i] += Vol * v2Ptr[cell];
+                        if (do_average) {
+                          binAv[v1i * nBins + v2i] += Vol;
+                          binAvX1[v1i * nBins + v2i] += Vol * v1Ptr[cell];
+                          binAvX2[v1i * nBins + v2i] += Vol * v2Ptr[cell];
+                        }
+                      }
+                    }
+                  } // i
+                } // j
+#if (AMREX_SPACEDIM == 3)
+              } // k
+#endif
+            } // MFI
+            ParallelDescriptor::ReduceIntSum(v1l);
+            ParallelDescriptor::ReduceIntSum(v1g);
+            ParallelDescriptor::ReduceIntSum(v2l);
+            ParallelDescriptor::ReduceIntSum(v2g);
+            if (verbose) {
+              if (v1l)
+                std::cout << "v1i<0:      " << v1l << std::endl;
+              if (v1g)
+                std::cout << "v1i>=nBins: " << v1g << std::endl;
+              if (v2l)
+                std::cout << "v2i<0:      " << v2l << std::endl;
+              if (v2g)
+                std::cout << "v2i>=nBins: " << v2g << std::endl;
+            }
+          } // Level
+          iPair++;
+        }
+      }
+      if (verbose)
+        std::cout << "   ...done." << std::endl;
+
+      // Reduce data
+      for (int iPair = 0; iPair < nPairs; iPair++) {
+        Real* bin = binArray[iPair].dataPtr();
+        Real* binX1 = binX1Array[iPair].dataPtr();
+        Real* binX2 = binX2Array[iPair].dataPtr();
+        ParallelDescriptor::ReduceRealSum(
+          bin, binArray[iPair].size(), ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum(
+          binX1, binX1Array[iPair].size(),
+          ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum(
+          binX2, binX2Array[iPair].size(),
+          ParallelDescriptor::IOProcessorNumber());
+      }
+
+      // Output the data to file
+      if (ParallelDescriptor::IOProcessor()) {
+
+        if (outSuffix != "") {
+          std::string oFile = infile + outSuffix;
+          if (!UtilCreateDirectory(oFile, 0755))
+            CreateDirectoryFailed(oFile);
         }
 
-        // Evaluate the pdf for each pair
-        if (verbose)
-            std::cout << "Evaluating pdfs..." << std::endl;
+        domainVol = 1;
+        for (int dd = 0; dd < AMREX_SPACEDIM; ++dd) {
+          domainVol *= probHi[dd] - probLo[dd];
+        }
+
+        Real small = 1.e-7;
+
         int iPair = 0;
-        for (int var1=0; var1<nVars; var1++) {
-            for (int var2 = var1+1; var2<nVars; var2++) {
-                if (verbose)
-                    std::cout << "   + " << whichVar[var1] << "-" << whichVar[var2] << std::endl;
-                Real *bin=binArray[iPair].dataPtr();
-                Real *binX1=binX1Array[iPair].dataPtr();
-                Real *binX2=binX2Array[iPair].dataPtr();
-                Real *binAv, *binAvX1, *binAvX2;
-                if (do_average) {
-                    binAv = binAvArray[iPair].dataPtr();
-                    binAvX1 = binAvX1Array[iPair].dataPtr();
-                    binAvX2 = binAvX2Array[iPair].dataPtr();
+
+        for (int var1 = 0; var1 < nVars; var1++) {
+          // Change in var1 between each bin
+          Real dv1 = (vMax[var1] - vMin[var1]) / (Real)nBins;
+
+          for (int var2 = var1 + 1; var2 < nVars; var2++) {
+            // Change in var2 between each bin
+            Real dv2 = (vMax[var2] - vMin[var2]) / (Real)nBins;
+
+            // Pull out the pointer for this pair
+            Real* bin = binArray[iPair].dataPtr();
+            Real* binX1 = binX1Array[iPair].dataPtr();
+            Real* binX2 = binX2Array[iPair].dataPtr();
+
+            // Divide Xi by bin vol to average (has to come first)
+            for (int v1i = 0, i = 0; v1i < nBins; v1i++) {
+              Real v1 = vMin[var1] + dv1 * (0.5 + (Real)v1i);
+              for (int v2i = 0; v2i < nBins; v2i++, i++) {
+                Real v2 = vMin[var2] + dv2 * (0.5 + (Real)v2i);
+                Real div = bin[i];
+                if (div > 0) {
+                  binX1[i] /= div;
+                  binX2[i] /= div;
+                } else { // This is the bit that breaks the derivation of the 1D
+                         // pdfs
+                  binX1[i] = v1;
+                  binX2[i] = v2;
                 }
-                for (int iLevel=0; iLevel<nLevels; iLevel++) {
-                    if (verbose)
-                        std::cout << "      Level " << iLevel << std::endl;
-                    int v1l=0; int v1g=0; int v2l=0; int v2g=0;
-                    for(MFIter ntmfi(*mf[iLevel]); ntmfi.isValid(); ++ntmfi) {
-                        const FArrayBox &myFab = (*mf[iLevel])[ntmfi];
-                        const Real *dx = amrData.DxLevel()[iLevel].dataPtr();
-                        const Real *cPtr  = myFab.dataPtr(cVar); // Conditioning
-                        const Real *v1Ptr = myFab.dataPtr(var1);
-                        const Real *v2Ptr = myFab.dataPtr(var2);
-                        const Real *isPtr = myFab.dataPtr(nVars); // Intersect
-			const Box&  bx    = ntmfi.validbox();
-			const int  *lo    = bx.loVect();
-			const int  *hi    = bx.hiVect(); 
-                        const int   ix    = hi[0]-lo[0]+1;
-                        const int   jx    = hi[1]-lo[1]+1;
-                        Real        Vol   = dx[0]*dx[1];
-#if (AMREX_SPACEDIM==3)
-                        const int   kx    = hi[2]-lo[2]+1;
-                        ;           Vol  *= dx[2];
-                        for (int k=0; k<kx; k++) {
-                            Real z=probLo[2] + dx[2]*(0.5+(Real)(k+lo[2]));
-#endif
-                            for (int j=0; j<jx; j++) {
-                                Real y=probLo[1] + dx[1]*(0.5+(Real)(j+lo[1]));
-                                for (int i=0; i<ix; i++) {
-                                    Real x=probLo[0] + dx[0]*(0.5+(Real)(i+lo[0]));
-#if (AMREX_SPACEDIM==3)
-                                    int cell = (k*jx+j)*ix+i;
-#else
-                                    int cell = j*ix+i;
-#endif
-                                    if (isPtr[cell]>0) {  // Intersect
-
-                                        int contribute=1;
-          
-                                        if (do_conditioning>0) {
-     
-                                            double cVal = cPtr[cell];
-     
-                                            if (norm_cVal==1)
-                                                cVal = (cVal-cNormMin)/(cNormMax-cNormMin);
-     
-                                            if (do_conditioning==2)
-                                                cVal = cVal * (1.-cVal);
-     
-                                            if (cVal<cMin || cVal>cMax) contribute=0;
-                                        }
-          
-                                        if (contribute==1) {
-                                            int v1i = (int)(nBins*(v1Ptr[cell]-vMin[var1])/(vMax[var1]-vMin[var1]));
-                                            if (v1i<0)      { v1l++; v1i=0; }
-                                            if (v1i>=nBins) { v1g++; v1i=nBins-1; }
-                                            int v2i = (int)(nBins*(v2Ptr[cell]-vMin[var2])/(vMax[var2]-vMin[var2]));
-                                            if (v2i<0)      { v2l++; v2i=0; }
-                                            if (v2i>=nBins) { v2g++; v2i=nBins-1; }
-                                            bin[v1i*nBins+v2i]+=Vol;
-                                            binX1[v1i*nBins+v2i]+=Vol*v1Ptr[cell];
-                                            binX2[v1i*nBins+v2i]+=Vol*v2Ptr[cell];
-                                            if (do_average) {
-                                                binAv[v1i*nBins+v2i]+=Vol;
-                                                binAvX1[v1i*nBins+v2i]+=Vol*v1Ptr[cell];
-                                                binAvX2[v1i*nBins+v2i]+=Vol*v2Ptr[cell];
-                                            }
-                                        }
-                                    }
-                                } // i
-                            } // j
-#if (AMREX_SPACEDIM==3)
-                        } // k
-#endif
-                    } // MFI
-                    ParallelDescriptor::ReduceIntSum(v1l);
-                    ParallelDescriptor::ReduceIntSum(v1g);
-                    ParallelDescriptor::ReduceIntSum(v2l);
-                    ParallelDescriptor::ReduceIntSum(v2g);
-                    if (verbose) {
-                        if (v1l) std::cout << "v1i<0:      " << v1l << std::endl;
-                        if (v1g) std::cout << "v1i>=nBins: " << v1g << std::endl;
-                        if (v2l) std::cout << "v2i<0:      " << v2l << std::endl; 
-                        if (v2g) std::cout << "v2i>=nBins: " << v2g << std::endl;
-                    }
-                } // Level
-                iPair++;
+              }
             }
-        }
-        if (verbose)
-            std::cout << "   ...done." << std::endl;
 
-        // Reduce data
-        for (int iPair=0; iPair<nPairs; iPair++) {
-            Real *bin=binArray[iPair].dataPtr();
-            Real *binX1=binX1Array[iPair].dataPtr();
-            Real *binX2=binX2Array[iPair].dataPtr();
-            ParallelDescriptor::ReduceRealSum(bin,binArray[iPair].size(),ParallelDescriptor::IOProcessorNumber());
-            ParallelDescriptor::ReduceRealSum(binX1,binX1Array[iPair].size(),ParallelDescriptor::IOProcessorNumber());
-            ParallelDescriptor::ReduceRealSum(binX2,binX2Array[iPair].size(),ParallelDescriptor::IOProcessorNumber());
-        }
+            // Now divide by volume to make pdf integral to unity (has to come
+            // second)
+            for (int i = 0; i < nBins * nBins; i++)
+              bin[i] /= domainVol;
 
-        // Output the data to file
+            // Let's write some files...
+            std::string filename;
+            FILE* file;
+
+            if (output_gnuplot) {
+              // Output data for gnuplot
+              // Format: x y pdf
+              filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".gpd";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                Real v1 = vMin[var1] + dv1 * (0.5 + (Real)v1i);
+                for (int v2i = 0; v2i < nBins; v2i++) {
+                  Real v2 = vMin[var2] + dv2 * (0.5 + (Real)v2i);
+                  fprintf(file, "%e %e %e\n", v1, v2, bin[v1i * nBins + v2i]);
+                }
+              }
+              fclose(file);
+            }
+
+            if (output_matlab) {
+              // Output data for matlab (3 files)
+              // Format: pdf matrix
+              filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                for (int v2i = 0; v2i < nBins; v2i++)
+                  fprintf(file, "%e ", bin[v1i * nBins + v2i]);
+                fprintf(file, "\n");
+              }
+              fclose(file);
+              // Format: var1 range
+              filename =
+                infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_x.dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++)
+                fprintf(file, "%e\n", vMin[var1] + dv1 * (0.5 + (Real)v1i));
+              fclose(file);
+              // Format: var2 range
+              filename =
+                infile + outSuffix + "/Pdf_" + whichVarOut[var2] + "_x.dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v2i = 0; v2i < nBins; v2i++)
+                fprintf(file, "%e\n", vMin[var2] + dv2 * (0.5 + (Real)v2i));
+              fclose(file);
+              // PdfX1
+              filename = infile + outSuffix + "/PdfX1_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                for (int v2i = 0; v2i < nBins; v2i++)
+                  fprintf(file, "%e ", binX1[v1i * nBins + v2i]);
+                fprintf(file, "\n");
+              }
+              fclose(file);
+              // PdfX2
+              filename = infile + outSuffix + "/PdfX2_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                for (int v2i = 0; v2i < nBins; v2i++)
+                  fprintf(file, "%e ", binX2[v1i * nBins + v2i]);
+                fprintf(file, "\n");
+              }
+              fclose(file);
+            }
+
+            if (output_tecplot) {
+              // Output data for tecplot
+              // Format: Header, each node, quadrilateral indices between nodes
+              filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".tpd";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              fprintf(
+                file, "VARIABLES = %s %s logpdf pdf\n", whichVar[var1].c_str(),
+                whichVar[var2].c_str());
+              fprintf(
+                file, "ZONE N=%i E=%i F=FEPOINT ET=QUADRILATERAL\n",
+                nBins * nBins, (nBins - 1) * (nBins - 1));
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                Real v1 = vMin[var1] + dv1 * (0.5 + (Real)v1i);
+                for (int v2i = 0; v2i < nBins; v2i++) {
+                  Real v2 = vMin[var2] + dv2 * (0.5 + (Real)v2i);
+                  Real p = bin[v1i * nBins + v2i];
+                  fprintf(file, "%e %e %e %e\n", v1, v2, log(p + small), p);
+                }
+              }
+              for (int v1i = 0; v1i < nBins - 1; v1i++) {
+                for (int v2i = 0; v2i < nBins - 1; v2i++) {
+                  int i1 = v1i * nBins + v2i + 1;
+                  int i2 = (v1i + 1) * nBins + v2i + 1;
+                  int i3 = (v1i + 1) * nBins + (v2i + 1) + 1;
+                  int i4 = v1i * nBins + (v2i + 1) + 1;
+                  fprintf(file, "%i %i %i %i\n", i1, i2, i3, i4);
+                }
+              }
+              fclose(file);
+            }
+
+            if (output_fab) {
+              // Output data in fab format
+              filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".fab";
+              std::cout << "Opening file " << filename << std::endl;
+              std::ofstream os(filename.c_str(), std::ios::binary);
+              FArrayBox fab(
+                Box(
+                  IntVect::TheZeroVector(),
+                  IntVect(AMREX_D_DECL(nBins - 1, nBins - 1, 0))),
+                4);
+              std::cout << "box: " << fab.box() << std::endl;
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                Real v1 = vMin[var1] + dv1 * (0.5 + (Real)v1i);
+                for (int v2i = 0; v2i < nBins; v2i++) {
+                  Real v2 = vMin[var2] + dv2 * (0.5 + (Real)v2i);
+                  Real p = bin[v1i * nBins + v2i];
+                  IntVect iv(AMREX_D_DECL(v1i, v2i, 0));
+
+                  fab(iv, 0) = v1;
+                  fab(iv, 1) = v2;
+                  fab(iv, 2) = log(p + small);
+                  fab(iv, 3) = p;
+                }
+              }
+              fab.writeOn(os);
+              os.close();
+            }
+
+            if (output_scatter) {
+              // Output non-zero bins as scatter plot
+              // Format: x y
+              filename = infile + outSuffix + "/Scatter_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                Real v1 = vMin[var1] + dv1 * (0.5 + (Real)v1i);
+                for (int v2i = 0; v2i < nBins; v2i++) {
+                  Real v2 = vMin[var2] + dv2 * (0.5 + (Real)v2i);
+                  if (bin[v1i * nBins + v2i] > 0)
+                    fprintf(file, "%e %e\n", v1, v2);
+                }
+              }
+              fclose(file);
+            }
+
+            iPair++;
+          } // var2
+        } // var1
+      } // IOProcessor
+
+      if (output_plotfile) {
+        // Let's write the data as a "plotfile"
+        //
+        // Put the data into a multifab
+        //
+        Real small = 1.e-7;
+        int ngrow(0);
+        // Vector<int> pmap(1+1);
+        // pmap[0] = ParallelDescriptor::IOProcessorNumber();
+        // pmap[1] = ParallelDescriptor::MyProc();
+        // DistributionMapping distMap(pmap);
+        BoxArray ba(Box(
+          IntVect::TheZeroVector(),
+          IntVect(AMREX_D_DECL(nBins - 1, nBins - 1, 0))));
+        DistributionMapping distMap(ba);
+        MultiFab omf(ba, distMap, 2 * nPairs, ngrow);
+        omf.setVal(0);
+        for (MFIter ntmfi(omf); ntmfi.isValid(); ++ntmfi) {
+          for (int iPair = 0; iPair < nPairs; iPair++) {
+            Real* bin = binArray[iPair].dataPtr();
+            Real* fab = omf[ntmfi].dataPtr(iPair);
+            for (int v1i = 0; v1i < nBins; v1i++)
+              for (int v2i = 0; v2i < nBins; v2i++)
+                fab[v2i * nBins + v1i] = bin[v1i * nBins + v2i];
+          }
+          for (int iPair = 0; iPair < nPairs; iPair++) {
+            Real* bin = binArray[iPair].dataPtr();
+            Real* fab = omf[ntmfi].dataPtr(iPair + nPairs);
+            for (int v1i = 0; v1i < nBins; v1i++)
+              for (int v2i = 0; v2i < nBins; v2i++)
+                fab[v2i * nBins + v1i] = log(small + bin[v1i * nBins + v2i]);
+          }
+        }
+        //
+        // Now do all the work for a plot file
+        //
+        std::string pltfile;
+        if (outSuffix != "")
+          pltfile = infile + outSuffix;
+        else
+          pltfile = infile + "jpdf";
+
+        if (ParallelDescriptor::IOProcessor())
+          if (!UtilCreateDirectory(pltfile, 0755))
+            CreateDirectoryFailed(pltfile);
+        ParallelDescriptor::Barrier();
+
+        std::string HeaderFileName = pltfile + "/Header";
+
+        static const std::string the_plot_file_type("NavierStokes-V1.1");
+
         if (ParallelDescriptor::IOProcessor()) {
-            
-            if (outSuffix != "")
-            {
-                std::string oFile = infile + outSuffix;
-                if (!UtilCreateDirectory(oFile,0755))
-                    CreateDirectoryFailed(oFile);
+
+          std::ofstream os;
+          os.open(HeaderFileName.c_str());
+
+          int old_prec = os.precision(15);
+
+          // The plot file type
+          os << the_plot_file_type << '\n';
+          // The number of variables
+          os << 2 * nPairs << '\n';
+          // The variable names
+          for (int var1 = 0; var1 < nVars; var1++) {
+            for (int var2 = var1 + 1; var2 < nVars; var2++) {
+              std::string variableName =
+                "Pdf_" + whichVar[var1] + "_" + whichVar[var2];
+              os << variableName << '\n';
             }
-            
-            domainVol = 1;
-            for (int dd=0; dd<AMREX_SPACEDIM; ++dd) {
-                domainVol *= probHi[dd]-probLo[dd];
+          }
+          for (int var1 = 0; var1 < nVars; var1++) {
+            for (int var2 = var1 + 1; var2 < nVars; var2++) {
+              std::string variableName =
+                "Pdf_" + whichVar[var1] + "_" + whichVar[var2] + " (log)";
+              os << variableName << '\n';
             }
+          }
+          // The number of space dimensions
+          os << "2" << '\n'; // Hardwire
+          // Time
+          os << amrData.Time() << '\n';
+          // Finest level
+          os << "0" << '\n'; // Hardwire
+          // Domain
+          os << "0 0\n";
+          os << "1 1\n";
+          // Refinement ratios
+          os << '\n'; // Hardwire
+          // Cell sizes
+          os << "((0,0) (" << nBins - 1 << "," << nBins - 1 << ") (0,0))"
+             << '\n';
+          // Time steps
+          // os << amrData.Step << '\n'; // FIXME
+          os << "0" << '\n';
+          // dx
+          os << 1.0 / nBins << " " << 1.0 / nBins << '\n';
+          // CoordSys & bndry
+          os << "0\n0\n"; // Hardwire
+          //
+          // Now for the specific grids
+          //
+          // Level x- Number of grids - Time
+          os << "0 1 " << amrData.Time() << '\n';
+          // Time steps
+          // os << amrData.Step << '\n'; // FIXME
+          os << "0" << '\n';
+          // Grid domain
+          os << "0 1\n";
+          os << "0 1\n";
+          // Where to find the data
+          os << "Level_0/Cell" << '\n';
+          // Now let's add a bit so we know what the axes are
+          for (int v = 0; v < nVars; v++)
+            os << vMin[v] << " " << vMax[v] << '\n';
+          // That's all folks
+          os.close();
+        }
+        // Build the directory to hold the MultiFab at this level.
+        // The name is relative to the directory containing the Header file.
+        //
+        static const std::string BaseName = "/Cell";
+        std::string Level = "Level_0";
+        //
+        // Now for the full pathname of that directory.
+        //
+        std::string FullPath = pltfile;
+        if (!FullPath.empty() && FullPath[FullPath.length() - 1] != '/')
+          FullPath += '/';
+        FullPath += Level;
+        //
+        // Write the multifab
+        //
+        if (ParallelDescriptor::IOProcessor())
+          if (!UtilCreateDirectory(FullPath, 0755))
+            CreateDirectoryFailed(FullPath);
+        ParallelDescriptor::Barrier();
+        //
+        // Use the Full pathname when naming the MultiFab.
+        //
+        std::string TheFullPath = FullPath;
+        TheFullPath += BaseName;
+        VisMF::Write(omf, TheFullPath);
+      } // Output plotfile
 
-            Real small = 1.e-7;
-
-            int iPair = 0;
-
-            for (int var1=0; var1<nVars; var1++) {
-                // Change in var1 between each bin
-                Real dv1 = (vMax[var1]-vMin[var1])/(Real)nBins;
-
-                for (int var2 = var1+1; var2<nVars; var2++) {
-                    // Change in var2 between each bin
-                    Real dv2 = (vMax[var2]-vMin[var2])/(Real)nBins;
-
-                    // Pull out the pointer for this pair
-                    Real *bin=binArray[iPair].dataPtr();
-                    Real *binX1=binX1Array[iPair].dataPtr();
-                    Real *binX2=binX2Array[iPair].dataPtr();
-
-                    // Divide Xi by bin vol to average (has to come first)
-                    for (int v1i=0, i=0; v1i<nBins; v1i++) {
-                        Real v1 = vMin[var1] + dv1*(0.5+(Real)v1i);
-                        for (int v2i=0; v2i<nBins; v2i++, i++) {
-                            Real v2 = vMin[var2] + dv2*(0.5+(Real)v2i);
-                            Real div = bin[i];
-                            if (div>0) {
-                                binX1[i]/=div;
-                                binX2[i]/=div;
-                            } else { // This is the bit that breaks the derivation of the 1D pdfs
-                                binX1[i] = v1;
-                                binX2[i] = v2;
-                            }
-                        }
-                    }
-
-                    // Now divide by volume to make pdf integral to unity (has to come second)
-                    for (int i=0; i<nBins*nBins; i++)
-                        bin[i]/=domainVol;
-
-                    // Let's write some files...
-                    std::string filename;
-                    FILE *file;
-
-                    if (output_gnuplot) {
-                        // Output data for gnuplot
-                        // Format: x y pdf
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".gpd";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            Real v1 = vMin[var1] + dv1*(0.5+(Real)v1i);
-                            for (int v2i=0; v2i<nBins; v2i++) {
-                                Real v2 = vMin[var2] + dv2*(0.5+(Real)v2i);
-                                fprintf(file,"%e %e %e\n",v1,v2,bin[v1i*nBins+v2i]);
-                            }
-                        }
-                        fclose(file);
-                    }
-
-                    if (output_matlab) {
-                        // Output data for matlab (3 files)
-                        // Format: pdf matrix
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            for (int v2i=0; v2i<nBins; v2i++)
-                                fprintf(file,"%e ",bin[v1i*nBins+v2i]);
-                            fprintf(file,"\n");
-                        }
-                        fclose(file);
-                        // Format: var1 range
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_x.dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++)
-                            fprintf(file,"%e\n",vMin[var1] + dv1*(0.5+(Real)v1i));
-                        fclose(file);
-                        // Format: var2 range
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var2] + "_x.dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v2i=0; v2i<nBins; v2i++)
-                            fprintf(file,"%e\n",vMin[var2] + dv2*(0.5+(Real)v2i));
-                        fclose(file);
-                        // PdfX1
-                        filename = infile + outSuffix + "/PdfX1_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            for (int v2i=0; v2i<nBins; v2i++)
-                                fprintf(file,"%e ",binX1[v1i*nBins+v2i]);
-                            fprintf(file,"\n");
-                        }
-                        fclose(file);
-                        // PdfX2
-                        filename = infile + outSuffix + "/PdfX2_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            for (int v2i=0; v2i<nBins; v2i++)
-                                fprintf(file,"%e ",binX2[v1i*nBins+v2i]);
-                            fprintf(file,"\n");
-                        }
-                        fclose(file);
-                    }
-
-                    if (output_tecplot) {
-                        // Output data for tecplot
-                        // Format: Header, each node, quadrilateral indices between nodes
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".tpd";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        fprintf(file,"VARIABLES = %s %s logpdf pdf\n",whichVar[var1].c_str(),whichVar[var2].c_str());
-                        fprintf(file,"ZONE N=%i E=%i F=FEPOINT ET=QUADRILATERAL\n",nBins*nBins,(nBins-1)*(nBins-1));
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            Real v1 = vMin[var1] + dv1*(0.5+(Real)v1i);
-                            for (int v2i=0; v2i<nBins; v2i++) {
-                                Real v2 = vMin[var2] + dv2*(0.5+(Real)v2i);
-                                Real p  = bin[v1i*nBins+v2i];
-                                fprintf(file,"%e %e %e %e\n",v1,v2,log(p+small),p);
-                            }
-                        }
-                        for (int v1i=0; v1i<nBins-1; v1i++) {
-                            for (int v2i=0; v2i<nBins-1; v2i++) {
-                                int i1 =  v1i   *nBins+ v2i   +1;
-                                int i2 = (v1i+1)*nBins+ v2i   +1;
-                                int i3 = (v1i+1)*nBins+(v2i+1)+1;
-                                int i4 =  v1i   *nBins+(v2i+1)+1;
-                                fprintf(file,"%i %i %i %i\n",i1,i2,i3,i4);
-                            }
-                        }
-                        fclose(file);
-                    }
-
-                    if (output_fab) {
-                        // Output data in fab format
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".fab";
-                        std::cout << "Opening file " << filename << std::endl;
-                        std::ofstream os(filename.c_str(),std::ios::binary);
-                        FArrayBox fab(Box(IntVect::TheZeroVector(),IntVect(AMREX_D_DECL(nBins-1,nBins-1,0))),4);
-                        std::cout << "box: " << fab.box() << std::endl;
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            Real v1 = vMin[var1] + dv1*(0.5+(Real)v1i);
-                            for (int v2i=0; v2i<nBins; v2i++) {
-                                Real v2 = vMin[var2] + dv2*(0.5+(Real)v2i);
-                                Real p  = bin[v1i*nBins+v2i];
-                                IntVect iv(AMREX_D_DECL(v1i,v2i,0));
-
-                                fab(iv,0) = v1;
-                                fab(iv,1) = v2;
-                                fab(iv,2) = log(p+small);
-                                fab(iv,3) = p;
-                            }
-                        }
-                        fab.writeOn(os);
-                        os.close();
-                    }
-
-                    if (output_scatter) {
-                        // Output non-zero bins as scatter plot
-                        // Format: x y
-                        filename = infile + outSuffix + "/Scatter_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            Real v1 = vMin[var1] + dv1*(0.5+(Real)v1i);
-                            for (int v2i=0; v2i<nBins; v2i++) {
-                                Real v2 = vMin[var2] + dv2*(0.5+(Real)v2i);
-                                if (bin[v1i*nBins+v2i]>0)
-                                    fprintf(file,"%e %e\n",v1,v2);
-                            }
-                        }
-                        fclose(file);
-                    }
-      
-                    iPair++;
-                } // var2
-            } // var1
-        } // IOProcessor
- 
-        if (output_plotfile) {
-            // Let's write the data as a "plotfile"
-            //
-            // Put the data into a multifab
-            //
-            Real small = 1.e-7;
-            int ngrow(0);
-            //Vector<int> pmap(1+1);
-            //pmap[0] = ParallelDescriptor::IOProcessorNumber();
-            //pmap[1] = ParallelDescriptor::MyProc();
-            //DistributionMapping distMap(pmap);
-            BoxArray ba(Box(IntVect::TheZeroVector(),IntVect(AMREX_D_DECL(nBins-1,nBins-1,0))));
-            DistributionMapping distMap(ba);
-            MultiFab omf(ba, distMap, 2*nPairs, ngrow);
-            omf.setVal(0);
-            for(MFIter ntmfi(omf); ntmfi.isValid(); ++ntmfi) {
-                for (int iPair=0; iPair<nPairs; iPair++) {
-                    Real *bin=binArray[iPair].dataPtr();
-                    Real *fab=omf[ntmfi].dataPtr(iPair);
-                    for (int v1i=0; v1i<nBins; v1i++)
-                        for (int v2i=0; v2i<nBins; v2i++)
-                            fab[v2i*nBins+v1i]=bin[v1i*nBins+v2i];
-                }
-                for (int iPair=0; iPair<nPairs; iPair++) {
-                    Real *bin=binArray[iPair].dataPtr();
-                    Real *fab=omf[ntmfi].dataPtr(iPair+nPairs);
-                    for (int v1i=0; v1i<nBins; v1i++)
-                        for (int v2i=0; v2i<nBins; v2i++)
-                            fab[v2i*nBins+v1i]=log(small+bin[v1i*nBins+v2i]);
-                }
-            }
-            //
-            // Now do all the work for a plot file
-            // 
-            std::string pltfile;
-            if (outSuffix != "")
-                pltfile = infile + outSuffix;
-            else
-                pltfile = infile + "jpdf";
-
-            if (ParallelDescriptor::IOProcessor())
-                if (!UtilCreateDirectory(pltfile, 0755))
-                    CreateDirectoryFailed(pltfile);
-            ParallelDescriptor::Barrier();
-   
-            std::string HeaderFileName = pltfile + "/Header";
-   
-            static const std::string the_plot_file_type("NavierStokes-V1.1");
-
-            if (ParallelDescriptor::IOProcessor()) {
-     
-                std::ofstream os;
-                os.open(HeaderFileName.c_str());
-     
-                int old_prec = os.precision(15);
-     
-                // The plot file type
-                os << the_plot_file_type << '\n';
-                // The number of variables
-                os << 2*nPairs << '\n';
-                // The variable names
-                for (int var1=0; var1<nVars; var1++) {
-                    for (int var2=var1+1; var2<nVars; var2++) {
-                        std::string variableName = "Pdf_" + whichVar[var1] + "_" + whichVar[var2];
-                        os << variableName << '\n';
-                    }
-                }
-                for (int var1=0; var1<nVars; var1++) {
-                    for (int var2=var1+1; var2<nVars; var2++) {
-                        std::string variableName = "Pdf_" + whichVar[var1] + "_" + whichVar[var2] + " (log)";
-                        os << variableName << '\n';
-                    }
-                }
-                // The number of space dimensions
-                os << "2" << '\n'; // Hardwire
-                // Time
-                os << amrData.Time() << '\n'; 
-                // Finest level
-                os << "0" << '\n'; // Hardwire
-                // Domain
-                os << "0 0\n";
-                os << "1 1\n";
-                // Refinement ratios
-                os << '\n'; // Hardwire
-                // Cell sizes
-                os << "((0,0) (" << nBins-1 << "," << nBins-1 << ") (0,0))" << '\n';
-                // Time steps
-                //os << amrData.Step << '\n'; // FIXME
-                os << "0" << '\n';
-                // dx
-                os << 1.0/nBins << " " << 1.0/nBins << '\n';
-                // CoordSys & bndry
-                os << "0\n0\n"; // Hardwire
-                //
-                // Now for the specific grids
-                //
-                // Level x- Number of grids - Time
-                os << "0 1 " << amrData.Time() << '\n';
-                // Time steps
-                //os << amrData.Step << '\n'; // FIXME
-                os << "0" << '\n';
-                // Grid domain
-                os << "0 1\n";
-                os << "0 1\n";
-                // Where to find the data
-                os << "Level_0/Cell" << '\n';
-                // Now let's add a bit so we know what the axes are
-                for (int v=0; v<nVars; v++)
-                    os << vMin[v] << " " << vMax[v] << '\n';
-                // That's all folks
-                os.close();
-            }
-            // Build the directory to hold the MultiFab at this level.
-            // The name is relative to the directory containing the Header file.
-            //
-            static const std::string BaseName = "/Cell";
-            std::string Level = "Level_0";
-            //
-            // Now for the full pathname of that directory.
-            //
-            std::string FullPath = pltfile;
-            if (!FullPath.empty() && FullPath[FullPath.length()-1] != '/')
-                FullPath += '/';
-            FullPath += Level;
-            //
-            // Write the multifab
-            //
-            if (ParallelDescriptor::IOProcessor())
-                if (!UtilCreateDirectory(FullPath, 0755))
-                    CreateDirectoryFailed(FullPath);
-            ParallelDescriptor::Barrier();
-            //
-            // Use the Full pathname when naming the MultiFab.
-            //
-            std::string TheFullPath = FullPath;
-            TheFullPath += BaseName;
-            VisMF::Write(omf,TheFullPath);
-        } // Output plotfile
- 
     } // iPlot
-    
-    
+
     if (do_average) {
-        // Reduce data
-        for (int iPair=0; iPair<nPairs; iPair++) {
-            Real *binAv=binAvArray[iPair].dataPtr();
-            Real *binAvX1=binAvX1Array[iPair].dataPtr();
-            Real *binAvX2=binAvX2Array[iPair].dataPtr();
-            ParallelDescriptor::ReduceRealSum(binAv,binAvArray[iPair].size(),ParallelDescriptor::IOProcessorNumber());
-            ParallelDescriptor::ReduceRealSum(binAvX1,binAvX1Array[iPair].size(),ParallelDescriptor::IOProcessorNumber());
-            ParallelDescriptor::ReduceRealSum(binAvX2,binAvX2Array[iPair].size(),ParallelDescriptor::IOProcessorNumber());
-        }
+      // Reduce data
+      for (int iPair = 0; iPair < nPairs; iPair++) {
+        Real* binAv = binAvArray[iPair].dataPtr();
+        Real* binAvX1 = binAvX1Array[iPair].dataPtr();
+        Real* binAvX2 = binAvX2Array[iPair].dataPtr();
+        ParallelDescriptor::ReduceRealSum(
+          binAv, binAvArray[iPair].size(),
+          ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum(
+          binAvX1, binAvX1Array[iPair].size(),
+          ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum(
+          binAvX2, binAvX2Array[iPair].size(),
+          ParallelDescriptor::IOProcessorNumber());
+      }
 
-        // Output the data to file
-        if (ParallelDescriptor::IOProcessor()) {
+      // Output the data to file
+      if (ParallelDescriptor::IOProcessor()) {
 
-            std::string infile = "JPDFAverage";
-            std::string oFile = infile + outSuffix;
-            if (!UtilCreateDirectory(oFile,0755))
-                CreateDirectoryFailed(oFile);
+        std::string infile = "JPDFAverage";
+        std::string oFile = infile + outSuffix;
+        if (!UtilCreateDirectory(oFile, 0755))
+          CreateDirectoryFailed(oFile);
 
-            Real small = 1.e-7;
+        Real small = 1.e-7;
 
-            int iPair = 0;
+        int iPair = 0;
 
-            for (int var1=0; var1<nVars; var1++) {
-                // Change in var1 between each bin
-                Real dv1 = (vMax[var1]-vMin[var1])/(Real)nBins;
-   
-                for (int var2 = var1+1; var2<nVars; var2++) {
-                    // Change in var2 between each bin
-                    Real dv2 = (vMax[var2]-vMin[var2])/(Real)nBins;
-     
-                    // Pull out the pointer for this pair
-                    Real *binAv=binAvArray[iPair].dataPtr();
-                    Real *binAvX1=binAvX1Array[iPair].dataPtr();
-                    Real *binAvX2=binAvX2Array[iPair].dataPtr();
-     
-                    // Divide Xi by bin vol to average (has to come first)
-                    for (int v1i=0, i=0; v1i<nBins; v1i++) {
-                        Real v1 = vMin[var1] + dv1*(0.5+(Real)v1i);
-                        for (int v2i=0; v2i<nBins; v2i++, i++) {
-                            Real v2 = vMin[var2] + dv2*(0.5+(Real)v2i);
-                            Real div = binAv[i];
-                            if (div>0) {
-                                binAvX1[i]/=div;
-                                binAvX2[i]/=div;
-                            } else {
-                                binAvX1[i] = v1;
-                                binAvX2[i] = v2;
-                            }
-                        }
-                    }
-     
-                    // Now divide by volume to make pdf integral to unity (has to come second)
-                    for (int i=0; i<nBins*nBins; i++)
-                        binAv[i]/=domainVol*(Real)nPlotFiles;
+        for (int var1 = 0; var1 < nVars; var1++) {
+          // Change in var1 between each bin
+          Real dv1 = (vMax[var1] - vMin[var1]) / (Real)nBins;
 
-                    // Let's write some files...
-                    std::string filename;
-                    FILE *file;
-     
-                    if (output_gnuplot) {
-                        // Output data for gnuplot
-                        // Format: x y pdf
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".gpd";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            Real v1 = vMin[var1] + dv1*(0.5+(Real)v1i);
-                            for (int v2i=0; v2i<nBins; v2i++) {
-                                Real v2 = vMin[var2] + dv2*(0.5+(Real)v2i);
-                                fprintf(file,"%e %e %e\n",v1,v2,binAv[v1i*nBins+v2i]);
-                            }
-                        }
-                        fclose(file);
-                    }
-     
-                    if (output_matlab) {
-                        // Output data for matlab (3 files)
-                        // Format: pdf matrix
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            for (int v2i=0; v2i<nBins; v2i++)
-                                fprintf(file,"%e ",binAv[v1i*nBins+v2i]);
-                            fprintf(file,"\n");
-                        }
-                        fclose(file);
-                        // Format: var1 range
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_x.dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++)
-                            fprintf(file,"%e\n",vMin[var1] + dv1*(0.5+(Real)v1i));
-                        fclose(file);
-                        // Format: var2 range
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var2] + "_x.dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v2i=0; v2i<nBins; v2i++)
-                            fprintf(file,"%e\n",vMin[var2] + dv2*(0.5+(Real)v2i));
-                        fclose(file);
-                        // PdfX1
-                        filename = infile + outSuffix + "/PdfX1_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            for (int v2i=0; v2i<nBins; v2i++)
-                                fprintf(file,"%e ",binAvX1[v1i*nBins+v2i]);
-                            fprintf(file,"\n");
-                        }
-                        fclose(file);
-                        // PdfX2
-                        filename = infile + outSuffix + "/PdfX2_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            for (int v2i=0; v2i<nBins; v2i++)
-                                fprintf(file,"%e ",binAvX2[v1i*nBins+v2i]);
-                            fprintf(file,"\n");
-                        }
-                        fclose(file);
-                    }
-     
-                    if (output_tecplot) {
-                        // Output data for tecplot
-                        // Format: Header, each node, quadrilateral indices between nodes
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".tpd";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        fprintf(file,"VARIABLES = %s %s logpdf pdf\n",whichVar[var1].c_str(),whichVar[var2].c_str());
-                        fprintf(file,"ZONE N=%i E=%i F=FEPOINT ET=QUADRILATERAL\n",nBins*nBins,(nBins-1)*(nBins-1));
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            Real v1 = vMin[var1] + dv1*(0.5+(Real)v1i);
-                            for (int v2i=0; v2i<nBins; v2i++) {
-                                Real v2 = vMin[var2] + dv2*(0.5+(Real)v2i);
-                                Real p  = binAv[v1i*nBins+v2i];
-                                fprintf(file,"%e %e %e %e\n",v1,v2,log(p+small),p);
-                            }
-                        }
-                        for (int v1i=0; v1i<nBins-1; v1i++) {
-                            for (int v2i=0; v2i<nBins-1; v2i++) {
-                                int i1 =  v1i   *nBins+ v2i   +1;
-                                int i2 = (v1i+1)*nBins+ v2i   +1;
-                                int i3 = (v1i+1)*nBins+(v2i+1)+1;
-                                int i4 =  v1i   *nBins+(v2i+1)+1;
-                                fprintf(file,"%i %i %i %i\n",i1,i2,i3,i4);
-                            }
-                        }
-                        fclose(file);
-                    }
-     
-                    if (output_fab) {
-                        // Output data in fab format
-                        filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".fab";
-                        std::cout << "Opening file " << filename << std::endl;
-                        std::ofstream os(filename.c_str());
-                        FArrayBox fab(Box(IntVect::TheZeroVector(),IntVect(AMREX_D_DECL(nBins-1,nBins-1,0))),4);
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            Real v1 = vMin[var1] + dv1*(0.5+(Real)v1i);
-                            for (int v2i=0; v2i<nBins; v2i++) {
-                                Real v2 = vMin[var2] + dv2*(0.5+(Real)v2i);
-                                Real p  = binAv[v1i*nBins+v2i];
-                                IntVect iv(AMREX_D_DECL(v1i,v2i,0));
-                                fab(iv,0) = v1;
-                                fab(iv,1) = v2;
-                                fab(iv,2) = log(p+small);
-                                fab(iv,3) = p;
-                            }
-                        }
-                        fab.writeOn(os);
-                        os.close();
-                    }
-     
-                    if (output_scatter) {
-                        // Output non-zero bins as scatter plot
-                        // Format: x y
-                        filename = infile + outSuffix + "/Scatter_" + whichVarOut[var1] + "_" + whichVarOut[var2] + ".dat";
-                        std::cout << "Opening file " << filename << std::endl;
-                        file = fopen(filename.c_str(),"w");
-                        for (int v1i=0; v1i<nBins; v1i++) {
-                            Real v1 = vMin[var1] + dv1*(0.5+(Real)v1i);
-                            for (int v2i=0; v2i<nBins; v2i++) {
-                                Real v2 = vMin[var2] + dv2*(0.5+(Real)v2i);
-                                if (binAv[v1i*nBins+v2i]>0)
-                                    fprintf(file,"%e %e\n",v1,v2);
-                            }
-                        }
-                        fclose(file);
-                    }
-     
-                    iPair++;
-                } // var2
-            } // var1
-        } // IOProcessor
+          for (int var2 = var1 + 1; var2 < nVars; var2++) {
+            // Change in var2 between each bin
+            Real dv2 = (vMax[var2] - vMin[var2]) / (Real)nBins;
+
+            // Pull out the pointer for this pair
+            Real* binAv = binAvArray[iPair].dataPtr();
+            Real* binAvX1 = binAvX1Array[iPair].dataPtr();
+            Real* binAvX2 = binAvX2Array[iPair].dataPtr();
+
+            // Divide Xi by bin vol to average (has to come first)
+            for (int v1i = 0, i = 0; v1i < nBins; v1i++) {
+              Real v1 = vMin[var1] + dv1 * (0.5 + (Real)v1i);
+              for (int v2i = 0; v2i < nBins; v2i++, i++) {
+                Real v2 = vMin[var2] + dv2 * (0.5 + (Real)v2i);
+                Real div = binAv[i];
+                if (div > 0) {
+                  binAvX1[i] /= div;
+                  binAvX2[i] /= div;
+                } else {
+                  binAvX1[i] = v1;
+                  binAvX2[i] = v2;
+                }
+              }
+            }
+
+            // Now divide by volume to make pdf integral to unity (has to come
+            // second)
+            for (int i = 0; i < nBins * nBins; i++)
+              binAv[i] /= domainVol * (Real)nPlotFiles;
+
+            // Let's write some files...
+            std::string filename;
+            FILE* file;
+
+            if (output_gnuplot) {
+              // Output data for gnuplot
+              // Format: x y pdf
+              filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".gpd";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                Real v1 = vMin[var1] + dv1 * (0.5 + (Real)v1i);
+                for (int v2i = 0; v2i < nBins; v2i++) {
+                  Real v2 = vMin[var2] + dv2 * (0.5 + (Real)v2i);
+                  fprintf(file, "%e %e %e\n", v1, v2, binAv[v1i * nBins + v2i]);
+                }
+              }
+              fclose(file);
+            }
+
+            if (output_matlab) {
+              // Output data for matlab (3 files)
+              // Format: pdf matrix
+              filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                for (int v2i = 0; v2i < nBins; v2i++)
+                  fprintf(file, "%e ", binAv[v1i * nBins + v2i]);
+                fprintf(file, "\n");
+              }
+              fclose(file);
+              // Format: var1 range
+              filename =
+                infile + outSuffix + "/Pdf_" + whichVarOut[var1] + "_x.dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++)
+                fprintf(file, "%e\n", vMin[var1] + dv1 * (0.5 + (Real)v1i));
+              fclose(file);
+              // Format: var2 range
+              filename =
+                infile + outSuffix + "/Pdf_" + whichVarOut[var2] + "_x.dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v2i = 0; v2i < nBins; v2i++)
+                fprintf(file, "%e\n", vMin[var2] + dv2 * (0.5 + (Real)v2i));
+              fclose(file);
+              // PdfX1
+              filename = infile + outSuffix + "/PdfX1_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                for (int v2i = 0; v2i < nBins; v2i++)
+                  fprintf(file, "%e ", binAvX1[v1i * nBins + v2i]);
+                fprintf(file, "\n");
+              }
+              fclose(file);
+              // PdfX2
+              filename = infile + outSuffix + "/PdfX2_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                for (int v2i = 0; v2i < nBins; v2i++)
+                  fprintf(file, "%e ", binAvX2[v1i * nBins + v2i]);
+                fprintf(file, "\n");
+              }
+              fclose(file);
+            }
+
+            if (output_tecplot) {
+              // Output data for tecplot
+              // Format: Header, each node, quadrilateral indices between nodes
+              filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".tpd";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              fprintf(
+                file, "VARIABLES = %s %s logpdf pdf\n", whichVar[var1].c_str(),
+                whichVar[var2].c_str());
+              fprintf(
+                file, "ZONE N=%i E=%i F=FEPOINT ET=QUADRILATERAL\n",
+                nBins * nBins, (nBins - 1) * (nBins - 1));
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                Real v1 = vMin[var1] + dv1 * (0.5 + (Real)v1i);
+                for (int v2i = 0; v2i < nBins; v2i++) {
+                  Real v2 = vMin[var2] + dv2 * (0.5 + (Real)v2i);
+                  Real p = binAv[v1i * nBins + v2i];
+                  fprintf(file, "%e %e %e %e\n", v1, v2, log(p + small), p);
+                }
+              }
+              for (int v1i = 0; v1i < nBins - 1; v1i++) {
+                for (int v2i = 0; v2i < nBins - 1; v2i++) {
+                  int i1 = v1i * nBins + v2i + 1;
+                  int i2 = (v1i + 1) * nBins + v2i + 1;
+                  int i3 = (v1i + 1) * nBins + (v2i + 1) + 1;
+                  int i4 = v1i * nBins + (v2i + 1) + 1;
+                  fprintf(file, "%i %i %i %i\n", i1, i2, i3, i4);
+                }
+              }
+              fclose(file);
+            }
+
+            if (output_fab) {
+              // Output data in fab format
+              filename = infile + outSuffix + "/Pdf_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".fab";
+              std::cout << "Opening file " << filename << std::endl;
+              std::ofstream os(filename.c_str());
+              FArrayBox fab(
+                Box(
+                  IntVect::TheZeroVector(),
+                  IntVect(AMREX_D_DECL(nBins - 1, nBins - 1, 0))),
+                4);
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                Real v1 = vMin[var1] + dv1 * (0.5 + (Real)v1i);
+                for (int v2i = 0; v2i < nBins; v2i++) {
+                  Real v2 = vMin[var2] + dv2 * (0.5 + (Real)v2i);
+                  Real p = binAv[v1i * nBins + v2i];
+                  IntVect iv(AMREX_D_DECL(v1i, v2i, 0));
+                  fab(iv, 0) = v1;
+                  fab(iv, 1) = v2;
+                  fab(iv, 2) = log(p + small);
+                  fab(iv, 3) = p;
+                }
+              }
+              fab.writeOn(os);
+              os.close();
+            }
+
+            if (output_scatter) {
+              // Output non-zero bins as scatter plot
+              // Format: x y
+              filename = infile + outSuffix + "/Scatter_" + whichVarOut[var1] +
+                         "_" + whichVarOut[var2] + ".dat";
+              std::cout << "Opening file " << filename << std::endl;
+              file = fopen(filename.c_str(), "w");
+              for (int v1i = 0; v1i < nBins; v1i++) {
+                Real v1 = vMin[var1] + dv1 * (0.5 + (Real)v1i);
+                for (int v2i = 0; v2i < nBins; v2i++) {
+                  Real v2 = vMin[var2] + dv2 * (0.5 + (Real)v2i);
+                  if (binAv[v1i * nBins + v2i] > 0)
+                    fprintf(file, "%e %e\n", v1, v2);
+                }
+              }
+              fclose(file);
+            }
+
+            iPair++;
+          } // var2
+        } // var1
+      } // IOProcessor
     }
-    } 
-    Finalize();
-    return 0;
+  }
+  Finalize();
+  return 0;
 }
-

--- a/Src/makePlotfile.cpp
+++ b/Src/makePlotfile.cpp
@@ -8,41 +8,49 @@
 
 using namespace amrex;
 
-static
-void
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "Utility to build 3D plotfile from list of 2D FABs";
   std::cerr << "usage:\n";
-  std::cerr << argv[0] << " infile_head=<s> infile_tail=<s> outfile=<s> start=<i> end=<i> interval=<i> names=<s> probLo=<r> probHi=<r> [options] \n\tOptions:\n";
-  std::cerr << "\t     infile_head=<s> where s is the start of the fab names \n";
+  std::cerr
+    << argv[0]
+    << " infile_head=<s> infile_tail=<s> outfile=<s> start=<i> end=<i> "
+       "interval=<i> names=<s> probLo=<r> probHi=<r> [options] \n\tOptions:\n";
+  std::cerr
+    << "\t     infile_head=<s> where s is the start of the fab names \n";
   std::cerr << "\t     infile_tail=<s> where s is the end of the fab names\n";
   std::cerr << "\t     outfile=<s> where s is the name of plotfile\n";
   std::cerr << "\t     start=<i> where i is the starting number of the files\n";
   std::cerr << "\t     end=<i> where i is the ending number of the files\n";
   std::cerr << "\t     interval=<i> where i is the interval between files\n";
-  std::cerr << "\t     names=<s> where s is the name of the variables from the fab\n";
-  std::cerr << "\t     probLo=<r,r,(r)> is an array of size 2 or 3 to specify the bottom corner of the plotfile box. If 2 values given, the third is calculated based on number of planes.\n";
-  std::cerr << "\t     probHi=<r,r,r> is an array of 3 to specify top corner of plotfile box\n";  
-  std::cerr << "\t     time=<r> where r is time to give the plotfilee (OPT, DEF->0.0)\n";
-  std::cerr << "\t     verbose=<i> do you want it verbose? (0 or 1) (OPT, DEF->0)\n";
+  std::cerr
+    << "\t     names=<s> where s is the name of the variables from the fab\n";
+  std::cerr << "\t     probLo=<r,r,(r)> is an array of size 2 or 3 to specify "
+               "the bottom corner of the plotfile box. If 2 values given, the "
+               "third is calculated based on number of planes.\n";
+  std::cerr << "\t     probHi=<r,r,r> is an array of 3 to specify top corner "
+               "of plotfile box\n";
+  std::cerr << "\t     time=<r> where r is time to give the plotfilee (OPT, "
+               "DEF->0.0)\n";
+  std::cerr
+    << "\t     verbose=<i> do you want it verbose? (0 or 1) (OPT, DEF->0)\n";
   exit(1);
 }
 
-
-int main(int argc, char *argv[])
+int
+main(int argc, char* argv[])
 {
   amrex::Initialize(argc, argv);
 
-  ParmParse pp;  
+  ParmParse pp;
 
   if (argc < 2 || pp.contains("help")) {
-    print_usage(argc,argv);
+    print_usage(argc, argv);
   }
 
   bool verbose(false);
-  if(pp.contains("verbose") || (pp.contains("v"))) {
+  if (pp.contains("verbose") || (pp.contains("v"))) {
     verbose = true;
     AmrData::SetVerbose(true);
   }
@@ -51,70 +59,76 @@ int main(int argc, char *argv[])
     verbose = true;
     AmrData::SetVerbose(true);
   }
-  
+
   DataServices::SetBatchMode();
   Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-  int start,end,interval,nfiles;  
+  int start, end, interval, nfiles;
   std::string infile_head, infile_tail;
 
-
-  pp.get("infile_head",infile_head);
-  pp.get("infile_tail",infile_tail);
-  pp.get("start",start);
-  pp.get("end",end);
-  pp.get("interval",interval);
-  nfiles = (end-start)/interval;
+  pp.get("infile_head", infile_head);
+  pp.get("infile_tail", infile_tail);
+  pp.get("start", start);
+  pp.get("end", end);
+  pp.get("interval", interval);
+  nfiles = (end - start) / interval;
   // read plot file name to output
   std::string outfile;
-  pp.get("outfile",outfile);
-  if (verbose) std::cout << "outfile = " << outfile << std::endl;
+  pp.get("outfile", outfile);
+  if (verbose)
+    std::cout << "outfile = " << outfile << std::endl;
 
   // read a time to assign
   Real time(0.);
-  pp.query("time",time);
-  if (verbose) std::cout << "time = " << time << std::endl;
+  pp.query("time", time);
+  if (verbose)
+    std::cout << "time = " << time << std::endl;
 
   // read in the variable names to use
-  int nVars=pp.countval("names");
-  Vector<std::string> names; names.resize(nVars);
-  if (verbose) std::cout << "variables =";
-  for (int iVar=0; iVar<nVars; iVar++) {
-    pp.get("names",names[iVar],iVar);
-    if (verbose) std::cout << " " << names[iVar]; 
+  int nVars = pp.countval("names");
+  Vector<std::string> names;
+  names.resize(nVars);
+  if (verbose)
+    std::cout << "variables =";
+  for (int iVar = 0; iVar < nVars; iVar++) {
+    pp.get("names", names[iVar], iVar);
+    if (verbose)
+      std::cout << " " << names[iVar];
   }
-  if (verbose) std::cout << std::endl;
+  if (verbose)
+    std::cout << std::endl;
 
   //
   // Read fab data (only using header at this stage)
   //
-  if (verbose) std::cout << "Reading fab..." << std::endl;
+  if (verbose)
+    std::cout << "Reading fab..." << std::endl;
   std::ifstream ifs;
   std::string start_str = std::to_string(start);
   if (start < 100000) {
-    start_str = "0"+start_str;
+    start_str = "0" + start_str;
   }
-		      
+
   std::string infiletest = infile_head + start_str + infile_tail;
-  amrex::Print() << "Getting geometry from file: "+infiletest << std::endl;
+  amrex::Print() << "Getting geometry from file: " + infiletest << std::endl;
   FArrayBox fab;
 
-  Vector<Real> probLo = {0.0,0.0,0.0};
-  Vector<Real> probHi = {0.0,0.0,0.0};
-  Vector<int> nx = {0,0,0};
-  
+  Vector<Real> probLo = {0.0, 0.0, 0.0};
+  Vector<Real> probHi = {0.0, 0.0, 0.0};
+  Vector<int> nx = {0, 0, 0};
+
   if (ParallelDescriptor::IOProcessor()) {
     ifs.open(infiletest);
     fab.readFrom(ifs);
     ifs.close();
-    if (verbose) std::cout << "   ... done." << std::endl;
-
+    if (verbose)
+      std::cout << "   ... done." << std::endl;
 
     std::cout << "fab.nComp = " << fab.nComp() << std::endl;
-    if (fab.nComp()!=nVars) {
+    if (fab.nComp() != nVars) {
       amrex::Error("Mismatch fab.nComp != nVars");
     }
-    
+
     // figure out how big the full domain box needs to be
     const Box& box = fab.box();
     if (verbose) {
@@ -123,110 +137,109 @@ int main(int argc, char *argv[])
     nx[0] = box.length(0);
     nx[1] = box.length(1);
     nx[2] = nfiles;
-    int pCells=nx[0]*nx[1];
-    long nCells=nx[0]*nx[1]*nx[2];
-    
+    int pCells = nx[0] * nx[1];
+    long nCells = nx[0] * nx[1] * nx[2];
+
     if (verbose) {
-      Print() << "cells = "
-	      << nx[0] << " " << nx[1] << " " << nx[2] << " "
-	      << " (" << nCells << ")\n";
+      Print() << "cells = " << nx[0] << " " << nx[1] << " " << nx[2] << " "
+              << " (" << nCells << ")\n";
     }
     // assign a physical size
     int calcz;
-    if (pp.countval("probLo")==3) {
-      for (int i=0; i<3; i++) {
-	pp.get("probLo",probLo[i],i);
+    if (pp.countval("probLo") == 3) {
+      for (int i = 0; i < 3; i++) {
+        pp.get("probLo", probLo[i], i);
       }
-      calcz = 0; 
+      calcz = 0;
     } else if (pp.countval("probLo") == 2) {
-      for (int i=0; i<2; i++) {
-	pp.get("probLo",probLo[i],i);
+      for (int i = 0; i < 2; i++) {
+        pp.get("probLo", probLo[i], i);
       }
       calcz = 1;
     } else {
       amrex::Error("Need 3 values for probLo");
     }
-    
-    if (pp.countval("probHi")==3) {
-      for (int i=0; i<3; i++) {
-	pp.get("probHi",probHi[i],i);
+
+    if (pp.countval("probHi") == 3) {
+      for (int i = 0; i < 3; i++) {
+        pp.get("probHi", probHi[i], i);
       }
     } else {
       amrex::Error("Need 3 values for probHi");
     }
     Real dx[3];
     if (calcz) {
-      for (int i=0; i<2; i++) {
-	dx[i] = (probHi[i]-probLo[i])/(Real)nx[i];
+      for (int i = 0; i < 2; i++) {
+        dx[i] = (probHi[i] - probLo[i]) / (Real)nx[i];
       }
       dx[2] = dx[0];
-      probLo[2] = -dx[2]*nx[2];
+      probLo[2] = -dx[2] * nx[2];
     } else {
-      for (int i=0; i<3; i++) {
-	dx[i] = (probHi[i]-probLo[i])/(Real)nx[i];
+      for (int i = 0; i < 3; i++) {
+        dx[i] = (probHi[i] - probLo[i]) / (Real)nx[i];
       }
     }
   }
 
-  ParallelDescriptor::ReduceRealSum(probLo.data(),3);
-  ParallelDescriptor::ReduceRealSum(probHi.data(),3);
-  ParallelDescriptor::ReduceIntSum(nx.data(),3);
-  
+  ParallelDescriptor::ReduceRealSum(probLo.data(), 3);
+  ParallelDescriptor::ReduceRealSum(probHi.data(), 3);
+  ParallelDescriptor::ReduceIntSum(nx.data(), 3);
+
   if (verbose) {
-    Print() << "probLo = "  << probLo[0] << " " << probLo[1] << " " << probLo[2] << std::endl;
-    Print() << "probHi = "  << probHi[0] << " " << probHi[1] << " " << probHi[2] << std::endl;
-    Print() << "nx = "   << nx[0] << " " << nx[1] << " " << nx[2] << std::endl;
+    Print() << "probLo = " << probLo[0] << " " << probLo[1] << " " << probLo[2]
+            << std::endl;
+    Print() << "probHi = " << probHi[0] << " " << probHi[1] << " " << probHi[2]
+            << std::endl;
+    Print() << "nx = " << nx[0] << " " << nx[1] << " " << nx[2] << std::endl;
   }
-  
-  RealBox rb(probLo.data(),probHi.data()); // make real box for geometry 
-  Vector<int> is_per(AMREX_SPACEDIM,0); //hard code to no periodicity for the minute
-    
-  
+
+  RealBox rb(probLo.data(), probHi.data()); // make real box for geometry
+  Vector<int> is_per(
+    AMREX_SPACEDIM, 0); // hard code to no periodicity for the minute
+
   //
   // Let's try a slab domain decomposition
   //
 
-  Vector<int> plovec = {0,0,0};
-  Vector<int> phivec = {nx[0]-1,nx[1]-1,nx[2]-1};
-  
-  IntVect     pdLo(plovec);
-  IntVect     pdHi(phivec);
-  Box         probDomain(pdLo,pdHi);
-  int coord = 0; //hard code cartesian
+  Vector<int> plovec = {0, 0, 0};
+  Vector<int> phivec = {nx[0] - 1, nx[1] - 1, nx[2] - 1};
+
+  IntVect pdLo(plovec);
+  IntVect pdHi(phivec);
+  Box probDomain(pdLo, pdHi);
+  int coord = 0; // hard code cartesian
   Geometry geoms(probDomain, &rb, coord, &(is_per[0]));
   // make a box for each file
-  int         nBoxes(nfiles);
-  BoxArray    domainBoxArray(nBoxes);
+  int nBoxes(nfiles);
+  BoxArray domainBoxArray(nBoxes);
 
   // Make some the slabs
-  Box         tempBox(probDomain);    
-  Vector<int> tempBoxSmall(nBoxes,0);
-  Vector<int> tempBoxBig(nBoxes,0);
+  Box tempBox(probDomain);
+  Vector<int> tempBoxSmall(nBoxes, 0);
+  Vector<int> tempBoxBig(nBoxes, 0);
 
   if (verbose)
     std::cout << "Slab decomposition:" << std::endl;
-  for (int iBox=0; iBox<nBoxes; iBox++) {
+  for (int iBox = 0; iBox < nBoxes; iBox++) {
     tempBoxSmall[iBox] = probDomain.smallEnd(2) + iBox;
-    tempBoxBig[iBox]   = tempBoxSmall[iBox];
+    tempBoxBig[iBox] = tempBoxSmall[iBox];
     if (verbose) {
-      std::cout << "   iBox / small / big: "
-		<< iBox << " / "
-		<< tempBoxSmall[iBox] << " / "
-		<< tempBoxBig[iBox] << std::endl;
+      std::cout << "   iBox / small / big: " << iBox << " / "
+                << tempBoxSmall[iBox] << " / " << tempBoxBig[iBox] << std::endl;
     }
-  }    
-  for (int iBox=0; iBox<nBoxes; iBox++) {
+  }
+  for (int iBox = 0; iBox < nBoxes; iBox++) {
     tempBox.setSmall(Amrvis::ZDIR, tempBoxSmall[iBox]);
-    tempBox.setBig(Amrvis::ZDIR, tempBoxBig[iBox]); 
+    tempBox.setBig(Amrvis::ZDIR, tempBoxBig[iBox]);
     domainBoxArray.set(iBox, tempBox);
   }
-  
+
   // And now the distibution mapping
 
   DistributionMapping domainDistMap(domainBoxArray);
-  
-  MultiFab *mf;
-  mf = new MultiFab(domainBoxArray,domainDistMap,nVars,0);
+
+  MultiFab* mf;
+  mf = new MultiFab(domainBoxArray, domainDistMap, nVars, 0);
   //
   // Populate data
   //
@@ -234,39 +247,40 @@ int main(int argc, char *argv[])
     std::cout << "Populating data:" << std::endl;
 
   for (MFIter mfi(*mf); mfi.isValid(); ++mfi) {
-    
+
     // destination fab
     FArrayBox& myFab = (*mf)[mfi];
-    
+
     // load data
-    int iFile=nfiles-myFab.smallEnd()[2]-1;
-    int fileNum = start+iFile*interval;
+    int iFile = nfiles - myFab.smallEnd()[2] - 1;
+    int fileNum = start + iFile * interval;
 
     std::ostringstream oss;
     oss << std::setw(6) << std::setfill('0') << fileNum;
     std::string filenum_str = oss.str();
-    
-    std::string infile_local = infile_head+filenum_str+infile_tail;
-    std::cout << "iFile = " << iFile << ": " <<  infile_local << std::endl;
+
+    std::string infile_local = infile_head + filenum_str + infile_tail;
+    std::cout << "iFile = " << iFile << ": " << infile_local << std::endl;
     ifs.open(infile_local);
     fab.readFrom(ifs);
     ifs.close();
-    Vector<int> shiftvec = {0,0,myFab.smallEnd()[2]};
+    Vector<int> shiftvec = {0, 0, myFab.smallEnd()[2]};
     IntVect shift(shiftvec);
     fab.shift(shift);
     const Box& inBox = fab.box();
-    for (int dir=0; dir<2; dir++) {
-      if (inBox.length(dir)!=nx[dir]) {
-	std::cerr << "file = " << infile_local << std::endl;
-	std::cerr << "inBox.length(" << dir << ") = " << inBox.length(dir) << std::endl;
-	amrex::Error("inBox.length mismatch!");
+    for (int dir = 0; dir < 2; dir++) {
+      if (inBox.length(dir) != nx[dir]) {
+        std::cerr << "file = " << infile_local << std::endl;
+        std::cerr << "inBox.length(" << dir << ") = " << inBox.length(dir)
+                  << std::endl;
+        amrex::Error("inBox.length mismatch!");
       }
     }
 
     // copy data
     myFab.copy(fab);
   }
-  
+
   // write the output plotfile
   // should be able to replace with modern call to writeplotfile
 
@@ -274,23 +288,7 @@ int main(int argc, char *argv[])
     Print() << "*** writing plotfile " << std::endl;
   }
   int levelSteps;
-  WriteSingleLevelPlotfile(outfile,*mf,names, geoms,time,levelSteps);
+  WriteSingleLevelPlotfile(outfile, *mf, names, geoms, time, levelSteps);
   amrex::Finalize();
   return 0;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/Src/mergeMEF.cpp
+++ b/Src/mergeMEF.cpp
@@ -10,325 +10,309 @@
 #include "DataServices.H"
 #include "Geometry.H"
 #include "Utility.H"
-using std::vector;
-using std::map;
-using std::string;
 using std::cerr;
-using std::endl;
 using std::cout;
+using std::endl;
+using std::map;
 using std::ofstream;
+using std::string;
+using std::vector;
 
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Array<int>&        faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label);
+void read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Array<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label);
 
-void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Array<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label);
+void write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label);
 
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return Tokenize(line,std::string(", "));
+  std::string line;
+  std::getline(is, line);
+  return Tokenize(line, std::string(", "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return line;
+  std::string line;
+  std::getline(is, line);
+  return line;
 }
 
-static
-void
-merge_iso(FArrayBox&        nodesM,
-          Array<int>&       faceDataM,
-          int&              nEltsM,
-          const FArrayBox&  nodes,
-          const Array<int>& faceData,
-          int               nElts,
-          Real              eps,
-          int               verbose,
-          bool              remDupNodes);
+static void merge_iso(
+  FArrayBox& nodesM,
+  Array<int>& faceDataM,
+  int& nEltsM,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  Real eps,
+  int verbose,
+  bool remDupNodes);
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    BoxLib::Initialize(argc,argv);
-    {
+  BoxLib::Initialize(argc, argv);
+  {
     ParmParse pp;
 
-    int verbose=0; pp.query("verbose",verbose);
-    Real eps=1.e-8; pp.query("eps",eps);
-    bool remDupNodes = false; pp.query("remDupNodes",remDupNodes);
-    
-    Array<string> infiles;
-    int nf=pp.countval("infiles");
-    infiles.resize(nf);
-    pp.getarr("infiles",infiles,0,nf);
-    string outfile; pp.get("outfile",outfile);
+    int verbose = 0;
+    pp.query("verbose", verbose);
+    Real eps = 1.e-8;
+    pp.query("eps", eps);
+    bool remDupNodes = false;
+    pp.query("remDupNodes", remDupNodes);
 
-    FArrayBox nodesM,nodes;
+    Array<string> infiles;
+    int nf = pp.countval("infiles");
+    infiles.resize(nf);
+    pp.getarr("infiles", infiles, 0, nf);
+    string outfile;
+    pp.get("outfile", outfile);
+
+    FArrayBox nodesM, nodes;
     Array<int> faceDataM, faceData;
-    vector<string> namesM,names;
+    vector<string> namesM, names;
     string labelM, label;
     int nEltsM, nElts;
-    for (int i=0; i<infiles.size(); ++i)
-    {
+    for (int i = 0; i < infiles.size(); ++i) {
+      if (verbose)
+        cout << "Reading " << infiles[i] << endl;
+
+      read_iso(infiles[i], nodes, faceData, nElts, names, label);
+      if (i == 0) {
+        int nComp = nodes.nComp();
+        nodesM.resize(nodes.box(), nComp);
+        nodesM.copy(nodes, 0, 0, nComp);
+        namesM.resize(nComp);
+        for (int j = 0; j < nComp; ++j) {
+          namesM[j] = names[j];
+        }
+        nEltsM = nElts;
+        labelM = label;
+        faceDataM.resize(faceData.size());
+        for (int j = 0; j < faceData.size(); ++j) {
+          faceDataM[j] = faceData[j];
+        }
+      } else {
+        // For now, simply assert that the files have the same components
+        bool sameComps = true;
+        if (namesM.size() == names.size()) {
+          for (int j = 0; j < names.size() && sameComps; ++j)
+            sameComps &= names[j] == namesM[j];
+        }
+        if (!sameComps)
+          BoxLib::Abort("Incompatible files");
+
         if (verbose)
-            cout << "Reading " << infiles[i] << endl;
+          cout << "  merging surfaces" << endl;
 
-        read_iso(infiles[i],nodes,faceData,nElts,names,label);
-        if (i==0)
-        {
-            int nComp = nodes.nComp();
-            nodesM.resize(nodes.box(),nComp);
-            nodesM.copy(nodes,0,0,nComp);
-            namesM.resize(nComp);
-            for (int j=0; j<nComp; ++j)
-            {
-                namesM[j] = names[j];
-            }
-            nEltsM = nElts;
-            labelM = label;
-            faceDataM.resize(faceData.size());
-            for (int j=0; j<faceData.size(); ++j)
-            {
-                faceDataM[j] = faceData[j];
-            }
-        }
-        else
-        {
-            // For now, simply assert that the files have the same components
-            bool sameComps = true;
-            if (namesM.size() == names.size())
-            {
-                for (int j=0; j<names.size() && sameComps; ++j)
-                    sameComps &= names[j]==namesM[j];
-            }
-            if (!sameComps)
-                BoxLib::Abort("Incompatible files");
-
-            if (verbose)
-                cout << "  merging surfaces" << endl;
-
-            merge_iso(nodesM,faceDataM,nEltsM,nodes,faceData,nElts,eps,verbose,remDupNodes);
-        }
+        merge_iso(
+          nodesM, faceDataM, nEltsM, nodes, faceData, nElts, eps, verbose,
+          remDupNodes);
+      }
     }
 
     cout << "Writing " << outfile << endl;
 
-    write_iso(outfile,nodesM,faceDataM,nEltsM,namesM,labelM);
-    }
-    BoxLib::Finalize();
-    return 0;
+    write_iso(outfile, nodesM, faceDataM, nEltsM, namesM, labelM);
+  }
+  BoxLib::Finalize();
+  return 0;
 }
 
-static
-void
-merge_iso(FArrayBox&        nodesM,
-          Array<int>&       faceDataM,
-          int&              nEltsM,
-          const FArrayBox&  nodes,
-          const Array<int>& faceData,
-          int               nElts,
-          Real              eps,
-          int               verbose,
-          bool              remDupNodes)
+static void
+merge_iso(
+  FArrayBox& nodesM,
+  Array<int>& faceDataM,
+  int& nEltsM,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  Real eps,
+  int verbose,
+  bool remDupNodes)
 {
-    int nodesPerEltM = (int)(faceDataM.size() / nEltsM);
-    if (nodesPerEltM * nEltsM != faceDataM.size())
-        BoxLib::Abort("Non-constant nodes/elt not supported");
+  int nodesPerEltM = (int)(faceDataM.size() / nEltsM);
+  if (nodesPerEltM * nEltsM != faceDataM.size())
+    BoxLib::Abort("Non-constant nodes/elt not supported");
 
-    int nodesPerElt = (int)(faceData.size() / nElts);
-    if (nodesPerElt * nElts != faceData.size())
-        BoxLib::Abort("Non-constant nodes/elt not supported");
+  int nodesPerElt = (int)(faceData.size() / nElts);
+  if (nodesPerElt * nElts != faceData.size())
+    BoxLib::Abort("Non-constant nodes/elt not supported");
 
-    if (nodesPerEltM != nodesPerElt)
-        BoxLib::Abort("Incompatible surfaces");
+  if (nodesPerEltM != nodesPerElt)
+    BoxLib::Abort("Incompatible surfaces");
 
-    const Box& box = nodes.box();
-    int nNodes;
-    if (box.numPtsOK() && box.numPts()==(int)(box.numPts()))
-        nNodes = box.numPts();
+  const Box& box = nodes.box();
+  int nNodes;
+  if (box.numPtsOK() && box.numPts() == (int)(box.numPts()))
+    nNodes = box.numPts();
+  else
+    BoxLib::Abort("New surface too big");
+
+  const Box& boxM = nodesM.box();
+  long nNodesM;
+  if (boxM.numPtsOK() && boxM.numPts() == (int)(boxM.numPts()))
+    nNodesM = boxM.numPts();
+  else
+    BoxLib::Abort("Old surface too big");
+
+  int nComp = nodes.nComp();
+  vector<Real*> dptrM(nComp);
+  vector<const Real*> dptr(nComp);
+  for (int j = 0; j < nComp; ++j) {
+    dptrM[j] = nodesM.dataPtr(j);
+    dptr[j] = nodes.dataPtr(j);
+  }
+  Array<int> newNodes(nNodes);
+  Real epsSq = eps * eps;
+  int cnt = nNodesM;
+  for (int i = 0; i < nNodes; ++i) {
+    bool found = false;
+    if (remDupNodes) {
+      for (int j = 0; j < nNodesM && !found; ++j) {
+        Real dist = 0;
+        for (int k = 0; k < AMREX_SPACEDIM; ++k) {
+          Real dx = dptr[k][i] - dptrM[k][j];
+          dist += dx * dx;
+        }
+        if (dist <= epsSq) {
+          found = true;
+          newNodes[i] = j;
+        }
+      }
+    }
+    if (!found)
+      newNodes[i] = cnt++;
+  }
+
+  if (cnt > nNodesM) {
+    FArrayBox old(nodesM.box(), nComp);
+    old.copy(nodesM);
+    nodesM.resize(Box(boxM).growHi(0, cnt - nNodesM), nComp);
+    nodesM.copy(old);
+    old.clear();
+    for (int k = 0; k < nComp; ++k) {
+      Real* d = nodesM.dataPtr(k);
+      for (int i = 0; i < newNodes.size(); ++i) {
+        if (newNodes[i] >= nNodesM) {
+          d[newNodes[i]] = dptr[k][i];
+        }
+      }
+    }
+
+    int offset = faceDataM.size();
+    Array<int> oldFD(offset);
+    for (int i = 0; i < offset; ++i)
+      oldFD[i] = faceDataM[i];
+
+    faceDataM.resize(offset + faceData.size());
+    for (int i = 0; i < offset; ++i)
+      faceDataM[i] = oldFD[i];
+    for (int i = 0; i < faceData.size(); ++i) {
+      faceDataM[offset + i] = newNodes[faceData[i] - 1] + 1;
+    }
+    oldFD.clear();
+    nEltsM = (int)(faceDataM.size() / nodesPerElt);
+  }
+}
+
+void
+write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label)
+{
+  // Rotate data to vary quickest on component
+  int nCompSurf = nodes.nComp();
+  int nNodes = nodes.box().numPts();
+
+  FArrayBox tnodes(nodes.box(), nCompSurf);
+  const Real** np = new const Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      ndat[j] = np[j][i];
+    }
+    ndat += nCompSurf;
+  }
+  delete[] np;
+
+  std::ofstream ofs;
+  ofs.open(outfile.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
+  ofs << label << endl;
+  for (int i = 0; i < nCompSurf; ++i) {
+    ofs << names[i];
+    if (i < nCompSurf - 1)
+      ofs << " ";
     else
-        BoxLib::Abort("New surface too big");
-
-    const Box& boxM = nodesM.box();
-    long nNodesM;
-    if (boxM.numPtsOK() && boxM.numPts()==(int)(boxM.numPts()))
-        nNodesM = boxM.numPts();
-    else
-        BoxLib::Abort("Old surface too big");
-
-    int nComp = nodes.nComp();
-    vector<Real*> dptrM(nComp);
-    vector<const Real*> dptr(nComp);
-    for (int j=0; j<nComp; ++j)
-    {
-        dptrM[j] = nodesM.dataPtr(j);
-        dptr[j] = nodes.dataPtr(j);
-    }
-    Array<int> newNodes(nNodes);
-    Real epsSq = eps*eps;
-    int cnt = nNodesM;
-    for (int i=0; i<nNodes; ++i)
-    {
-        bool found = false;
-        if (remDupNodes)
-        {
-            for (int j=0; j<nNodesM && !found; ++j)
-            {
-                Real dist = 0;
-                for (int k=0; k<AMREX_SPACEDIM; ++k)
-                {
-                    Real dx = dptr[k][i] - dptrM[k][j];
-                    dist += dx*dx;
-                }
-                if (dist <= epsSq)
-                {
-                    found = true;
-                    newNodes[i] = j;
-                }
-            }
-        }
-        if (!found)
-            newNodes[i] = cnt++;
-    }
-
-    if (cnt>nNodesM)
-    {
-        FArrayBox old(nodesM.box(),nComp);
-        old.copy(nodesM);
-        nodesM.resize(Box(boxM).growHi(0,cnt-nNodesM),nComp);
-        nodesM.copy(old);
-        old.clear();
-        for (int k=0; k<nComp; ++k)
-        {
-            Real* d = nodesM.dataPtr(k);
-            for (int i=0; i<newNodes.size(); ++i)
-            {
-                if (newNodes[i]>=nNodesM)
-                {
-                    d[newNodes[i]] = dptr[k][i];
-                }
-            }
-        }
-
-        int offset = faceDataM.size();
-        Array<int> oldFD(offset);
-        for (int i=0; i<offset; ++i)
-            oldFD[i] = faceDataM[i];
-
-        faceDataM.resize(offset+faceData.size());
-        for (int i=0; i<offset; ++i)
-            faceDataM[i] = oldFD[i];
-        for (int i=0; i<faceData.size(); ++i)
-        {
-            faceDataM[offset+i] = newNodes[faceData[i] - 1] + 1;
-        }
-        oldFD.clear();
-        nEltsM = (int) (faceDataM.size() / nodesPerElt);
-    }
+      ofs << std::endl;
+  }
+  int nodesPerElt = faceData.size() / nElts;
+  ofs << nElts << " " << nodesPerElt << endl;
+  tnodes.writeOn(ofs);
+  ofs.write((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
+  ofs.close();
 }
 
 void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Array<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label)
+read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Array<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label)
 {
-    // Rotate data to vary quickest on component
-    int nCompSurf = nodes.nComp();
-    int nNodes = nodes.box().numPts();
+  std::ifstream ifs;
+  ifs.open(infile.c_str(), std::ios::in | std::ios::binary);
+  label = parseTitle(ifs);
+  names = parseVarNames(ifs);
+  const int nCompSurf = names.size();
 
-    FArrayBox tnodes(nodes.box(),nCompSurf);
-    const Real** np = new const Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            ndat[j] = np[j][i];
-        }
-        ndat += nCompSurf;
-    }
-    delete [] np;
+  int nodesPerElt;
+  ifs >> nElts;
+  ifs >> nodesPerElt;
 
-    std::ofstream ofs;
-    ofs.open(outfile.c_str(),std::ios::out|std::ios::trunc|std::ios::binary);
-    ofs << label << endl;
-    for (int i=0; i<nCompSurf; ++i)
-    {
-        ofs << names[i];
-        if (i < nCompSurf-1)
-            ofs << " ";
-        else
-            ofs << std::endl;
+  FArrayBox tnodes;
+  tnodes.readFrom(ifs);
+  const int nNodes = tnodes.box().numPts();
+
+  // "rotate" the data so that the components are 'in the right spot for fab
+  // data'
+  nodes.resize(tnodes.box(), nCompSurf);
+  Real** np = new Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      np[j][i] = ndat[j];
     }
-    int nodesPerElt = faceData.size() / nElts;
-    ofs << nElts << " " << nodesPerElt << endl;
-    tnodes.writeOn(ofs);
-    ofs.write((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-    ofs.close();
+    ndat += nCompSurf;
+  }
+  delete[] np;
+  tnodes.clear();
+
+  faceData.resize(nElts * nodesPerElt, 0);
+  ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
 }
-
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Array<int>&        faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label)
-{
-    std::ifstream ifs;
-    ifs.open(infile.c_str(),std::ios::in|std::ios::binary);
-    label = parseTitle(ifs);
-    names = parseVarNames(ifs);
-    const int nCompSurf = names.size();
-
-    int nodesPerElt;
-    ifs >> nElts;
-    ifs >> nodesPerElt;
-
-    FArrayBox tnodes;
-    tnodes.readFrom(ifs);
-    const int nNodes = tnodes.box().numPts();
-
-    // "rotate" the data so that the components are 'in the right spot for fab data'
-    nodes.resize(tnodes.box(),nCompSurf);
-    Real** np = new Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            np[j][i] = ndat[j];
-        }
-        ndat += nCompSurf;
-    }
-    delete [] np;
-    tnodes.clear();
-
-    faceData.resize(nElts*nodesPerElt,0);
-    ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-}
-

--- a/Src/multMEF.cpp
+++ b/Src/multMEF.cpp
@@ -12,233 +12,227 @@
 #include "DataServices.H"
 #include "Geometry.H"
 #include "Utility.H"
-using std::vector;
-using std::map;
-using std::string;
 using std::cerr;
-using std::endl;
 using std::cout;
+using std::endl;
+using std::map;
 using std::ofstream;
+using std::string;
+using std::vector;
 
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Array<int>&        faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label);
+void read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Array<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label);
 
-void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Array<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label);
+void write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label);
 
 vector<std::string>
-Tokenize (const std::string& instr, const std::string& separators)
+Tokenize(const std::string& instr, const std::string& separators)
 {
-    vector<char*> ptr;
-    //
-    // Make copy of line that we can modify.
-    //
-    char* line = new char[instr.size()+1];
+  vector<char*> ptr;
+  //
+  // Make copy of line that we can modify.
+  //
+  char* line = new char[instr.size() + 1];
 
-    (void) strcpy(line, instr.c_str());
+  (void)strcpy(line, instr.c_str());
 
-    char* token = 0;
+  char* token = 0;
 
-    if (!((token = strtok(line, separators.c_str())) == 0))
-    {
-        ptr.push_back(token);
-        while (!((token = strtok(0, separators.c_str())) == 0))
-            ptr.push_back(token);
-    }
+  if (!((token = strtok(line, separators.c_str())) == 0)) {
+    ptr.push_back(token);
+    while (!((token = strtok(0, separators.c_str())) == 0))
+      ptr.push_back(token);
+  }
 
-    vector<std::string> tokens(ptr.size());
+  vector<std::string> tokens(ptr.size());
 
-    for (int i = 1; i < ptr.size(); i++)
-    {
-        char* p = ptr[i];
+  for (int i = 1; i < ptr.size(); i++) {
+    char* p = ptr[i];
 
-        while (strchr(separators.c_str(), *(p-1)) != 0)
-            *--p = 0;
-    }
+    while (strchr(separators.c_str(), *(p - 1)) != 0)
+      *--p = 0;
+  }
 
-    for (int i = 0; i < ptr.size(); i++)
-        tokens[i] = ptr[i];
+  for (int i = 0; i < ptr.size(); i++)
+    tokens[i] = ptr[i];
 
-    delete line;
+  delete line;
 
-    return tokens;
+  return tokens;
 }
 
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return Tokenize(line,std::string(", "));
+  std::string line;
+  std::getline(is, line);
+  return Tokenize(line, std::string(", "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return line;
+  std::string line;
+  std::getline(is, line);
+  return line;
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    BoxLib::Initialize(argc,argv);
+  BoxLib::Initialize(argc, argv);
 
-    ParmParse pp;
+  ParmParse pp;
 
-    int nElts;
-    string infile; pp.get("infile",infile);
-    string outfile; pp.get("outfile",outfile);
+  int nElts;
+  string infile;
+  pp.get("infile", infile);
+  string outfile;
+  pp.get("outfile", outfile);
 
-    FArrayBox nodes;
-    Array<int> faceData;
-    vector<string> names;
-    string label;
-    read_iso(infile,nodes,faceData,nElts,names,label);
-    int nodesPerElt = faceData.size() / nElts;
-    AMREX_ASSERT(nodesPerElt*nElts == faceData.size());
+  FArrayBox nodes;
+  Array<int> faceData;
+  vector<string> names;
+  string label;
+  read_iso(infile, nodes, faceData, nElts, names, label);
+  int nodesPerElt = faceData.size() / nElts;
+  AMREX_ASSERT(nodesPerElt * nElts == faceData.size());
 
-    nElts = faceData.size() / nodesPerElt;
-    int nCompMEF = nodes.nComp();
-    AMREX_ASSERT(nElts*nodesPerElt == faceData.size());
+  nElts = faceData.size() / nodesPerElt;
+  int nCompMEF = nodes.nComp();
+  AMREX_ASSERT(nElts * nodesPerElt == faceData.size());
 
-    Array<int> comps;
-    int nComp=0;
-    if (nComp = pp.countval("comps"))
-    {
-        comps.resize(nComp);
-        pp.getarr("comps",comps,0,nComp);
+  Array<int> comps;
+  int nComp = 0;
+  if (nComp = pp.countval("comps")) {
+    comps.resize(nComp);
+    pp.getarr("comps", comps, 0, nComp);
+  } else {
+    int sComp = 0;
+    pp.query("sComp", sComp);
+    nComp = 1;
+    pp.query("nComp", nComp);
+    AMREX_ASSERT(sComp + nComp <= nCompMEF);
+    comps.resize(nComp);
+    for (int i = 0; i < nComp; ++i)
+      comps[i] = sComp + i;
+  }
+
+  FArrayBox nodesOut(nodes.box(), 1);
+  vector<string> namesOut(1);
+  namesOut[0] = "product";
+  pp.query("nameOut", namesOut[0]);
+
+  nodesOut.setVal(1.0); // Initialize to 1
+  Real* datOut = nodesOut.dataPtr(0);
+  int nNodes = nodes.box().numPts();
+  for (int j = 0; j < nComp; ++j) {
+    AMREX_ASSERT(comps[j] < nCompMEF);
+    Real* dat = nodes.dataPtr(comps[j]);
+    for (int i = 0; i < nNodes; ++i)
+      datOut[i] *= dat[i];
+  }
+
+  write_iso(outfile, nodesOut, faceData, nElts, namesOut, label);
+
+  BoxLib::Finalize();
+  return 0;
+}
+
+void
+write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label)
+{
+  // Rotate data to vary quickest on component
+  int nCompSurf = nodes.nComp();
+  int nNodes = nodes.box().numPts();
+
+  FArrayBox tnodes(nodes.box(), nCompSurf);
+  const Real** np = new const Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      ndat[j] = np[j][i];
     }
+    ndat += nCompSurf;
+  }
+  delete[] np;
+
+  std::ofstream ofs;
+  ofs.open(outfile.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
+  ofs << label << endl;
+  for (int i = 0; i < nCompSurf; ++i) {
+    ofs << names[i];
+    if (i < nCompSurf - 1)
+      ofs << " ";
     else
-    {
-        int sComp = 0;
-        pp.query("sComp",sComp);
-        nComp = 1;
-        pp.query("nComp",nComp);
-        AMREX_ASSERT(sComp+nComp <= nCompMEF);
-        comps.resize(nComp);
-        for (int i=0; i<nComp; ++i)
-            comps[i] = sComp + i;
-    }
-
-    FArrayBox nodesOut(nodes.box(),1);
-    vector<string> namesOut(1);
-    namesOut[0] = "product"; pp.query("nameOut",namesOut[0]);
-
-    nodesOut.setVal(1.0); // Initialize to 1
-    Real* datOut = nodesOut.dataPtr(0);
-    int nNodes = nodes.box().numPts();
-    for (int j=0; j<nComp; ++j)
-    {
-        AMREX_ASSERT(comps[j]<nCompMEF);
-        Real* dat=nodes.dataPtr(comps[j]);
-        for (int i=0; i<nNodes; ++i)
-            datOut[i] *= dat[i];
-    }
-
-    write_iso(outfile,nodesOut,faceData,nElts,namesOut,label);
-
-    BoxLib::Finalize();
-    return 0;
+      ofs << std::endl;
+  }
+  int nodesPerElt = faceData.size() / nElts;
+  ofs << nElts << " " << nodesPerElt << endl;
+  tnodes.writeOn(ofs);
+  ofs.write((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
+  ofs.close();
 }
 
 void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Array<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label)
+read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Array<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label)
 {
-    // Rotate data to vary quickest on component
-    int nCompSurf = nodes.nComp();
-    int nNodes = nodes.box().numPts();
+  std::ifstream ifs;
+  ifs.open(infile.c_str(), std::ios::in | std::ios::binary);
+  label = parseTitle(ifs);
+  names = parseVarNames(ifs);
+  const int nCompSurf = names.size();
 
-    FArrayBox tnodes(nodes.box(),nCompSurf);
-    const Real** np = new const Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            ndat[j] = np[j][i];
-        }
-        ndat += nCompSurf;
-    }
-    delete [] np;
+  int nodesPerElt;
+  ifs >> nElts;
+  ifs >> nodesPerElt;
 
-    std::ofstream ofs;
-    ofs.open(outfile.c_str(),std::ios::out|std::ios::trunc|std::ios::binary);
-    ofs << label << endl;
-    for (int i=0; i<nCompSurf; ++i)
-    {
-        ofs << names[i];
-        if (i < nCompSurf-1)
-            ofs << " ";
-        else
-            ofs << std::endl;
+  FArrayBox tnodes;
+  tnodes.readFrom(ifs);
+  const int nNodes = tnodes.box().numPts();
+
+  // "rotate" the data so that the components are 'in the right spot for fab
+  // data'
+  nodes.resize(tnodes.box(), nCompSurf);
+  Real** np = new Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      np[j][i] = ndat[j];
     }
-    int nodesPerElt = faceData.size() / nElts;
-    ofs << nElts << " " << nodesPerElt << endl;
-    tnodes.writeOn(ofs);
-    ofs.write((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-    ofs.close();
+    ndat += nCompSurf;
+  }
+  delete[] np;
+  tnodes.clear();
+
+  faceData.resize(nElts * nodesPerElt, 0);
+  ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
 }
-
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Array<int>&        faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label)
-{
-    std::ifstream ifs;
-    ifs.open(infile.c_str(),std::ios::in|std::ios::binary);
-    label = parseTitle(ifs);
-    names = parseVarNames(ifs);
-    const int nCompSurf = names.size();
-
-    int nodesPerElt;
-    ifs >> nElts;
-    ifs >> nodesPerElt;
-
-    FArrayBox tnodes;
-    tnodes.readFrom(ifs);
-    const int nNodes = tnodes.box().numPts();
-
-    // "rotate" the data so that the components are 'in the right spot for fab data'
-    nodes.resize(tnodes.box(),nCompSurf);
-    Real** np = new Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            np[j][i] = ndat[j];
-        }
-        ndat += nCompSurf;
-    }
-    delete [] np;
-    tnodes.clear();
-
-    faceData.resize(nElts*nodesPerElt,0);
-    ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-}
-

--- a/Src/optimalEstimatorANN.H
+++ b/Src/optimalEstimatorANN.H
@@ -13,9 +13,10 @@
 #include <string>
 #include <iostream>
 
-//optimalEstimatorANN.cpp
+// optimalEstimatorANN.cpp
 
-struct Net : torch::nn::Module {
+struct Net : torch::nn::Module
+{
 public:
   // Constructor declaration
   Net(int input_size, amrex::Vector<int> neurons, int output_size);
@@ -25,19 +26,18 @@ public:
 
 private:
   // Forward pass declaration
-  //torch::Tensor tansig(torch::Tensor x);
+  // torch::Tensor tansig(torch::Tensor x);
   torch::Tensor activate(torch::Tensor x);
 
   // Function to initialize weights
   void initializeWeights();
 
   // Declare layers
-  //torch::nn::Linearfc1{nullptr}, fc2{nullptr}, fc3{nullptr}; // Add more layers if needed
+  // torch::nn::Linearfc1{nullptr}, fc2{nullptr}, fc3{nullptr}; // Add more
+  // layers if needed
 
   int n_layers;
   amrex::Vector<torch::nn::Linear> layers;
 };
 
 #endif
-
-

--- a/Src/optimalEstimatorANN.cpp
+++ b/Src/optimalEstimatorANN.cpp
@@ -1,18 +1,25 @@
 #include <optimalEstimatorANN.H>
 
-Net::Net(int input_size, amrex::Vector<int> neurons, int output_size) {
+Net::Net(int input_size, amrex::Vector<int> neurons, int output_size)
+{
   n_layers = neurons.size();
-  layers.resize(n_layers+1,nullptr);
+  layers.resize(n_layers + 1, nullptr);
   if (n_layers == 0) {
-    layers[0] = register_module("fc",torch::nn::Linear(input_size,output_size));
+    layers[0] =
+      register_module("fc", torch::nn::Linear(input_size, output_size));
     layers[0]->to(torch::kDouble);
   } else {
-    layers[0] = register_module("fc0", torch::nn::Linear(input_size,neurons[0]));
+    layers[0] =
+      register_module("fc0", torch::nn::Linear(input_size, neurons[0]));
     layers[0]->to(torch::kDouble);
-    layers[n_layers] = register_module("fc"+std::to_string(n_layers),torch::nn::Linear(neurons[n_layers-1],output_size));
+    layers[n_layers] = register_module(
+      "fc" + std::to_string(n_layers),
+      torch::nn::Linear(neurons[n_layers - 1], output_size));
     layers[n_layers]->to(torch::kDouble);
     for (int n = 1; n < n_layers; n++) {
-      layers[n] = register_module("fc"+std::to_string(n),torch::nn::Linear(neurons[n-1],neurons[n]));
+      layers[n] = register_module(
+        "fc" + std::to_string(n),
+        torch::nn::Linear(neurons[n - 1], neurons[n]));
       layers[n]->to(torch::kDouble);
     }
   }
@@ -20,25 +27,31 @@ Net::Net(int input_size, amrex::Vector<int> neurons, int output_size) {
 }
 
 // Implement the forward pass
-torch::Tensor Net::forward(torch::Tensor x) {
-  //following Berger et al. (2018), linear activation function, after tansig function  
+torch::Tensor
+Net::forward(torch::Tensor x)
+{
+  // following Berger et al. (2018), linear activation function, after tansig
+  // function
   for (int n = 0; n < n_layers; n++) {
     x = activate(layers[n]->forward(x));
   }
   x = layers[n_layers]->forward(x);
-  
+
   return x;
 }
 
-torch::Tensor Net::activate(torch::Tensor x) {
-    return torch::tanh(x);
+torch::Tensor
+Net::activate(torch::Tensor x)
+{
+  return torch::tanh(x);
 }
- 
+
 // Function to initialize weights
-void Net::initializeWeights() {
+void
+Net::initializeWeights()
+{
   // Calculate the scaling factor
-    for (int n = 0; n <= n_layers; n++) {
+  for (int n = 0; n <= n_layers; n++) {
     torch::nn::init::xavier_uniform_(layers[n]->weight);
-    }
+  }
 }
-    

--- a/Src/optimalEstimatorInfer.cpp
+++ b/Src/optimalEstimatorInfer.cpp
@@ -7,15 +7,12 @@
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
 
-
 using namespace amrex;
 
 #include <optimalEstimatorANN.H>
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile=f1 [options] \n\tOptions:\n";
@@ -25,61 +22,62 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     // Open plotfile header and create an amrData object pointing into it
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
-    // Set up input field data names, and destination components to load data upon read.
+    // Set up input field data names, and destination components to load data
+    // upon read.
     int nFeatures = pp.countval("features");
     int nTargets = pp.countval("targets");
     int nCompIn = nFeatures + nTargets;
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
     Vector<std::string> features(nFeatures);
-    pp.getarr("features",features);
+    pp.getarr("features", features);
     Vector<std::string> targets(nTargets);
-    pp.getarr("targets",targets);
+    pp.getarr("targets", targets);
     for (int n = 0; n < nFeatures; n++) {
       inNames[n] = features[n];
       destFillComps[n] = n;
     }
     for (int n = 0; n < nTargets; n++) {
-      inNames[n+nFeatures] = targets[n];
-      destFillComps[n+nFeatures] = n+nFeatures;
+      inNames[n + nFeatures] = targets[n];
+      destFillComps[n + nFeatures] = n + nFeatures;
     }
 
     // Loop over AMR levels in the plotfile, read the data and do work
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    pp.query("finestLevel", finestLevel);
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     Print() << "Periodicity assumed for this case: ";
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        Print() << is_per[idim] << " ";
+      Print() << is_per[idim] << " ";
     }
     Print() << "\n";
 
@@ -93,37 +91,39 @@ main (int   argc,
       pp.get("cMax",cMax);
     }
     */
-    std::string path="optimal_estimator"; pp.query("model_path",path);
+    std::string path = "optimal_estimator";
+    pp.query("model_path", path);
     path += ".pt";
     int Nlev = finestLevel + 1;
     const int nGrow = 0;
-    int nCompOut = 3*nTargets;
+    int nCompOut = 3 * nTargets;
     Vector<std::string> outNames(nCompOut);
     for (int n = 0; n < nTargets; n++) {
       outNames[n] = targets[n];
-      outNames[n+nTargets] = targets[n]+"_cond_";
+      outNames[n + nTargets] = targets[n] + "_cond_";
       for (int nf = 0; nf < nFeatures; nf++) {
-	outNames[n+nTargets] += features[nf];
-	if (nf != nFeatures - 1) {
-	  outNames[n+nTargets] += ","; 
-	}
+        outNames[n + nTargets] += features[nf];
+        if (nf != nFeatures - 1) {
+          outNames[n + nTargets] += ",";
+        }
       }
-      outNames[n+2*nTargets] = "irr_"+outNames[n+nTargets];
-    }   
+      outNames[n + 2 * nTargets] = "irr_" + outNames[n + nTargets];
+    }
 
-    //declare Vector of MultiFab, one MultiFab for each level
+    // declare Vector of MultiFab, one MultiFab for each level
     Vector<MultiFab> outdata(Nlev);
-    //also need to hold the geometry of each level
+    // also need to hold the geometry of each level
     Vector<Geometry> geoms(Nlev);
 
-    RealBox rb(&(amrData.ProbLo()[0]),&(amrData.ProbHi()[0]));
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
     int n_layers = pp.countval("neurons");
-    Vector<int> neurons(n_layers); pp.getarr("neurons",neurons);
+    Vector<int> neurons(n_layers);
+    pp.getarr("neurons", neurons);
     // set pytorch data type (default is float or torch::kFloat32)
     auto dtype0 = torch::kDouble;
-    auto model = std::make_shared<Net>(nFeatures,neurons,nTargets);
-    torch::load(model,path);
-    
+    auto model = std::make_shared<Net>(nFeatures, neurons, nTargets);
+    torch::load(model, path);
+
 #ifdef AMREX_USE_CUDA
     torch::Device device0(torch::kCUDA);
     model.to(device0);
@@ -133,19 +133,20 @@ main (int   argc,
 #else
     auto tensoropt = torch::TensorOptions().dtype(dtype0);
 #endif
-    Vector<Real> f_max(nFeatures,-1e100);
-    Vector<Real> f_min(nFeatures,1e100);
-    Vector<Real> t_max(nTargets,-1e100);
-    Vector<Real> t_min(nTargets,1e100);
+    Vector<Real> f_max(nFeatures, -1e100);
+    Vector<Real> f_min(nFeatures, 1e100);
+    Vector<Real> t_max(nTargets, -1e100);
+    Vector<Real> t_min(nTargets, 1e100);
 
-    std::string minmax_path="minmax"; pp.query("minmax_path",minmax_path);
+    std::string minmax_path = "minmax";
+    pp.query("minmax_path", minmax_path);
     minmax_path += ".bin";
-    
-    std::ifstream file(minmax_path,std::ios::out);
-    file.read((char*)f_min.dataPtr(),sizeof(Real)*nFeatures);
-    file.read((char*)f_max.dataPtr(),sizeof(Real)*nFeatures);
-    file.read((char*)t_min.dataPtr(),sizeof(Real)*nTargets);
-    file.read((char*)t_max.dataPtr(),sizeof(Real)*nTargets);
+
+    std::ifstream file(minmax_path, std::ios::out);
+    file.read((char*)f_min.dataPtr(), sizeof(Real) * nFeatures);
+    file.read((char*)f_max.dataPtr(), sizeof(Real) * nFeatures);
+    file.read((char*)t_min.dataPtr(), sizeof(Real) * nTargets);
+    file.read((char*)t_max.dataPtr(), sizeof(Real) * nTargets);
 
     for (int nv = 0; nv < nFeatures; nv++) {
       Print() << "f_max[" << nv << "] = " << f_max[nv] << std::endl;
@@ -156,95 +157,105 @@ main (int   argc,
       Print() << "t_min[" << nv << "] = " << t_min[nv] << std::endl;
     }
 
-    //now we have a trained model which should be the same on all processes
+    // now we have a trained model which should be the same on all processes
 
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-      //Get the array of boxes for this level
+    for (int lev = 0; lev < Nlev; ++lev) {
+      // Get the array of boxes for this level
       const BoxArray ba = amrData.boxArray(lev);
-      //Distribution mapping i.e. how are boxes distributed across processors
+      // Distribution mapping i.e. how are boxes distributed across processors
       const DistributionMapping dm(ba);
-      //set up a multifab for the outdata with the same boxarray, distribution mapping, components and ngrow
-      outdata[lev] = MultiFab(ba,dm,nCompOut,nGrow);
-      //we'll load each level as we go, so only need to fill one multifab at a time
-      MultiFab indata(ba,dm,nCompIn,nGrow);
-      int coord = 0; //indicates cartesian
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb,coord,&(is_per[0]));
+      // set up a multifab for the outdata with the same boxarray, distribution
+      // mapping, components and ngrow
+      outdata[lev] = MultiFab(ba, dm, nCompOut, nGrow);
+      // we'll load each level as we go, so only need to fill one multifab at a
+      // time
+      MultiFab indata(ba, dm, nCompIn, nGrow);
+      int coord = 0; // indicates cartesian
+      geoms[lev] =
+        Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
 
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps); //magic IO call
+      amrData.FillVar(indata, lev, inNames, destFillComps); // magic IO call
       Print() << "Data has been read for level " << lev << std::endl;
-      
-      MultiFab::Copy(outdata[lev],indata,nFeatures,0,nTargets,nGrow); //copy the target data
 
-      //Iterate over the multiFabs - distributes each box to a process and iterates over it
-      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-	//box for this iteration
+      MultiFab::Copy(
+        outdata[lev], indata, nFeatures, 0, nTargets,
+        nGrow); // copy the target data
+
+      // Iterate over the multiFabs - distributes each box to a process and
+      // iterates over it
+      for (MFIter mfi(indata, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        // box for this iteration
         const Box& bx = mfi.tilebox();
-	const IntVect bx_lo = bx.smallEnd();
-	      
-	const IntVect nbox = bx.size();
+        const IntVect bx_lo = bx.smallEnd();
+
+        const IntVect nbox = bx.size();
 #if AMREX_SPACEDIM == 2
-	int ncell = nbox[0] * nbox[1];
+        int ncell = nbox[0] * nbox[1];
 #else
-	int ncell = nbox[0] * nbox[1] * nbox[2];
+        int ncell = nbox[0] * nbox[1] * nbox[2];
 #endif
-	//arrays for in and out data
-	Array4<Real> const& inbox  = indata.array(mfi);
-        Array4<Real> const& outbox_t = outdata[lev].array(mfi,0);
-        Array4<Real> const& outbox_oe = outdata[lev].array(mfi,nTargets);
-        Array4<Real> const& outbox_irr = outdata[lev].array(mfi,2*nTargets);
-	//magic i,j,k looper (works in serial/MPI/CUDA and 2D/3D)
-	//create array to feed to model
-	amrex::Gpu::ManagedVector<Real> trainingVec(ncell*nFeatures);
-	Real* AMREX_RESTRICT trainingPtr = trainingVec.dataPtr();
-	AMREX_PARALLEL_FOR_3D ( bx, i, j, k,
-			      {
-				int ii = i - bx_lo[0];
-				int jj = j - bx_lo[1];
-				int index = jj*nbox[0] + ii;
+        // arrays for in and out data
+        Array4<Real> const& inbox = indata.array(mfi);
+        Array4<Real> const& outbox_t = outdata[lev].array(mfi, 0);
+        Array4<Real> const& outbox_oe = outdata[lev].array(mfi, nTargets);
+        Array4<Real> const& outbox_irr = outdata[lev].array(mfi, 2 * nTargets);
+        // magic i,j,k looper (works in serial/MPI/CUDA and 2D/3D)
+        // create array to feed to model
+        amrex::Gpu::ManagedVector<Real> trainingVec(ncell * nFeatures);
+        Real* AMREX_RESTRICT trainingPtr = trainingVec.dataPtr();
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
+          int ii = i - bx_lo[0];
+          int jj = j - bx_lo[1];
+          int index = jj * nbox[0] + ii;
 #if AMREX_SPACEDIM == 3
-				int kk = k - bx_lo[2];
-				index += kk*nbox[0]*nbox[1];
-#endif				
-				for (int n = 0; n < nFeatures; n++) {
-				  trainingPtr[index*nFeatures + n] = -1.0 + 2*(inbox(i, j, k, n)-f_min[n])/(f_max[n]-f_min[n]);
-				}
-			      });
-	torch::Tensor local_tensor = torch::from_blob(trainingPtr,{ncell,nFeatures},tensoropt);
-	//std::cout << local_tensor << std::endl;
-	torch::Tensor output = model->forward(local_tensor);
-	//std::cout << output << std::endl;
-	output = output.contiguous();
-	amrex::Gpu::ManagedVector<Real> outputVec(ncell*nTargets);
-	Real* AMREX_RESTRICT outputPtr = outputVec.dataPtr();
-	std::memcpy(outputPtr, output.data_ptr<Real>(), ncell*nTargets*sizeof(Real));
-	AMREX_PARALLEL_FOR_3D ( bx, i, j, k,
-				{
-				  int ii = i - bx_lo[0];
-				  int jj = j - bx_lo[1];
-				  int index = jj*nbox[0] + ii;
-#if AMREX_SPACEDIM == 3
-				  int kk = k - bx_lo[2];
-				  index += kk*nbox[0]*nbox[1];
+          int kk = k - bx_lo[2];
+          index += kk * nbox[0] * nbox[1];
 #endif
-				  for (int n = 0; n < nTargets; n++) {
-				    outbox_oe(i,j,k,n) = t_min[n] + 0.5*(t_max[n]-t_min[n])*(outputPtr[index*nTargets + n] + 1.0);
-				    outbox_irr(i,j,k,n) = (outbox_t(i,j,k,n)-outbox_oe(i,j,k,n))*(outbox_t(i,j,k,n)-outbox_oe(i,j,k,n));
-				  }
-				});
-	
+          for (int n = 0; n < nFeatures; n++) {
+            trainingPtr[index * nFeatures + n] =
+              -1.0 + 2 * (inbox(i, j, k, n) - f_min[n]) / (f_max[n] - f_min[n]);
+          }
+        });
+        torch::Tensor local_tensor =
+          torch::from_blob(trainingPtr, {ncell, nFeatures}, tensoropt);
+        // std::cout << local_tensor << std::endl;
+        torch::Tensor output = model->forward(local_tensor);
+        // std::cout << output << std::endl;
+        output = output.contiguous();
+        amrex::Gpu::ManagedVector<Real> outputVec(ncell * nTargets);
+        Real* AMREX_RESTRICT outputPtr = outputVec.dataPtr();
+        std::memcpy(
+          outputPtr, output.data_ptr<Real>(), ncell * nTargets * sizeof(Real));
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
+          int ii = i - bx_lo[0];
+          int jj = j - bx_lo[1];
+          int index = jj * nbox[0] + ii;
+#if AMREX_SPACEDIM == 3
+          int kk = k - bx_lo[2];
+          index += kk * nbox[0] * nbox[1];
+#endif
+          for (int n = 0; n < nTargets; n++) {
+            outbox_oe(i, j, k, n) =
+              t_min[n] + 0.5 * (t_max[n] - t_min[n]) *
+                           (outputPtr[index * nTargets + n] + 1.0);
+            outbox_irr(i, j, k, n) =
+              (outbox_t(i, j, k, n) - outbox_oe(i, j, k, n)) *
+              (outbox_t(i, j, k, n) - outbox_oe(i, j, k, n));
+          }
+        });
       }
       Print() << "Derive finished for level " << lev << std::endl;
     }
-    std::string outfile =getFileRoot(plotFileName)+ "_OE"; pp.query("outfile",outfile); 
+    std::string outfile = getFileRoot(plotFileName) + "_OE";
+    pp.query("outfile", outfile);
     Print() << "Writing new data to " << outfile << std::endl;
-    Vector<int> isteps(Nlev,0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2,2,2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(outdata),outNames, geoms, 0.0, isteps, refRatios);
-    
-  }    
+    Vector<int> isteps(Nlev, 0);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps,
+      refRatios);
+  }
   Finalize();
   return 0;
 }

--- a/Src/optimalEstimatorTraining.cpp
+++ b/Src/optimalEstimatorTraining.cpp
@@ -2,10 +2,8 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile=f1 [options] \n\tOptions:\n";
@@ -15,11 +13,13 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
-torch::Tensor compute_regularisation(const torch::nn::Module& model) {
+torch::Tensor
+compute_regularisation(const torch::nn::Module& model)
+{
   torch::Tensor l2_reg = torch::tensor(0.0);
   for (const auto param : model.parameters()) {
     l2_reg += torch::sum(torch::pow(param, 2));
@@ -41,71 +41,74 @@ torch::Tensor compute_regularisation(const torch::nn::Module& model) {
   return l2_reg;
 }*/
 
-
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     // Open plotfile header and create an amrData object pointing into it
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
-    // Set up input field data names, and destination components to load data upon read.
+    // Set up input field data names, and destination components to load data
+    // upon read.
     int nFeatures = pp.countval("features");
     int nTargets = pp.countval("targets");
     int nCompIn = nFeatures + nTargets;
-    int nEpochs = 1000; pp.query("nEpochs",nEpochs);
+    int nEpochs = 1000;
+    pp.query("nEpochs", nEpochs);
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
     Vector<std::string> features(nFeatures);
-    pp.getarr("features",features);
+    pp.getarr("features", features);
     Vector<std::string> targets(nTargets);
-    pp.getarr("targets",targets);
+    pp.getarr("targets", targets);
     for (int n = 0; n < nFeatures; n++) {
       inNames[n] = features[n];
       destFillComps[n] = n;
     }
     for (int n = 0; n < nTargets; n++) {
-      inNames[n+nFeatures] = targets[n];
-      destFillComps[n+nFeatures] = n+nFeatures;
+      inNames[n + nFeatures] = targets[n];
+      destFillComps[n + nFeatures] = n + nFeatures;
     }
-    
+
     // Loop over AMR levels in the plotfile, read the data and do work
     int finestLevel = amrData.FinestLevel();
     int minLevel = 0;
-    pp.query("finestLevel",finestLevel);
-    pp.query("minLevel",minLevel);
-    
-    std::string path="optimal_estimator"; pp.query("model_path",path);    
+    pp.query("finestLevel", finestLevel);
+    pp.query("minLevel", minLevel);
+
+    std::string path = "optimal_estimator";
+    pp.query("model_path", path);
     path += ".pt";
     int Nlev = finestLevel + 1;
     const int nGrow = 0;
     int n_layers = pp.countval("neurons");
-    Vector<int> neurons(n_layers); pp.getarr("neurons",neurons);
-    torch::manual_seed(42); //ensure same seeding used each time
+    Vector<int> neurons(n_layers);
+    pp.getarr("neurons", neurons);
+    torch::manual_seed(42); // ensure same seeding used each time
     int reg_mode = 0;
     pp.query("reg_mode", reg_mode);
 
     auto dtype0 = torch::kDouble;
 
-    auto model = std::make_shared<Net>(nFeatures,neurons,nTargets);
-    
+    auto model = std::make_shared<Net>(nFeatures, neurons, nTargets);
+
 #ifdef AMREX_USE_CUDA
     torch::Device device0(torch::kCUDA);
     model->to(device0);
@@ -113,104 +116,107 @@ main (int   argc,
     // set tensor options
     auto tensoropt = torch::TensorOptions().dtype(dtype0).device(device0);
 #else
-    auto tensoropt = torch::TensorOptions().dtype(dtype0);//.device(device0);
+    auto tensoropt = torch::TensorOptions().dtype(dtype0); //.device(device0);
 #endif
-    
-    Vector<Real> f_max(nFeatures,-1e100);
-    Vector<Real> f_min(nFeatures,1e100);
-    Vector<Real> t_max(nTargets,-1e100);
-    Vector<Real> t_min(nTargets,1e100);
-    int batch_size = -1; pp.query("batch_size",batch_size);
+
+    Vector<Real> f_max(nFeatures, -1e100);
+    Vector<Real> f_min(nFeatures, 1e100);
+    Vector<Real> t_max(nTargets, -1e100);
+    Vector<Real> t_min(nTargets, 1e100);
+    int batch_size = -1;
+    pp.query("batch_size", batch_size);
     Vector<MultiFab> indata(Nlev);
-    
+
     for (int lev = minLevel; lev < Nlev; lev++) {
-      //Get the array of boxes for this level
+      // Get the array of boxes for this level
       BoxArray ba = amrData.boxArray(lev);
       if (batch_size > 0) {
-	ba.maxSize(batch_size);
+        ba.maxSize(batch_size);
       }
-      //Distribution mapping i.e. how are boxes distributed across processors
+      // Distribution mapping i.e. how are boxes distributed across processors
       const DistributionMapping dm(ba);
-      
-      indata[lev].define(ba,dm,nCompIn,nGrow);
+
+      indata[lev].define(ba, dm, nCompIn, nGrow);
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata[lev],lev,inNames,destFillComps); //magic IO call
+      amrData.FillVar(indata[lev], lev, inNames, destFillComps); // magic IO
+                                                                 // call
       Print() << "Data has been read for level " << lev << std::endl;
-      
+
       for (int nv = 0; nv < nFeatures; nv++) {
-	f_max[nv] = std::max(f_max[nv],indata[lev].max(nv));
-	f_min[nv] = std::min(f_min[nv],indata[lev].min(nv));
+        f_max[nv] = std::max(f_max[nv], indata[lev].max(nv));
+        f_min[nv] = std::min(f_min[nv], indata[lev].min(nv));
       }
       for (int nv = 0; nv < nTargets; nv++) {
-	t_max[nv] = std::max(t_max[nv],indata[lev].max(nv+nFeatures));
-	t_min[nv] = std::min(t_min[nv],indata[lev].min(nv+nFeatures));
+        t_max[nv] = std::max(t_max[nv], indata[lev].max(nv + nFeatures));
+        t_min[nv] = std::min(t_min[nv], indata[lev].min(nv + nFeatures));
       }
       if (lev == Nlev - 1) {
-	for (int nv = 0; nv < nFeatures; nv++) {
-	  Print() << "f_max[" << nv << "] = " << f_max[nv] << std::endl;
-	  Print() << "f_min[" << nv << "] = " << f_min[nv] << std::endl;
-	}
-	for (int nv = 0; nv < nTargets; nv++) {
-	  Print() << "t_max[" << nv << "] = " << t_max[nv] << std::endl;
-	  Print() << "t_min[" << nv << "] = " << t_min[nv] << std::endl;
-	}
+        for (int nv = 0; nv < nFeatures; nv++) {
+          Print() << "f_max[" << nv << "] = " << f_max[nv] << std::endl;
+          Print() << "f_min[" << nv << "] = " << f_min[nv] << std::endl;
+        }
+        for (int nv = 0; nv < nTargets; nv++) {
+          Print() << "t_max[" << nv << "] = " << t_max[nv] << std::endl;
+          Print() << "t_min[" << nv << "] = " << t_min[nv] << std::endl;
+        }
       }
     }
     Vector<amrex::Gpu::ManagedVector<Real>> training_batches, target_batches;
     Vector<int> ncell_batch;
-    
+
     for (int lev = minLevel; lev < Nlev; lev++) {
-      for (MFIter mfi(indata[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)  {
-	const Box& bx = mfi.tilebox();
+      for (MFIter mfi(indata[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.tilebox();
 
-	Array4<Real> const& training = indata[lev].array(mfi,0);
-	Array4<Real> const& target = indata[lev].array(mfi,nFeatures);
-	
-	const IntVect bx_lo = bx.smallEnd();
-	const IntVect nbox = bx.size();
+        Array4<Real> const& training = indata[lev].array(mfi, 0);
+        Array4<Real> const& target = indata[lev].array(mfi, nFeatures);
+
+        const IntVect bx_lo = bx.smallEnd();
+        const IntVect nbox = bx.size();
 #if AMREX_SPACEDIM == 2
-	int ncell = nbox[0] * nbox[1];
+        int ncell = nbox[0] * nbox[1];
 #else
-	int ncell = nbox[0] * nbox[1] * nbox[2];
+        int ncell = nbox[0] * nbox[1] * nbox[2];
 #endif
-	
-	// create a temporary array to store MultiFab data
-	// this is needed to create a tensor from a contiguous block of memory
-	amrex::Gpu::ManagedVector<Real> trainingVec(ncell*nFeatures);
-	amrex::Gpu::ManagedVector<Real> targetVec(ncell*nTargets);
-       
-	Real* AMREX_RESTRICT trainingPtr = trainingVec.dataPtr();
-	Real* AMREX_RESTRICT targetPtr = targetVec.dataPtr();
-	AMREX_PARALLEL_FOR_3D ( bx, i, j, k,
-				{
-				  int ii = i - bx_lo[0];
-				  int jj = j - bx_lo[1];
-				  int index = jj*nbox[0] + ii;
-#if AMREX_SPACEDIM == 3
-				  int kk = k - bx_lo[2];
-				  index += kk*nbox[0]*nbox[1];
-#endif
-				  
-				  for (int n = 0; n < nFeatures; n++) {
-				    trainingPtr[index*nFeatures + n] = -1.0 + 2.0*(training(i, j, k, n)-f_min[n])/(f_max[n]-f_min[n]);
-				  }
-				  for (int n = 0; n < nTargets; n++) {
-				    targetPtr[index*nTargets + n] = -1.0 + 2.0*(target(i,j,k,n)-t_min[n])/(t_max[n]-t_min[n]);
-				  }
-				});
-	
 
-	ncell_batch.push_back(ncell);
-	training_batches.push_back(trainingVec);
-	target_batches.push_back(targetVec);
-	
+        // create a temporary array to store MultiFab data
+        // this is needed to create a tensor from a contiguous block of memory
+        amrex::Gpu::ManagedVector<Real> trainingVec(ncell * nFeatures);
+        amrex::Gpu::ManagedVector<Real> targetVec(ncell * nTargets);
+
+        Real* AMREX_RESTRICT trainingPtr = trainingVec.dataPtr();
+        Real* AMREX_RESTRICT targetPtr = targetVec.dataPtr();
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
+          int ii = i - bx_lo[0];
+          int jj = j - bx_lo[1];
+          int index = jj * nbox[0] + ii;
+#if AMREX_SPACEDIM == 3
+          int kk = k - bx_lo[2];
+          index += kk * nbox[0] * nbox[1];
+#endif
+
+          for (int n = 0; n < nFeatures; n++) {
+            trainingPtr[index * nFeatures + n] =
+              -1.0 +
+              2.0 * (training(i, j, k, n) - f_min[n]) / (f_max[n] - f_min[n]);
+          }
+          for (int n = 0; n < nTargets; n++) {
+            targetPtr[index * nTargets + n] =
+              -1.0 +
+              2.0 * (target(i, j, k, n) - t_min[n]) / (t_max[n] - t_min[n]);
+          }
+        });
+
+        ncell_batch.push_back(ncell);
+        training_batches.push_back(trainingVec);
+        target_batches.push_back(targetVec);
       }
     }
-    
+
     if (training_batches.empty()) {
       amrex::Abort("Some processes have no data!");
     }
-    
+
     int num_batches = training_batches.size();
     Vector<int> indices(num_batches);
     for (int i = 0; i < num_batches; i++) {
@@ -223,41 +229,44 @@ main (int   argc,
     // Shuffle the indices
     std::shuffle(indices.begin(), indices.end(), g);
 
-
-    std::cout << "Number of batches on process " << ParallelDescriptor::MyProc() << " = " << num_batches << std::endl;
+    std::cout << "Number of batches on process " << ParallelDescriptor::MyProc()
+              << " = " << num_batches << std::endl;
 
     Real split = 0.7;
-    int num_train = (int)(split*num_batches);
-    int num_val = num_batches-num_train;
-    Vector<amrex::Gpu::ManagedVector<Real>> features_t(num_train), target_t(num_train);
-    Vector<amrex::Gpu::ManagedVector<Real>> features_e(num_val), target_e(num_val);
+    int num_train = (int)(split * num_batches);
+    int num_val = num_batches - num_train;
+    Vector<amrex::Gpu::ManagedVector<Real>> features_t(num_train),
+      target_t(num_train);
+    Vector<amrex::Gpu::ManagedVector<Real>> features_e(num_val),
+      target_e(num_val);
     Vector<int> ncell_t(num_train);
     Vector<int> ncell_e(num_val);
-    
-    
+
     for (int i = 0; i < num_train; i++) {
       features_t[i] = training_batches[indices[i]];
       target_t[i] = target_batches[indices[i]];
       ncell_t[i] = ncell_batch[indices[i]];
     }
     for (int i = num_train; i < num_batches; i++) {
-      features_e[i-num_train] = training_batches[indices[i]];
-      target_e[i-num_train] = target_batches[indices[i]];
-      ncell_e[i-num_train] = ncell_batch[indices[i]];
+      features_e[i - num_train] = training_batches[indices[i]];
+      target_e[i - num_train] = target_batches[indices[i]];
+      ncell_e[i - num_train] = ncell_batch[indices[i]];
     }
-    
-    Real learning_rate = 1e-3; pp.query("learning_rate",learning_rate);
-    
-    //at this point we have a bunch of distributed tensors, and a model
 
+    Real learning_rate = 1e-3;
+    pp.query("learning_rate", learning_rate);
+
+    // at this point we have a bunch of distributed tensors, and a model
 
     // Training loop
     Vector<int> train_indices(num_train);
-    for (int i = 0; i < num_train; i++) train_indices[i] = i;
+    for (int i = 0; i < num_train; i++)
+      train_indices[i] = i;
 
     torch::Tensor loss;
-    Real alpha = 0.01; pp.query("alpha",alpha);
-    Real beta = 1.0-alpha;
+    Real alpha = 0.01;
+    pp.query("alpha", alpha);
+    Real beta = 1.0 - alpha;
     Real prev_epoch_training_loss, prev_epoch_validation_loss;
 
     // Create an optimizer (other options SGD, LBFGS)
@@ -273,26 +282,27 @@ main (int   argc,
     );*/
     auto optimizer = torch::optim::Adam(model->parameters(), learning_rate);
 
-    
     for (int epoch = 0; epoch < nEpochs; ++epoch) {
       // Shuffle training batches every epoch
-      //std::shuffle(train_indices.begin(), train_indices.end(), g);
-   
-      Real epoch_training_loss = 0.0;
-      Real epoch_validation_loss = 0.0;      
-      for (int nb = 0; nb < num_train; nb++) {
-        //int ib = train_indices[nb];  // shuffled index
-	torch::Tensor train_input = torch::from_blob(features_t[nb].dataPtr(),{ncell_t[nb],nFeatures},tensoropt);
-	torch::Tensor train_target = torch::from_blob(target_t[nb].dataPtr(),{ncell_t[nb],nTargets},tensoropt);
-	
-	model->train();
+      // std::shuffle(train_indices.begin(), train_indices.end(), g);
 
-	auto output = model->forward(train_input);
-	auto mse_loss = torch::mse_loss(output, train_target);
-	auto reg_loss = compute_regularisation(*model);
-	
-	// Forward pass
-	loss = beta*mse_loss + alpha * reg_loss;
+      Real epoch_training_loss = 0.0;
+      Real epoch_validation_loss = 0.0;
+      for (int nb = 0; nb < num_train; nb++) {
+        // int ib = train_indices[nb];  // shuffled index
+        torch::Tensor train_input = torch::from_blob(
+          features_t[nb].dataPtr(), {ncell_t[nb], nFeatures}, tensoropt);
+        torch::Tensor train_target = torch::from_blob(
+          target_t[nb].dataPtr(), {ncell_t[nb], nTargets}, tensoropt);
+
+        model->train();
+
+        auto output = model->forward(train_input);
+        auto mse_loss = torch::mse_loss(output, train_target);
+        auto reg_loss = compute_regularisation(*model);
+
+        // Forward pass
+        loss = beta * mse_loss + alpha * reg_loss;
         /*if (reg_mode == 0) {
            auto reg_loss = compute_regularisation(*model); // normalized
            loss = beta * mse_loss + alpha * reg_loss;
@@ -300,67 +310,66 @@ main (int   argc,
         // Adam already applies L2 via weight_decay
            loss = mse_loss;
         }*/
-	
-	// Compute loss
-	//auto loss = custom_loss(output, train_target, *model);
-	// Backward pass and optimization step
-	optimizer.zero_grad();
-	loss.backward();
 
-	/*for (auto& param : model->parameters()) {
-    	    ParallelDescriptor::ReduceRealSum(param.grad().data_ptr<Real>(), param.numel());
-    	    param.grad().data() /= ParallelDescriptor::NProcs();  // <-- .data() here
-	}*/
+        // Compute loss
+        // auto loss = custom_loss(output, train_target, *model);
+        // Backward pass and optimization step
+        optimizer.zero_grad();
+        loss.backward();
 
-	optimizer.step();
-		
+        /*for (auto& param : model->parameters()) {
+                ParallelDescriptor::ReduceRealSum(param.grad().data_ptr<Real>(),
+        param.numel()); param.grad().data() /= ParallelDescriptor::NProcs();  //
+        <-- .data() here
+        }*/
 
-	epoch_training_loss += loss.item<Real>();	  
+        optimizer.step();
 
+        epoch_training_loss += loss.item<Real>();
       }
       for (int nb = 0; nb < num_val; nb++) {
-	torch::Tensor val_input = torch::from_blob(features_e[nb].dataPtr(),{ncell_e[nb],nFeatures},tensoropt);
-	torch::Tensor val_target = torch::from_blob(target_e[nb].dataPtr(),{ncell_e[nb],nTargets},tensoropt);
+        torch::Tensor val_input = torch::from_blob(
+          features_e[nb].dataPtr(), {ncell_e[nb], nFeatures}, tensoropt);
+        torch::Tensor val_target = torch::from_blob(
+          target_e[nb].dataPtr(), {ncell_e[nb], nTargets}, tensoropt);
 
-	model->eval();
-	auto val_output = model->forward(val_input);
-	auto val_loss = torch::mse_loss(val_output, val_target);
-	epoch_validation_loss += val_loss.item<Real>();
-
+        model->eval();
+        auto val_output = model->forward(val_input);
+        auto val_loss = torch::mse_loss(val_output, val_target);
+        epoch_validation_loss += val_loss.item<Real>();
       }
 
       epoch_training_loss /= num_train;
       epoch_validation_loss /= num_val;
 
-
       prev_epoch_training_loss = epoch_training_loss;
       prev_epoch_validation_loss = epoch_validation_loss;
-      
+
       for (auto& param : model->parameters()) {
-	param = param.contiguous();
-	ParallelDescriptor::ReduceRealSum((param.grad()).data_ptr<Real>(),param.numel());
+        param = param.contiguous();
+        ParallelDescriptor::ReduceRealSum(
+          (param.grad()).data_ptr<Real>(), param.numel());
       }
       ParallelDescriptor::ReduceRealSum(epoch_training_loss);
       ParallelDescriptor::ReduceRealSum(epoch_validation_loss);
-      Print() << "Epoch [" << epoch+1 << "/" << nEpochs << "], Training Loss: " << epoch_training_loss << ", Validation Loss: " << epoch_validation_loss << std::endl;
+      Print() << "Epoch [" << epoch + 1 << "/" << nEpochs
+              << "], Training Loss: " << epoch_training_loss
+              << ", Validation Loss: " << epoch_validation_loss << std::endl;
     }
-    
-    
-    
+
     if (ParallelDescriptor::IOProcessor()) {
-      //save the model
-      torch::save(model,path);
-      std::string minmax_path="minmax"; pp.query("minmax_path",minmax_path);
+      // save the model
+      torch::save(model, path);
+      std::string minmax_path = "minmax";
+      pp.query("minmax_path", minmax_path);
       minmax_path += ".bin";
-      std::ofstream file(minmax_path,std::ios::binary);      
-      file.write((char*)f_min.dataPtr(),sizeof(Real)*nFeatures);
-      file.write((char*)f_max.dataPtr(),sizeof(Real)*nFeatures);
-      file.write((char*)t_min.dataPtr(),sizeof(Real)*nTargets);
-      file.write((char*)t_max.dataPtr(),sizeof(Real)*nTargets);
+      std::ofstream file(minmax_path, std::ios::binary);
+      file.write((char*)f_min.dataPtr(), sizeof(Real) * nFeatures);
+      file.write((char*)f_max.dataPtr(), sizeof(Real) * nFeatures);
+      file.write((char*)t_min.dataPtr(), sizeof(Real) * nTargets);
+      file.write((char*)t_max.dataPtr(), sizeof(Real) * nTargets);
       file.close();
     }
-    
-    
   }
   Finalize();
   return 0;

--- a/Src/optimalEstimatorTraining_TH.cpp
+++ b/Src/optimalEstimatorTraining_TH.cpp
@@ -2,10 +2,8 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile=f1 [options] \n\tOptions:\n";
@@ -15,11 +13,13 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
-torch::Tensor compute_regularisation(const torch::nn::Module& model) {
+torch::Tensor
+compute_regularisation(const torch::nn::Module& model)
+{
   torch::Tensor l2_reg = torch::tensor(0.0);
   for (const auto param : model.parameters()) {
     l2_reg += torch::sum(torch::pow(param, 2));
@@ -28,10 +28,10 @@ torch::Tensor compute_regularisation(const torch::nn::Module& model) {
 }
 /*
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
-split_data(torch::Tensor input, torch::Tensor target, amrex::Real train_ratio, amrex::Real val_ratio) {
-    auto dataset_size = input.size(0);
-    auto train_size = static_cast<int>(dataset_size * train_ratio);
-    auto val_size = dataset_size-train_size;
+split_data(torch::Tensor input, torch::Tensor target, amrex::Real train_ratio,
+amrex::Real val_ratio) { auto dataset_size = input.size(0); auto train_size =
+static_cast<int>(dataset_size * train_ratio); auto val_size =
+dataset_size-train_size;
 
     std::vector<int> indices(dataset_size);
     std::iota(indices.begin(), indices.end(), 0);
@@ -39,9 +39,11 @@ split_data(torch::Tensor input, torch::Tensor target, amrex::Real train_ratio, a
     std::mt19937 g(rd());
     std::shuffle(indices.begin(), indices.end(), g);
 
-    auto train_indices = torch::tensor(std::vector<int>(indices.begin(), indices.begin() + train_size), torch::kLong);
-    auto val_indices = torch::tensor(std::vector<int>(indices.begin() + train_size, indices.end()), torch::kLong);
-    
+    auto train_indices = torch::tensor(std::vector<int>(indices.begin(),
+indices.begin() + train_size), torch::kLong); auto val_indices =
+torch::tensor(std::vector<int>(indices.begin() + train_size, indices.end()),
+torch::kLong);
+
     auto train_input = input.index_select(0, train_indices);
     auto train_target = target.index_select(0, train_indices);
     auto val_input = input.index_select(0, val_indices);
@@ -52,72 +54,76 @@ split_data(torch::Tensor input, torch::Tensor target, amrex::Real train_ratio, a
 */
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     // Open plotfile header and create an amrData object pointing into it
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
-    // Set up input field data names, and destination components to load data upon read.
+    // Set up input field data names, and destination components to load data
+    // upon read.
     int nFeatures = pp.countval("features");
     int nTargets = pp.countval("targets");
     int nCompIn = nFeatures + nTargets;
-    int nEpochs = 1000; pp.query("nEpochs",nEpochs);
+    int nEpochs = 1000;
+    pp.query("nEpochs", nEpochs);
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
     Vector<std::string> features(nFeatures);
-    pp.getarr("features",features);
+    pp.getarr("features", features);
     Vector<std::string> targets(nTargets);
-    pp.getarr("targets",targets);
+    pp.getarr("targets", targets);
     for (int n = 0; n < nFeatures; n++) {
       inNames[n] = features[n];
       destFillComps[n] = n;
     }
     for (int n = 0; n < nTargets; n++) {
-      inNames[n+nFeatures] = targets[n];
-      destFillComps[n+nFeatures] = n+nFeatures;
+      inNames[n + nFeatures] = targets[n];
+      destFillComps[n + nFeatures] = n + nFeatures;
     }
-    Vector<Real> f_scaling(nFeatures,1.0);
-    pp.queryarr("f_scaling",f_scaling);
-    Vector<Real> t_scaling(nTargets,1.0);
-    pp.queryarr("t_scaling",t_scaling); 
-    
+    Vector<Real> f_scaling(nFeatures, 1.0);
+    pp.queryarr("f_scaling", f_scaling);
+    Vector<Real> t_scaling(nTargets, 1.0);
+    pp.queryarr("t_scaling", t_scaling);
+
     // Loop over AMR levels in the plotfile, read the data and do work
     int finestLevel = amrData.FinestLevel();
     int minLevel = 0;
-    pp.query("finestLevel",finestLevel);
-    pp.query("minLevel",minLevel);
-    
-    std::string path="optimal_estimator"; pp.query("model_path",path);    
+    pp.query("finestLevel", finestLevel);
+    pp.query("minLevel", minLevel);
+
+    std::string path = "optimal_estimator";
+    pp.query("model_path", path);
     path += ".pt";
     int Nlev = finestLevel + 1;
     const int nGrow = 0;
     int n_layers = pp.countval("neurons");
-    Vector<int> neurons(n_layers); pp.getarr("neurons",neurons);
-    torch::manual_seed(42); //ensure same seeding used each time
+    Vector<int> neurons(n_layers);
+    pp.getarr("neurons", neurons);
+    torch::manual_seed(42); // ensure same seeding used each time
 
     auto dtype0 = torch::kDouble;
 
-    auto model = std::make_shared<Net>(nFeatures,neurons,nTargets);
-    //Net model(nFeatures,n_neurons,nTargets);
-    
+    auto model = std::make_shared<Net>(nFeatures, neurons, nTargets);
+    // Net model(nFeatures,n_neurons,nTargets);
+
 #ifdef AMREX_USE_CUDA
     torch::Device device0(torch::kCUDA);
     model.to(device0);
@@ -125,117 +131,120 @@ main (int   argc,
     // set tensor options
     auto tensoropt = torch::TensorOptions().dtype(dtype0).device(device0);
 #else
-    auto tensoropt = torch::TensorOptions().dtype(dtype0);//.device(device0);
+    auto tensoropt = torch::TensorOptions().dtype(dtype0); //.device(device0);
 #endif
-    
-    Vector<Real> f_max(nFeatures,-1e100);
-    Vector<Real> f_min(nFeatures,1e100);
-    Vector<Real> t_max(nTargets,-1e100);
-    Vector<Real> t_min(nTargets,1e100);
-    int batch_size = -1; pp.query("batch_size",batch_size);
+
+    Vector<Real> f_max(nFeatures, -1e100);
+    Vector<Real> f_min(nFeatures, 1e100);
+    Vector<Real> t_max(nTargets, -1e100);
+    Vector<Real> t_min(nTargets, 1e100);
+    int batch_size = -1;
+    pp.query("batch_size", batch_size);
     Vector<MultiFab> indata(Nlev);
-    
+
     for (int lev = minLevel; lev < Nlev; lev++) {
-      //Get the array of boxes for this level
+      // Get the array of boxes for this level
       BoxArray ba = amrData.boxArray(lev);
       if (batch_size > 0) {
-	//IntVect boxshape = {AMREX_D_DECL(box_size,box_size,box_size)};
-	//ba.minmaxSize(boxshape,boxshape); //everything comes in in equally sized boxes (box_size^AMREX_SPACEDIM)
-	//batch_size += ba.size();
-	ba.maxSize(batch_size);
+        // IntVect boxshape = {AMREX_D_DECL(box_size,box_size,box_size)};
+        // ba.minmaxSize(boxshape,boxshape); //everything comes in in equally
+        // sized boxes (box_size^AMREX_SPACEDIM) batch_size += ba.size();
+        ba.maxSize(batch_size);
       }
-      //Distribution mapping i.e. how are boxes distributed across processors
+      // Distribution mapping i.e. how are boxes distributed across processors
       const DistributionMapping dm(ba);
-      //Vector<torch::Tensor> lev_batches(amrData.boxArray(lev).size());
-      
-      indata[lev].define(ba,dm,nCompIn,nGrow);
+      // Vector<torch::Tensor> lev_batches(amrData.boxArray(lev).size());
+
+      indata[lev].define(ba, dm, nCompIn, nGrow);
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata[lev],lev,inNames,destFillComps); //magic IO call
+      amrData.FillVar(indata[lev], lev, inNames, destFillComps); // magic IO
+                                                                 // call
       Print() << "Data has been read for level " << lev << std::endl;
-      
+
       for (int nv = 0; nv < nFeatures; nv++) {
-	f_max[nv] = std::max(f_max[nv],indata[lev].max(nv));
-	f_min[nv] = std::min(f_max[nv],indata[lev].min(nv));
+        f_max[nv] = std::max(f_max[nv], indata[lev].max(nv));
+        f_min[nv] = std::min(f_max[nv], indata[lev].min(nv));
       }
       for (int nv = 0; nv < nTargets; nv++) {
-	t_max[nv] = std::max(t_max[nv],indata[lev].max(nv+nFeatures));
-	t_min[nv] = std::min(t_max[nv],indata[lev].min(nv+nFeatures));
+        t_max[nv] = std::max(t_max[nv], indata[lev].max(nv + nFeatures));
+        t_min[nv] = std::min(t_max[nv], indata[lev].min(nv + nFeatures));
       }
       if (lev == Nlev - 1) {
-	for (int nv = 0; nv < nFeatures; nv++) {
-	  Print() << "f_max[" << nv << "] = " << f_max[nv] << std::endl;
-	  Print() << "f_min[" << nv << "] = " << f_min[nv] << std::endl;
-	}
-	for (int nv = 0; nv < nTargets; nv++) {
-	  Print() << "t_max[" << nv << "] = " << t_max[nv] << std::endl;
-	  Print() << "t_min[" << nv << "] = " << t_min[nv] << std::endl;
-	}
+        for (int nv = 0; nv < nFeatures; nv++) {
+          Print() << "f_max[" << nv << "] = " << f_max[nv] << std::endl;
+          Print() << "f_min[" << nv << "] = " << f_min[nv] << std::endl;
+        }
+        for (int nv = 0; nv < nTargets; nv++) {
+          Print() << "t_max[" << nv << "] = " << t_max[nv] << std::endl;
+          Print() << "t_min[" << nv << "] = " << t_min[nv] << std::endl;
+        }
       }
     }
     Vector<amrex::Gpu::ManagedVector<Real>> training_batches, target_batches;
     Vector<int> ncell_batch;
-    
+
     for (int lev = minLevel; lev < Nlev; lev++) {
-      for (MFIter mfi(indata[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)  {
-	const Box& bx = mfi.tilebox();
+      for (MFIter mfi(indata[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.tilebox();
 
-	Array4<Real> const& training = indata[lev].array(mfi,0);
-	Array4<Real> const& target = indata[lev].array(mfi,nFeatures);
-	
-	const IntVect bx_lo = bx.smallEnd();
-	const IntVect nbox = bx.size();
+        Array4<Real> const& training = indata[lev].array(mfi, 0);
+        Array4<Real> const& target = indata[lev].array(mfi, nFeatures);
+
+        const IntVect bx_lo = bx.smallEnd();
+        const IntVect nbox = bx.size();
 #if AMREX_SPACEDIM == 2
-	int ncell = nbox[0] * nbox[1];
+        int ncell = nbox[0] * nbox[1];
 #else
-	int ncell = nbox[0] * nbox[1] * nbox[2];
+        int ncell = nbox[0] * nbox[1] * nbox[2];
 #endif
-	
-	// create a temporary array to store MultiFab data
-	// this is needed to create a tensor from a contiguous block of memory
-	amrex::Gpu::ManagedVector<Real> trainingVec(ncell*nFeatures);
-	amrex::Gpu::ManagedVector<Real> targetVec(ncell*nTargets);
-       
-	Real* AMREX_RESTRICT trainingPtr = trainingVec.dataPtr();
-	Real* AMREX_RESTRICT targetPtr = targetVec.dataPtr();
-	AMREX_PARALLEL_FOR_3D ( bx, i, j, k,
-				{
-				  int ii = i - bx_lo[0];
-				  int jj = j - bx_lo[1];
-				  int index = jj*nbox[0] + ii;
-#if AMREX_SPACEDIM == 3
-				  int kk = k - bx_lo[2];
-				  index += kk*nbox[0]*nbox[1];
-#endif
-				  
-				  for (int n = 0; n < nFeatures; n++) {
-				    trainingPtr[index*nFeatures + n] = -1.0 + 2.0*(training(i, j, k, n)-f_min[n])/(f_max[n]-f_min[n]);
-				  }
-				  for (int n = 0; n < nTargets; n++) {
-				    targetPtr[index*nTargets + n] = -1.0 + 2.0*(target(i,j,k,n)-t_min[n])/(t_max[n]-t_min[n]);
-				  }
-				});
-	
 
-	ncell_batch.push_back(ncell);
-	training_batches.push_back(trainingVec);
-	target_batches.push_back(targetVec);
-	
+        // create a temporary array to store MultiFab data
+        // this is needed to create a tensor from a contiguous block of memory
+        amrex::Gpu::ManagedVector<Real> trainingVec(ncell * nFeatures);
+        amrex::Gpu::ManagedVector<Real> targetVec(ncell * nTargets);
+
+        Real* AMREX_RESTRICT trainingPtr = trainingVec.dataPtr();
+        Real* AMREX_RESTRICT targetPtr = targetVec.dataPtr();
+        AMREX_PARALLEL_FOR_3D(bx, i, j, k, {
+          int ii = i - bx_lo[0];
+          int jj = j - bx_lo[1];
+          int index = jj * nbox[0] + ii;
+#if AMREX_SPACEDIM == 3
+          int kk = k - bx_lo[2];
+          index += kk * nbox[0] * nbox[1];
+#endif
+
+          for (int n = 0; n < nFeatures; n++) {
+            trainingPtr[index * nFeatures + n] =
+              -1.0 +
+              2.0 * (training(i, j, k, n) - f_min[n]) / (f_max[n] - f_min[n]);
+          }
+          for (int n = 0; n < nTargets; n++) {
+            targetPtr[index * nTargets + n] =
+              -1.0 +
+              2.0 * (target(i, j, k, n) - t_min[n]) / (t_max[n] - t_min[n]);
+          }
+        });
+
+        ncell_batch.push_back(ncell);
+        training_batches.push_back(trainingVec);
+        target_batches.push_back(targetVec);
       }
     }
-    
+
     if (training_batches.empty()) {
       amrex::Abort("Some processes have no data!");
     }
-    
+
     int num_batches = training_batches.size();
     /*
     //pick a random number (<num_batches)
     std::random_device rd;         // Obtain a random number from hardware
     std::mt19937 gen(rd());        // Seed the generator
-    
+
     // Create a uniform integer distribution
     std::uniform_int_distribution<> dis(0, num_batches-1);
-    
+
     // Generate a random number within the range
     int r_batches = dis(gen);
     */
@@ -250,157 +259,169 @@ main (int   argc,
     // Shuffle the indices
     std::shuffle(indices.begin(), indices.end(), g);
 
-
-    std::cout << "Number of batches on process " << ParallelDescriptor::MyProc() << " = " << num_batches << std::endl;
+    std::cout << "Number of batches on process " << ParallelDescriptor::MyProc()
+              << " = " << num_batches << std::endl;
 
     Real split = 0.7;
-    int num_train = (int)(split*num_batches);
-    int num_val = num_batches-num_train;
-    Vector<amrex::Gpu::ManagedVector<Real>> features_t(num_train), target_t(num_train);
-    Vector<amrex::Gpu::ManagedVector<Real>> features_e(num_val), target_e(num_val);
+    int num_train = (int)(split * num_batches);
+    int num_val = num_batches - num_train;
+    Vector<amrex::Gpu::ManagedVector<Real>> features_t(num_train),
+      target_t(num_train);
+    Vector<amrex::Gpu::ManagedVector<Real>> features_e(num_val),
+      target_e(num_val);
     Vector<int> ncell_t(num_train);
     Vector<int> ncell_e(num_val);
-    
-    
+
     for (int i = 0; i < num_train; i++) {
       features_t[i] = training_batches[indices[i]];
       target_t[i] = target_batches[indices[i]];
       ncell_t[i] = ncell_batch[indices[i]];
     }
     for (int i = num_train; i < num_batches; i++) {
-      features_e[i-num_train] = training_batches[indices[i]];
-      target_e[i-num_train] = target_batches[indices[i]];
-      ncell_e[i-num_train] = ncell_batch[indices[i]];
+      features_e[i - num_train] = training_batches[indices[i]];
+      target_e[i - num_train] = target_batches[indices[i]];
+      ncell_e[i - num_train] = ncell_batch[indices[i]];
     }
-    
-    Real learning_rate = 1e-3; pp.query("learning_rate",learning_rate);
-    
-    //at this point we have a bunch of distributed tensors, and a model
-    // Create an optimizer
-    //auto optimizer = torch::optim::SGD(model->parameters(), learning_rate);
+
+    Real learning_rate = 1e-3;
+    pp.query("learning_rate", learning_rate);
+
+    // at this point we have a bunch of distributed tensors, and a model
+    //  Create an optimizer
+    // auto optimizer = torch::optim::SGD(model->parameters(), learning_rate);
     auto optimizer = torch::optim::Adam(model->parameters(), learning_rate);
-    //auto optimizer = torch::optim::LBFGS(model->parameters(), learning_rate);
+    // auto optimizer = torch::optim::LBFGS(model->parameters(), learning_rate);
 
     // Training loop
     torch::Tensor loss;
-    Real alpha = 0.01; pp.query("alpha",alpha);
-    Real beta = 1.0-alpha;
+    Real alpha = 0.01;
+    pp.query("alpha", alpha);
+    Real beta = 1.0 - alpha;
     Real prev_epoch_training_loss, prev_epoch_validation_loss;
 
-    
     for (int epoch = 0; epoch < nEpochs; ++epoch) {
       Real epoch_training_loss = 0.0;
-      Real epoch_validation_loss = 0.0;      
+      Real epoch_validation_loss = 0.0;
       int counter = 0;
       for (int nb = 0; nb < num_train; nb++) {
-	torch::Tensor train_input = torch::from_blob(features_t[nb].dataPtr(),{ncell_t[nb],nFeatures},tensoropt);
-	torch::Tensor train_target = torch::from_blob(target_t[nb].dataPtr(),{ncell_t[nb],nTargets},tensoropt);
+        torch::Tensor train_input = torch::from_blob(
+          features_t[nb].dataPtr(), {ncell_t[nb], nFeatures}, tensoropt);
+        torch::Tensor train_target = torch::from_blob(
+          target_t[nb].dataPtr(), {ncell_t[nb], nTargets}, tensoropt);
 
-	//torch::Tensor val_input = torch::from_blob(features_e[nb].dataPtr(),{ncell_e[nb],nFeatures},tensoropt);
-	//torch::Tensor val_target = torch::from_blob(target_e[nb].dataPtr(),{ncell_e[nb],nTargets},tensoropt);
-	
-	//torch::Tensor training_batch = torch::from_blob(training_batches[nb].dataPtr(),{ncell_batch[nb],nFeatures},tensoropt);
-	//torch::Tensor target_batch = torch::from_blob(target_batches[nb].dataPtr(),{ncell_batch[nb],nTargets},tensoropt);
-	
-	//auto [train_input, train_target, val_input, val_target] = split_data(training_batch, target_batch, 0.7, 0.3);
-	//if (torch::std(train_target).item<Real>() < 0.001) {
-	//  counter++;
-	//  continue;
-	//}
-	//Print() << torch::std(train_target) << std::endl;
-							 
-	//auto [train_input,train_target] = removeConstantRows(train_input_all,train_target_all);
-	
-	model->train();
+        // torch::Tensor val_input =
+        // torch::from_blob(features_e[nb].dataPtr(),{ncell_e[nb],nFeatures},tensoropt);
+        // torch::Tensor val_target =
+        // torch::from_blob(target_e[nb].dataPtr(),{ncell_e[nb],nTargets},tensoropt);
 
-	auto output = model->forward(train_input);
-	auto mse_loss = torch::mse_loss(output, train_target);
-	auto reg_loss = compute_regularisation(*model);
-	
-	// Forward pass
-	//if (!loss.defined()) {
-	loss = beta*mse_loss + alpha * reg_loss;
-	//}
-	
-	// Compute loss
-	//auto loss = custom_loss(output, train_target, *model);
-	// Backward pass and optimization step
-	optimizer.zero_grad();
-	/*auto trHinv= compute_sum_inv_d2loss_dw2(loss,*model);
-	int n_params = model->parameters().size();
-	auto gamma = n_params*(1-trHinv/(2.0*(reg_loss + trHinv)));
-	auto alpha = gamma/(2.0*reg_loss);
-	auto beta = (nTargets-gamma)/(2.0*mse_loss);
-	loss = beta * mse_loss + alpha * reg_loss;*/
-	loss.backward();
-	optimizer.step();
-		
-	//if (nb == num_batches - 1) { //just compute on the last batch
-	epoch_training_loss += loss.item<Real>();	  
-	// Validation phase
-	//}
+        // torch::Tensor training_batch =
+        // torch::from_blob(training_batches[nb].dataPtr(),{ncell_batch[nb],nFeatures},tensoropt);
+        // torch::Tensor target_batch =
+        // torch::from_blob(target_batches[nb].dataPtr(),{ncell_batch[nb],nTargets},tensoropt);
+
+        // auto [train_input, train_target, val_input, val_target] =
+        // split_data(training_batch, target_batch, 0.7, 0.3); if
+        // (torch::std(train_target).item<Real>() < 0.001) {
+        //   counter++;
+        //   continue;
+        // }
+        // Print() << torch::std(train_target) << std::endl;
+
+        // auto [train_input,train_target] =
+        // removeConstantRows(train_input_all,train_target_all);
+
+        model->train();
+
+        auto output = model->forward(train_input);
+        auto mse_loss = torch::mse_loss(output, train_target);
+        auto reg_loss = compute_regularisation(*model);
+
+        // Forward pass
+        // if (!loss.defined()) {
+        loss = beta * mse_loss + alpha * reg_loss;
+        //}
+
+        // Compute loss
+        // auto loss = custom_loss(output, train_target, *model);
+        // Backward pass and optimization step
+        optimizer.zero_grad();
+        /*auto trHinv= compute_sum_inv_d2loss_dw2(loss,*model);
+        int n_params = model->parameters().size();
+        auto gamma = n_params*(1-trHinv/(2.0*(reg_loss + trHinv)));
+        auto alpha = gamma/(2.0*reg_loss);
+        auto beta = (nTargets-gamma)/(2.0*mse_loss);
+        loss = beta * mse_loss + alpha * reg_loss;*/
+        loss.backward();
+        optimizer.step();
+
+        // if (nb == num_batches - 1) { //just compute on the last batch
+        epoch_training_loss += loss.item<Real>();
+        // Validation phase
+        //}
       }
       for (int nb = 0; nb < num_val; nb++) {
-	torch::Tensor val_input = torch::from_blob(features_e[nb].dataPtr(),{ncell_e[nb],nFeatures},tensoropt);
-	torch::Tensor val_target = torch::from_blob(target_e[nb].dataPtr(),{ncell_e[nb],nTargets},tensoropt);
+        torch::Tensor val_input = torch::from_blob(
+          features_e[nb].dataPtr(), {ncell_e[nb], nFeatures}, tensoropt);
+        torch::Tensor val_target = torch::from_blob(
+          target_e[nb].dataPtr(), {ncell_e[nb], nTargets}, tensoropt);
 
-	model->eval();
-	auto val_output = model->forward(val_input);
-	auto val_loss = torch::mse_loss(val_output, val_target);
-	epoch_validation_loss += val_loss.item<Real>();
-
+        model->eval();
+        auto val_output = model->forward(val_input);
+        auto val_loss = torch::mse_loss(val_output, val_target);
+        epoch_validation_loss += val_loss.item<Real>();
       }
-      //Print() << num_batches << std::endl;
-      //Print() << counter << std::endl;
+      // Print() << num_batches << std::endl;
+      // Print() << counter << std::endl;
       epoch_training_loss /= split;
-      epoch_validation_loss /= 1-split;
+      epoch_validation_loss /= 1 - split;
       /*
       if (epoch > 0) {
-	//we're starting to overfit, bias the regularisation more
-	if (prev_epoch_training_loss > epoch_training_loss && prev_epoch_validation_loss < epoch_validation_loss) {
-	  Print() << "Overfitting, emphasising regularisation... " << std::endl;
-	  beta *= 0.9;
-	  alpha = 1.0-beta;
-	} else {
-	  Print() << "Not overfitting, emphasising fitting... " << std::endl;
-	  alpha *= 0.9;
-	  beta = 1.0-beta;
-	}
+  //we're starting to overfit, bias the regularisation more
+  if (prev_epoch_training_loss > epoch_training_loss &&
+  prev_epoch_validation_loss < epoch_validation_loss) { Print() << "Overfitting,
+  emphasising regularisation... " << std::endl; beta *= 0.9; alpha = 1.0-beta;
+  } else {
+    Print() << "Not overfitting, emphasising fitting... " << std::endl;
+    alpha *= 0.9;
+    beta = 1.0-beta;
+  }
       }
       */
-      //alpha -= alpha/(Real)nEpochs;
-      //beta += beta/(Real)nEpochs;
+      // alpha -= alpha/(Real)nEpochs;
+      // beta += beta/(Real)nEpochs;
       prev_epoch_training_loss = epoch_training_loss;
       prev_epoch_validation_loss = epoch_validation_loss;
-      
+
       for (auto& param : model->parameters()) {
-	param = param.contiguous();
-	ParallelDescriptor::ReduceRealSum((param.grad()).data_ptr<Real>(),param.numel());
+        param = param.contiguous();
+        ParallelDescriptor::ReduceRealSum(
+          (param.grad()).data_ptr<Real>(), param.numel());
       }
       ParallelDescriptor::ReduceRealSum(epoch_training_loss);
       ParallelDescriptor::ReduceRealSum(epoch_validation_loss);
-      Print() << "Epoch [" << epoch+1 << "/" << nEpochs << "], Training Loss: " << epoch_training_loss << ", Validation Loss: " << epoch_validation_loss << std::endl;
-     
-      //std::cout << "Process: " << ParallelDescriptor::MyProc() << ", Epoch [" << epoch << "/" << nEpochs << "], Training Loss: " << epoch_training_loss << ", Validation Loss: " << epoch_validation_loss << std::endl;
-      
+      Print() << "Epoch [" << epoch + 1 << "/" << nEpochs
+              << "], Training Loss: " << epoch_training_loss
+              << ", Validation Loss: " << epoch_validation_loss << std::endl;
+
+      // std::cout << "Process: " << ParallelDescriptor::MyProc() << ", Epoch ["
+      // << epoch << "/" << nEpochs << "], Training Loss: " <<
+      // epoch_training_loss << ", Validation Loss: " << epoch_validation_loss
+      // << std::endl;
     }
-    
-    
-    
+
     if (ParallelDescriptor::IOProcessor()) {
-      //save the model
-      torch::save(model,path);
-      std::string minmax_path="minmax"; pp.query("minmax_path",minmax_path);
+      // save the model
+      torch::save(model, path);
+      std::string minmax_path = "minmax";
+      pp.query("minmax_path", minmax_path);
       minmax_path += ".bin";
-      std::ofstream file(minmax_path,std::ios::binary);      
-      file.write((char*)f_min.dataPtr(),sizeof(Real)*nFeatures);
-      file.write((char*)f_max.dataPtr(),sizeof(Real)*nFeatures);
-      file.write((char*)t_min.dataPtr(),sizeof(Real)*nTargets);
-      file.write((char*)t_max.dataPtr(),sizeof(Real)*nTargets);
+      std::ofstream file(minmax_path, std::ios::binary);
+      file.write((char*)f_min.dataPtr(), sizeof(Real) * nFeatures);
+      file.write((char*)f_max.dataPtr(), sizeof(Real) * nFeatures);
+      file.write((char*)t_min.dataPtr(), sizeof(Real) * nTargets);
+      file.write((char*)t_max.dataPtr(), sizeof(Real) * nTargets);
       file.close();
     }
-    
-    
   }
   Finalize();
   return 0;

--- a/Src/partStream.cpp
+++ b/Src/partStream.cpp
@@ -4,65 +4,63 @@
 #include <StreamPC.H>
 
 using namespace amrex;
-static
-Vector<Vector<Real>>
-GetSeedLocations (const StreamParticleContainer& spc, Vector<int>& faceData)
+static Vector<Vector<Real>>
+GetSeedLocations(const StreamParticleContainer& spc, Vector<int>& faceData)
 {
   Vector<Vector<Real>> locs;
 
   ParmParse pp;
-  int nc=pp.countval("oneSeedPerCell");
-  int ni=pp.countval("isoFile");
-  int ns=pp.countval("seedLoc");
-  int nrL=pp.countval("seedRakeL");
-  int nrR=pp.countval("seedRakeR");
-  AMREX_ALWAYS_ASSERT((nc>0) ^ ((ni>0) ^ ((ns>0) ^ ((nrL>0) && nrR>0))));
-  if (nc>0)
-  {
+  int nc = pp.countval("oneSeedPerCell");
+  int ni = pp.countval("isoFile");
+  int ns = pp.countval("seedLoc");
+  int nrL = pp.countval("seedRakeL");
+  int nrR = pp.countval("seedRakeR");
+  AMREX_ALWAYS_ASSERT(
+    (nc > 0) ^ ((ni > 0) ^ ((ns > 0) ^ ((nrL > 0) && nrR > 0))));
+  if (nc > 0) {
     int finestLevel = spc.numLevels() - 1;
-    std::vector< std::pair<int,Box> > isects;
+    std::vector<std::pair<int, Box>> isects;
     FArrayBox mask;
-    for (int lev=0; lev<=finestLevel; ++lev)
-    {
+    for (int lev = 0; lev <= finestLevel; ++lev) {
       const auto& geom = spc.Geom(lev);
       const auto& dx = geom.CellSize();
       const auto& plo = geom.ProbLo();
 
       BoxArray baf;
       if (lev < finestLevel) {
-        baf = BoxArray(spc.ParticleBoxArray(lev+1)).coarsen(spc.GetParGDB()->refRatio(lev));
+        baf = BoxArray(spc.ParticleBoxArray(lev + 1))
+                .coarsen(spc.GetParGDB()->refRatio(lev));
       }
-      for (MFIter mfi = spc.MakeMFIter(lev); mfi.isValid(); ++mfi)
-      {
-        const Box& tile_box  = mfi.tilebox();
-        if (AMREX_SPACEDIM<3 || tile_box.contains(IntVect(AMREX_D_DECL(0,50,107)))) {
+      for (MFIter mfi = spc.MakeMFIter(lev); mfi.isValid(); ++mfi) {
+        const Box& tile_box = mfi.tilebox();
+        if (
+          AMREX_SPACEDIM < 3 ||
+          tile_box.contains(IntVect(AMREX_D_DECL(0, 50, 107)))) {
 
-          mask.resize(tile_box,1);
+          mask.resize(tile_box, 1);
           mask.setVal(1);
           if (lev < finestLevel) {
             isects = baf.intersections(tile_box);
             for (const auto& p : isects) {
-              mask.setVal(0,p.second,0,1);
+              mask.setVal(0, p.second, 0, 1);
             }
           }
 
-          for (IntVect iv = tile_box.smallEnd(); iv <= tile_box.bigEnd(); tile_box.next(iv))
-          {
-            if (mask(iv,0) > 0)
-            {
-              locs.push_back({AMREX_D_DECL(plo[0] + (iv[0] + 0.5)*dx[0],
-                                           plo[1] + (iv[1] + 0.5)*dx[1],
-                                           plo[2] + (iv[2] + 0.5)*dx[2])});
+          for (IntVect iv = tile_box.smallEnd(); iv <= tile_box.bigEnd();
+               tile_box.next(iv)) {
+            if (mask(iv, 0) > 0) {
+              locs.push_back({AMREX_D_DECL(
+                plo[0] + (iv[0] + 0.5) * dx[0], plo[1] + (iv[1] + 0.5) * dx[1],
+                plo[2] + (iv[2] + 0.5) * dx[2])});
             }
           }
         }
       }
     }
-  }
-  else if (ni>0)
-  {
+  } else if (ni > 0) {
     // Read in isosurface
-    std::string isoFile; pp.get("isoFile",isoFile);
+    std::string isoFile;
+    pp.get("isoFile", isoFile);
     if (ParallelDescriptor::IOProcessor())
       std::cerr << "Reading isoFile... " << isoFile << std::endl;
 
@@ -70,10 +68,10 @@ GetSeedLocations (const StreamParticleContainer& spc, Vector<int>& faceData)
     ifs.open(isoFile.c_str());
     // AJA added dummy line read; sometimes time, sometimes `decimated'
     std::string topline;
-    std::getline(ifs,topline);
+    std::getline(ifs, topline);
     std::string line;
-    std::getline(ifs,line);
-    auto surfNames = Tokenize(line,std::string(", "));
+    std::getline(ifs, line);
+    auto surfNames = Tokenize(line, std::string(", "));
     int nCompSeedNodes = surfNames.size();
     int nElts, nodesPerElt;
     ifs >> nElts;
@@ -84,141 +82,140 @@ GetSeedLocations (const StreamParticleContainer& spc, Vector<int>& faceData)
     int nSeedNodes = tnodes.box().numPts();
 
     Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nSeedNodes; ++i)
-    {
-      int o=i*nCompSeedNodes;
-      locs.push_back({AMREX_D_DECL(ndat[o+0], ndat[o+1], ndat[o+2])});
+    for (int i = 0; i < nSeedNodes; ++i) {
+      int o = i * nCompSeedNodes;
+      locs.push_back({AMREX_D_DECL(ndat[o + 0], ndat[o + 1], ndat[o + 2])});
     }
     tnodes.clear();
 
-    faceData.resize(nElts*nodesPerElt);
-    ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
+    faceData.resize(nElts * nodesPerElt);
+    ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
     ifs.close();
-  }
-  else if (pp.countval("seedLoc")>0)
-  {
+  } else if (pp.countval("seedLoc") > 0) {
     Vector<Real> loc(AMREX_SPACEDIM);
-    pp.getarr("seedLoc",loc,0,AMREX_SPACEDIM);
+    pp.getarr("seedLoc", loc, 0, AMREX_SPACEDIM);
     locs.push_back({AMREX_D_DECL(loc[0], loc[1], loc[2])});
-  }
-  else
-  {
+  } else {
     int seedRakeNum;
-    pp.get("seedRakeNum",seedRakeNum);
+    pp.get("seedRakeNum", seedRakeNum);
     AMREX_ALWAYS_ASSERT(seedRakeNum >= 2);
     Vector<Real> locL(AMREX_SPACEDIM), locR(AMREX_SPACEDIM);
-    pp.getarr("seedRakeL",locL,0,AMREX_SPACEDIM);
-    pp.getarr("seedRakeR",locR,0,AMREX_SPACEDIM);
+    pp.getarr("seedRakeL", locL, 0, AMREX_SPACEDIM);
+    pp.getarr("seedRakeR", locR, 0, AMREX_SPACEDIM);
 
-    for (int i=0; i<seedRakeNum; ++i) {
-      locs.push_back({AMREX_D_DECL(locL[0] + (i/double(seedRakeNum-1))*(locR[0] - locL[0]),
-                                   locL[1] + (i/double(seedRakeNum-1))*(locR[1] - locL[1]),
-                                   locL[2] + (i/double(seedRakeNum-1))*(locR[2] - locL[2]))});
+    for (int i = 0; i < seedRakeNum; ++i) {
+      locs.push_back({AMREX_D_DECL(
+        locL[0] + (i / double(seedRakeNum - 1)) * (locR[0] - locL[0]),
+        locL[1] + (i / double(seedRakeNum - 1)) * (locR[1] - locL[1]),
+        locL[2] + (i / double(seedRakeNum - 1)) * (locR[2] - locL[2]))});
     }
   }
   return locs;
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     ParmParse pp;
 
-    std::string infile; pp.get("infile",infile);
+    std::string infile;
+    pp.get("infile", infile);
     Vector<std::string> vectorVarNames(AMREX_SPACEDIM);
-    pp.getarr("vectorField",vectorVarNames);
-    int nVars= pp.countval("vars");
+    pp.getarr("vectorField", vectorVarNames);
+    int nVars = pp.countval("vars");
     Vector<std::string> inVarNames(nVars);
-    pp.getarr("vars",inVarNames);
+    pp.getarr("vars", inVarNames);
     PlotFileData pf(infile);
     int finestLevel = pf.finestLevel();
-    Vector<Geometry> geoms(finestLevel+1);
-    Vector<BoxArray> grids(finestLevel+1);
-    Vector<DistributionMapping> dms(finestLevel+1);
+    Vector<Geometry> geoms(finestLevel + 1);
+    Vector<BoxArray> grids(finestLevel + 1);
+    Vector<DistributionMapping> dms(finestLevel + 1);
     Vector<int> ratios(finestLevel);
     int nComp = AMREX_SPACEDIM + nVars;
 
-    
-    
     // get base for output files
     std::string outfile = infile;
-    pp.query("outfile",outfile);
+    pp.query("outfile", outfile);
 
     int writeParticles(0);
-    pp.query("writeParticles",writeParticles);
-    std::string particlefile = outfile+"_particles";
-    pp.query("particlefile",particlefile);
+    pp.query("writeParticles", writeParticles);
+    std::string particlefile = outfile + "_particles";
+    pp.query("particlefile", particlefile);
     int writeStreams(0);
-    pp.query("writeStreams",writeStreams);
-    std::string streamfile = outfile+"_stream";
-    pp.query("streamfile",streamfile);
+    pp.query("writeStreams", writeStreams);
+    std::string streamfile = outfile + "_stream";
+    pp.query("streamfile", streamfile);
     //
     int writeStreamBin(1);
-    pp.query("writeStreamBin",writeStreamBin);
-    std::string streamBinfile = outfile+"_streamBin";
-    pp.query("streamBinfile",streamBinfile);
-    
-    Vector<std::string> outVarNames = {AMREX_D_DECL("X","Y","Z")};
+    pp.query("writeStreamBin", writeStreamBin);
+    std::string streamBinfile = outfile + "_streamBin";
+    pp.query("streamBinfile", streamBinfile);
+
+    Vector<std::string> outVarNames = {AMREX_D_DECL("X", "Y", "Z")};
     for (int n = 0; n < nVars; n++) {
       outVarNames.push_back(inVarNames[n]);
     }
 
     IntVect pp_is_per;
-    pp.getarr("is_per",pp_is_per);
-    Array<int,AMREX_SPACEDIM> is_per = {AMREX_D_DECL(pp_is_per[0],pp_is_per[1],pp_is_per[2])};
-    RealBox rb(pf.probLo(),pf.probHi());
+    pp.getarr("is_per", pp_is_per);
+    Array<int, AMREX_SPACEDIM> is_per = {
+      AMREX_D_DECL(pp_is_per[0], pp_is_per[1], pp_is_per[2])};
+    RealBox rb(pf.probLo(), pf.probHi());
 
     int Nlev = finestLevel + 1;
     Vector<Vector<MultiFab>> pfdata(Nlev);
-    for (int lev=0; lev<Nlev; ++lev) {
-      geoms[lev].define(pf.probDomain(lev),rb,pf.coordSys(),is_per);
+    for (int lev = 0; lev < Nlev; ++lev) {
+      geoms[lev].define(pf.probDomain(lev), rb, pf.coordSys(), is_per);
       grids[lev] = pf.boxArray(lev);
       dms[lev] = pf.DistributionMap(lev);
-      if (lev < finestLevel) ratios[lev] = pf.refRatio(lev);
+      if (lev < finestLevel)
+        ratios[lev] = pf.refRatio(lev);
 
       pfdata[lev].resize(nComp);
       Print() << "Loading data on level " << lev << std::endl;
-      for (int d=0; d<AMREX_SPACEDIM; ++d) {
-        pfdata[lev][d] = pf.get(lev,vectorVarNames[d]);
+      for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+        pfdata[lev][d] = pf.get(lev, vectorVarNames[d]);
       }
       for (int n = 0; n < nVars; n++) {
-	pfdata[lev][n+AMREX_SPACEDIM] = pf.get(lev,inVarNames[n]);
+        pfdata[lev][n + AMREX_SPACEDIM] = pf.get(lev, inVarNames[n]);
       }
     }
 
     int nGrow = 3;
-    pp.query("nGrow",nGrow);
-      
-    Real time=0;
+    pp.query("nGrow", nGrow);
+
+    Real time = 0;
     PhysBCFunctNoOp f;
     PCInterp cbi;
     BCRec bc;
-    AMREX_ALWAYS_ASSERT(nGrow>=1);
+    AMREX_ALWAYS_ASSERT(nGrow >= 1);
     Vector<MultiFab> vectorField(Nlev);
-    for (int lev=0; lev<Nlev; ++lev) {
-      vectorField[lev].define(grids[lev],dms[lev],nComp,nGrow);
-      for (int d=0; d<nComp; ++d) {
-        if (lev==0) {
-          FillPatchSingleLevel(vectorField[lev],time,{&pfdata[lev][d]},{time},0,d,1,geoms[0],f,0);
-        }
-        else
-        {
-          FillPatchTwoLevels(vectorField[lev],time,{&pfdata[lev-1][d]},{time},{&pfdata[lev][d]},{time},0,d,1,
-                             geoms[lev-1],geoms[lev],f,0,f,0,ratios[lev-1]*IntVect::Unit,&cbi,{bc},0);
+    for (int lev = 0; lev < Nlev; ++lev) {
+      vectorField[lev].define(grids[lev], dms[lev], nComp, nGrow);
+      for (int d = 0; d < nComp; ++d) {
+        if (lev == 0) {
+          FillPatchSingleLevel(
+            vectorField[lev], time, {&pfdata[lev][d]}, {time}, 0, d, 1,
+            geoms[0], f, 0);
+        } else {
+          FillPatchTwoLevels(
+            vectorField[lev], time, {&pfdata[lev - 1][d]}, {time},
+            {&pfdata[lev][d]}, {time}, 0, d, 1, geoms[lev - 1], geoms[lev], f,
+            0, f, 0, ratios[lev - 1] * IntVect::Unit, &cbi, {bc}, 0);
         }
       }
       vectorField[lev].FillBoundary(geoms[lev].periodicity());
     }
 
     int Nsteps = 50;
-    pp.query("Nsteps",Nsteps);
-    StreamParticleContainer spc(Nsteps,geoms,dms,grids,ratios,nComp,pp_is_per,outVarNames);
-    
+    pp.query("Nsteps", Nsteps);
+    StreamParticleContainer spc(
+      Nsteps, geoms, dms, grids, ratios, nComp, pp_is_per, outVarNames);
+
     Vector<int> faceData;
-    auto locs = GetSeedLocations(spc,faceData);
+    auto locs = GetSeedLocations(spc, faceData);
     if (writeStreamBin == 1 && faceData.empty()) {
       Abort("Writing stream binary without surface definition!");
     }
@@ -226,65 +223,65 @@ main (int   argc,
     // Initialise particles
     Print() << "Initialising particles..." << std::endl;
     spc.InitParticles(locs);
-    
-    //Check if particles initialised fine
+
+    // Check if particles initialised fine
     if (spc.OK()) {
       Print() << "SPC is happy with initialisation :-)" << std::endl;
     }
-    
-#if AMREX_DEBUG //AJA 
+
+#if AMREX_DEBUG // AJA
     Print() << "Checking if initialised properly..." << std::endl;
     spc.InspectParticles(nStreamPairs);
 #endif
-   
+
     // Interpolate at start
     Print() << "Interpolation at the seed points..." << std::endl;
-    spc.InterpDataAtLocation(0,vectorField);
+    spc.InterpDataAtLocation(0, vectorField);
 
-    
     Print() << "Computing streams and interpolating..." << std::endl;
-    int cSpace=0; pp.query("cSpace",cSpace);
-    Real hRK = 0.1; pp.query("hRK",hRK);
-    AMREX_ALWAYS_ASSERT((cSpace == 1) || (hRK>=0 && hRK<=0.5));
-    //Real dt = hRK;// * geoms[finestLevel].CellSize()[0];
-    for (int step=0; step<Nsteps-1; ++step)
-    {
+    int cSpace = 0;
+    pp.query("cSpace", cSpace);
+    Real hRK = 0.1;
+    pp.query("hRK", hRK);
+    AMREX_ALWAYS_ASSERT((cSpace == 1) || (hRK >= 0 && hRK <= 0.5));
+    // Real dt = hRK;// * geoms[finestLevel].CellSize()[0];
+    for (int step = 0; step < Nsteps - 1; ++step) {
       // find next location
-      spc.ComputeNextLocation(step,hRK,vectorField,cSpace);
+      spc.ComputeNextLocation(step, hRK, vectorField, cSpace);
 
       // interpolate all data
-      spc.InterpDataAtLocation(step+1,vectorField);
-
+      spc.InterpDataAtLocation(step + 1, vectorField);
     }
 
     // check in again
     if (spc.OK()) {
       Print() << "SPC is happy afterwards :-)" << std::endl;
     }
-    
-#if AMREX_DEBUG //AJA checks
+
+#if AMREX_DEBUG // AJA checks
     Print() << "Checking if we broke things afterwards..." << std::endl;
     spc.InspectParticles(nStreamPairs);
 #endif
-    //check we didn't break them again
+    // check we didn't break them again
     spc.OK();
-    
+
     if (writeParticles) {
-      Print() << "Writing particles in plotfile to " << particlefile << std::endl;
+      Print() << "Writing particles in plotfile to " << particlefile
+              << std::endl;
       spc.WritePlotFile(particlefile, "particles");
     }
     if (writeStreams) {
-      Print() << "Writing streamlines in Tecplot ascii format to " << streamfile << std::endl;
+      Print() << "Writing streamlines in Tecplot ascii format to " << streamfile
+              << std::endl;
       spc.WriteStreamAsTecplot(streamfile);
     }
-        //
+    //
     // Write streamBin
     //
     if (writeStreamBin) {
       Print() << "Writing streamlines as binary " << streamBinfile << std::endl;
-      spc.WriteStreamAsBinary(streamBinfile,faceData);
+      spc.WriteStreamAsBinary(streamBinfile, faceData);
     }
-    
   }
   Finalize();
   return 0;

--- a/Src/progVar.cpp
+++ b/Src/progVar.cpp
@@ -9,152 +9,166 @@
 
 using namespace amrex;
 
-static
-void
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
-  std::cerr << "Calculates a progress variable and its source term from a pltFile as C = (Sum(specNames) - unburntVal)/(burntVal - unburntVal)\n";
+  std::cerr
+    << "Calculates a progress variable and its source term from a pltFile as C "
+       "= (Sum(specNames) - unburntVal)/(burntVal - unburntVal)\n";
   std::cerr << "usage:\n";
-  std::cerr << argv[0] << "inputs infile=<i> speciesNames=<s> unburntVal=<u> burntVal=<b> [options] \n\tOptions:\n";
+  std::cerr << argv[0]
+            << "inputs infile=<i> speciesNames=<s> unburntVal=<u> burntVal=<b> "
+               "[options] \n\tOptions:\n";
   std::cerr << "\t     infile=<i> where <i> is a pltfile\n";
-  std::cerr << "\t     speciesNames=<s> where <s> are all the species to be included in the progress variable\n";
-  std::cerr << "\t     unburntVal=float This is the sum of the included species in the unburnt unburntVal[DEF->0]\n";
-  std::cerr << "\t     burntVal=float This is the value of included species in the burnt comp[DEF->1]\n";
-  std::cerr << "\t     outsuffix=string This is the ending of the output pltfile[DEF->_prog]\n";
-  std::cerr << "\t     outname=string This is the name of the variable in the output [DEF->progVar]\n";
+  std::cerr << "\t     speciesNames=<s> where <s> are all the species to be "
+               "included in the progress variable\n";
+  std::cerr << "\t     unburntVal=float This is the sum of the included "
+               "species in the unburnt unburntVal[DEF->0]\n";
+  std::cerr << "\t     burntVal=float This is the value of included species in "
+               "the burnt comp[DEF->1]\n";
+  std::cerr << "\t     outsuffix=string This is the ending of the output "
+               "pltfile[DEF->_prog]\n";
+  std::cerr << "\t     outname=string This is the name of the variable in the "
+               "output [DEF->progVar]\n";
   exit(1);
 }
 
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
 
     Vector<std::string> species;
     int nSpec = pp.countval("speciesNames");
     species.resize(nSpec);
-    pp.getarr("speciesNames",species,0,nSpec);
+    pp.getarr("speciesNames", species, 0, nSpec);
 
-    Real unburnt = 0; pp.get("unburntVal", unburnt);
-    Real burnt = 1; pp.get("burntVal", burnt);
+    Real unburnt = 0;
+    pp.get("unburntVal", unburnt);
+    Real burnt = 1;
+    pp.get("burntVal", burnt);
 
-    std::string outsuffix = "_prog"; pp.get("outsuffix", outsuffix);
-    std::string outname = "progVar"; pp.get("outname", outname);
+    std::string outsuffix = "_prog";
+    pp.get("outsuffix", outsuffix);
+    std::string outname = "progVar";
+    pp.get("outname", outname);
 
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     Print() << "Periodicity assumed for this case: ";
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        Print() << is_per[idim] << " ";
+      Print() << is_per[idim] << " ";
     }
     Print() << std::endl;
 
-    RealBox rb(&(amrData.ProbLo()[0]),&(amrData.ProbHi()[0]));
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
 
     int nCompIn = amrData.NComp();
     Vector<std::string> inNames = amrData.PlotVarNames();
 
     // Get ids of relevant species (mass fractions)
     Vector<int> idY(nSpec, -1);
-    for (int j=0; j<nSpec; ++j)
-    {
-      for (int i=0; i<(int)inNames.size(); ++i)
-      {
-        if (inNames[i] == species[j]) idY[j] = i;
+    for (int j = 0; j < nSpec; ++j) {
+      for (int i = 0; i < (int)inNames.size(); ++i) {
+        if (inNames[i] == species[j])
+          idY[j] = i;
       }
-      if (idY[j]<0) {
+      if (idY[j] < 0) {
         amrex::Abort("Species " + species[j] + " not found in plotfile");
       }
     }
 
-   // Get ids of production rates I_R(<species>) for each species
-   Vector<int> idIR(nSpec, -1);
-   for (int j=0; j<nSpec; ++j)
-   {
-     // Strip "Y(" prefix and ")" suffix if present, e.g. "Y(H2)" -> "H2"
-     std::string specBase = species[j];
-     if (specBase.size() > 2 && specBase.substr(0,2) == "Y(" && specBase.back() == ')')
-     { 
-       specBase = specBase.substr(2, specBase.size() - 3);
-     }
+    // Get ids of production rates I_R(<species>) for each species
+    Vector<int> idIR(nSpec, -1);
+    for (int j = 0; j < nSpec; ++j) {
+      // Strip "Y(" prefix and ")" suffix if present, e.g. "Y(H2)" -> "H2"
+      std::string specBase = species[j];
+      if (
+        specBase.size() > 2 && specBase.substr(0, 2) == "Y(" &&
+        specBase.back() == ')') {
+        specBase = specBase.substr(2, specBase.size() - 3);
+      }
 
-     std::string irName = "I_R(" + specBase + ")";
-     for (int i=0; i<(int)inNames.size(); ++i)
-     {
-       if (inNames[i] == irName) idIR[j] = i;
-     }
-     if (idIR[j]<0) {
-       amrex::Abort("Production rate " + irName + " not found in plotfile");
-     }
-   }
+      std::string irName = "I_R(" + specBase + ")";
+      for (int i = 0; i < (int)inNames.size(); ++i) {
+        if (inNames[i] == irName)
+          idIR[j] = i;
+      }
+      if (idIR[j] < 0) {
+        amrex::Abort("Production rate " + irName + " not found in plotfile");
+      }
+    }
 
     Vector<MultiFab> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
     int nGrow = 0;
     // Output: specSum, progVar, I_R(progVar)
-    Vector<std::string> outNames = {"specSum", outname, "I_R(" + outname +")"};
+    Vector<std::string> outNames = {"specSum", outname, "I_R(" + outname + ")"};
 
     Vector<int> destFillComps(nCompIn);
-    for (int i=0; i<nCompIn; ++i) destFillComps[i] = i;
+    for (int i = 0; i < nCompIn; ++i)
+      destFillComps[i] = i;
 
     for (int lev = 0; lev < Nlev; ++lev) {
 
       const BoxArray ba = amrData.boxArray(lev);
       const DistributionMapping dm(ba);
 
-      outdata[lev] = MultiFab(ba,dm,outNames.size(),nGrow);
-      MultiFab indata(ba,dm,nCompIn,nGrow);
+      outdata[lev] = MultiFab(ba, dm, outNames.size(), nGrow);
+      MultiFab indata(ba, dm, nCompIn, nGrow);
 
       int coord = 0;
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb, coord, &(is_per[0]));
+      geoms[lev] =
+        Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
 
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps);
+      amrData.FillVar(indata, lev, inNames, destFillComps);
       Print() << "Data has been read for level " << lev << std::endl;
 
       // Copy species index arrays to device
       amrex::Gpu::DeviceVector<int> d_idY(idY.size());
-      amrex::Gpu::copy(amrex::Gpu::hostToDevice, idY.begin(), idY.end(), d_idY.begin());
+      amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, idY.begin(), idY.end(), d_idY.begin());
       int const* idY_d = d_idY.data();
 
       // Copy production rate index arrays to device
       amrex::Gpu::DeviceVector<int> d_idIR(idIR.size());
-      amrex::Gpu::copy(amrex::Gpu::hostToDevice, idIR.begin(), idIR.end(), d_idIR.begin());
+      amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, idIR.begin(), idIR.end(), d_idIR.begin());
       int const* idIR_d = d_idIR.data();
 
       Real denom = burnt - unburnt;
@@ -162,44 +176,40 @@ main (int   argc,
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
+      for (MFIter mfi(indata, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const Box& bx = mfi.tilebox();
         auto const& out_a = outdata[lev].array(mfi);
-        auto const& in_a  = indata.array(mfi);
-        amrex::ParallelFor(bx, [=]
-            AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {
-              // Sum of species mass fractions
-              Real sum = 0.0_rt;
-              for (int s=0; s<nSpec; ++s)
-              {
-                sum += in_a(i,j,k, idY_d[s]);
-              }
-              out_a(i,j,k,0) = sum;
+        auto const& in_a = indata.array(mfi);
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            // Sum of species mass fractions
+            Real sum = 0.0_rt;
+            for (int s = 0; s < nSpec; ++s) {
+              sum += in_a(i, j, k, idY_d[s]);
+            }
+            out_a(i, j, k, 0) = sum;
 
-              // Progress variable: C = (sum - unburnt) / (burnt - unburnt)
-              out_a(i,j,k,1) = (sum - unburnt) / denom;
+            // Progress variable: C = (sum - unburnt) / (burnt - unburnt)
+            out_a(i, j, k, 1) = (sum - unburnt) / denom;
 
-              // Production rate of progress variable:
-              // I_R(C) = Sum( I_R(species) ) / (burnt - unburnt)
-              Real irSum = 0.0_rt;
-              for (int s=0; s<nSpec; ++s)
-              {
-                irSum += in_a(i,j,k, idIR_d[s]);
-              }
-              out_a(i,j,k,2) = irSum / denom;
-            });
+            // Production rate of progress variable:
+            // I_R(C) = Sum( I_R(species) ) / (burnt - unburnt)
+            Real irSum = 0.0_rt;
+            for (int s = 0; s < nSpec; ++s) {
+              irSum += in_a(i, j, k, idIR_d[s]);
+            }
+            out_a(i, j, k, 2) = irSum / denom;
+          });
       }
-
     }
 
     std::string outfile(getFileRoot(plotFileName) + outsuffix);
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(outdata), outNames,
-                                   geoms, 0.0, isteps, refRatios);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps,
+      refRatios);
   }
   Finalize();
   return 0;

--- a/Src/qCriterion.cpp
+++ b/Src/qCriterion.cpp
@@ -11,47 +11,46 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile=<plotfilename>"
-                       << "\n\tOptions:"
-                       << "\n\tfinestLevel=[DEFAULT: finestLevel]"
-                       << "\n\tAux_Variables=<auxVarName0 auxVarName1 ...>"
-                       << "\n\tis_per=[DEFAULT: 0 0 0]\t\t\t\t(spatial directions of periodicity (0: non-periodic, 1: periodic))"
-                       << "\n\tsym_dir=[DEFAULT: 0 0 0]\t\t\t(spatial directions of symmetry (0: non-symmetric, 1: symmetric))"
-                       << "\n\toutfile=[DEFAULT: infile+\"_qCriterion\"]\n";
+            << "\n\tOptions:" << "\n\tfinestLevel=[DEFAULT: finestLevel]"
+            << "\n\tAux_Variables=<auxVarName0 auxVarName1 ...>"
+            << "\n\tis_per=[DEFAULT: 0 0 0]\t\t\t\t(spatial directions of "
+               "periodicity (0: non-periodic, 1: periodic))"
+            << "\n\tsym_dir=[DEFAULT: 0 0 0]\t\t\t(spatial directions of "
+               "symmetry (0: non-symmetric, 1: symmetric))"
+            << "\n\toutfile=[DEFAULT: infile+\"_qCriterion\"]\n";
   exit(1);
 }
 
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
   {
-    static_assert(AMREX_SPACEDIM == 3, "This tool must be compiled with DIM = 3");
+    static_assert(
+      AMREX_SPACEDIM == 3, "This tool must be compiled with DIM = 3");
 
     if (argc < 2) {
-      print_usage(argc,argv);
+      print_usage(argc, argv);
     }
 
     // ---------------------------------------------------------------------
     // Set defaults input values
     // ---------------------------------------------------------------------
-    std::string infile        = "";  
-    int finestLevel           = 1000;
-    int nAuxVar               = 0;
+    std::string infile = "";
+    int finestLevel = 1000;
+    int nAuxVar = 0;
 
     // ---------------------------------------------------------------------
     // ParmParse
@@ -59,46 +58,49 @@ main (int   argc,
     ParmParse pp;
 
     if (pp.contains("help")) {
-      print_usage(argc,argv);
+      print_usage(argc, argv);
     }
 
-    pp.get("infile",infile);
-    pp.query("finestLevel",finestLevel);
+    pp.get("infile", infile);
+    pp.query("finestLevel", finestLevel);
 
     // Initialize DataService
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(infile, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     // Plotfile global infos
-    finestLevel = std::min(finestLevel,amrData.FinestLevel());
+    finestLevel = std::min(finestLevel, amrData.FinestLevel());
     int Nlev = finestLevel + 1;
     const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    RealBox rb(&(amrData.ProbLo()[0]), 
-               &(amrData.ProbHi()[0]));
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
 
     int ID_VEL_X = -1, ID_VEL_Y = -1, ID_VEL_Z = -1;
     std::string gradVar_vel_x = "x_velocity";
     std::string gradVar_vel_y = "y_velocity";
     std::string gradVar_vel_z = "z_velocity";
-    for (int i=0; i<plotVarNames.size(); ++i) {
-      if (plotVarNames[i] == gradVar_vel_x) ID_VEL_X = i;
-      else if (plotVarNames[i] == gradVar_vel_y) ID_VEL_Y = i;
-      else if (plotVarNames[i] == gradVar_vel_z) ID_VEL_Z = i;
+    for (int i = 0; i < plotVarNames.size(); ++i) {
+      if (plotVarNames[i] == gradVar_vel_x)
+        ID_VEL_X = i;
+      else if (plotVarNames[i] == gradVar_vel_y)
+        ID_VEL_Y = i;
+      else if (plotVarNames[i] == gradVar_vel_z)
+        ID_VEL_Z = i;
     }
     if (ID_VEL_X == -1 || ID_VEL_Y == -1 || ID_VEL_Z == -1) {
-      std::cerr << "At least one velocity component was not found in the plt-file!\n";
+      std::cerr
+        << "At least one velocity component was not found in the plt-file!\n";
     }
 
     // Auxiliary variables
     nAuxVar = pp.countval("Aux_Variables");
     Vector<std::string> AuxVar(nAuxVar);
-    for(int ivar = 0; ivar < nAuxVar; ++ivar) { 
-         pp.get("Aux_Variables", AuxVar[ivar], ivar);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      pp.get("Aux_Variables", AuxVar[ivar], ivar);
     }
 
     // ---------------------------------------------------------------------
@@ -110,58 +112,57 @@ main (int   argc,
     inVarNames[1] = plotVarNames[ID_VEL_Y];
     inVarNames[2] = plotVarNames[ID_VEL_Z];
 
-    if (nAuxVar>0)
-    {
-        for (int ivar=0; ivar<nAuxVar; ++ivar) {
-            if ( amrData.StateNumber(AuxVar[ivar]) < 0 ) {
-               amrex::Abort("Unknown auxiliary variable name: "+AuxVar[ivar]);
-            }
-            inVarNames.push_back(AuxVar[ivar]);
-        } 
-        nCompIn += nAuxVar;
+    if (nAuxVar > 0) {
+      for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+        if (amrData.StateNumber(AuxVar[ivar]) < 0) {
+          amrex::Abort("Unknown auxiliary variable name: " + AuxVar[ivar]);
+        }
+        inVarNames.push_back(AuxVar[ivar]);
+      }
+      nCompIn += nAuxVar;
     }
 
     Vector<int> destFillComps(nCompIn);
-    for (int i=0; i<nCompIn; ++i) {
+    for (int i = 0; i < nCompIn; ++i) {
       destFillComps[i] = i;
     }
 
-    const int idGr_vel_x = nCompIn + 0*AMREX_SPACEDIM;
-    const int idGr_vel_y = nCompIn + 1*AMREX_SPACEDIM;
-    const int idGr_vel_z = nCompIn + 2*AMREX_SPACEDIM;
-    const int idQ = nCompIn + 3*AMREX_SPACEDIM;
-    const int idQNorm = nCompIn + 3*AMREX_SPACEDIM + 1 /*Q*/;
-    const int nCompOut = nCompIn + 3*AMREX_SPACEDIM + 2 /*Q and Q_norm*/;
+    const int idGr_vel_x = nCompIn + 0 * AMREX_SPACEDIM;
+    const int idGr_vel_y = nCompIn + 1 * AMREX_SPACEDIM;
+    const int idGr_vel_z = nCompIn + 2 * AMREX_SPACEDIM;
+    const int idQ = nCompIn + 3 * AMREX_SPACEDIM;
+    const int idQNorm = nCompIn + 3 * AMREX_SPACEDIM + 1 /*Q*/;
+    const int nCompOut = nCompIn + 3 * AMREX_SPACEDIM + 2 /*Q and Q_norm*/;
 
     // Check symmetry/periodicity in given coordinate direction
-    Vector<int> sym_dir(AMREX_SPACEDIM,0);
-    pp.queryarr("sym_dir",sym_dir,0,AMREX_SPACEDIM);
+    Vector<int> sym_dir(AMREX_SPACEDIM, 0);
+    pp.queryarr("sym_dir", sym_dir, 0, AMREX_SPACEDIM);
 
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     Print() << "Periodicity assumed for this case: ";
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        Print() << is_per[idim] << " ";
+      Print() << is_per[idim] << " ";
     }
     Print() << "\n";
     BCRec vel_x_BC;
     BCRec vel_y_BC;
     BCRec vel_z_BC;
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        vel_x_BC.setLo(idim,BCType::foextrap);
-        vel_y_BC.setLo(idim,BCType::foextrap);
-        vel_z_BC.setLo(idim,BCType::foextrap);
-        vel_x_BC.setHi(idim,BCType::foextrap);
-        vel_y_BC.setHi(idim,BCType::foextrap);
-        vel_z_BC.setHi(idim,BCType::foextrap);
-        if ( is_per[idim] ) {
-            vel_x_BC.setLo(idim, BCType::int_dir);
-            vel_y_BC.setLo(idim, BCType::int_dir);
-            vel_z_BC.setLo(idim, BCType::int_dir);
-            vel_x_BC.setHi(idim, BCType::int_dir);
-            vel_y_BC.setHi(idim, BCType::int_dir);
-            vel_z_BC.setHi(idim, BCType::int_dir);
-        }
+      vel_x_BC.setLo(idim, BCType::foextrap);
+      vel_y_BC.setLo(idim, BCType::foextrap);
+      vel_z_BC.setLo(idim, BCType::foextrap);
+      vel_x_BC.setHi(idim, BCType::foextrap);
+      vel_y_BC.setHi(idim, BCType::foextrap);
+      vel_z_BC.setHi(idim, BCType::foextrap);
+      if (is_per[idim]) {
+        vel_x_BC.setLo(idim, BCType::int_dir);
+        vel_y_BC.setLo(idim, BCType::int_dir);
+        vel_z_BC.setLo(idim, BCType::int_dir);
+        vel_x_BC.setHi(idim, BCType::int_dir);
+        vel_y_BC.setHi(idim, BCType::int_dir);
+        vel_z_BC.setHi(idim, BCType::int_dir);
+      }
     }
 
     int coord = 0;
@@ -176,20 +177,21 @@ main (int   argc,
     const int nGrow = 1;
 
     // Read data on all the levels
-    for (int lev=0; lev<Nlev; ++lev) {
+    for (int lev = 0; lev < Nlev; ++lev) {
 
       const BoxArray ba = amrData.boxArray(lev);
       grids[lev] = ba;
       dmap[lev] = DistributionMapping(ba);
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb,coord,&(is_per[0]));
+      geoms[lev] =
+        Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
       state[lev].define(grids[lev], dmap[lev], nCompOut, nGrow);
 
       Print() << "Reading data for level: " << lev << std::endl;
       amrData.FillVar(state[lev], lev, inVarNames, destFillComps);
 
-      state[lev].FillBoundary(ID_VEL_X,1,geoms[lev].periodicity());
-      state[lev].FillBoundary(ID_VEL_Y,1,geoms[lev].periodicity());
-      state[lev].FillBoundary(ID_VEL_Z,1,geoms[lev].periodicity());
+      state[lev].FillBoundary(ID_VEL_X, 1, geoms[lev].periodicity());
+      state[lev].FillBoundary(ID_VEL_Y, 1, geoms[lev].periodicity());
+      state[lev].FillBoundary(ID_VEL_Z, 1, geoms[lev].periodicity());
     }
 
     // Get face-centered gradients from MLMG
@@ -206,26 +208,26 @@ main (int   argc,
     poisson_vel_z.setMaxOrder(4);
     std::array<LinOpBCType, AMREX_SPACEDIM> lo_bc;
     std::array<LinOpBCType, AMREX_SPACEDIM> hi_bc;
-    for (int idim = 0; idim< AMREX_SPACEDIM; idim++){
-       if (is_per[idim] == 1) {
-          lo_bc[idim] = hi_bc[idim] = LinOpBCType::Periodic;
-       } else {
-          if (sym_dir[idim] == 1) {
-             lo_bc[idim] = hi_bc[idim] = LinOpBCType::reflect_odd;
-          } else {
-             lo_bc[idim] = hi_bc[idim] = LinOpBCType::Neumann;
-          }
-       }
+    for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+      if (is_per[idim] == 1) {
+        lo_bc[idim] = hi_bc[idim] = LinOpBCType::Periodic;
+      } else {
+        if (sym_dir[idim] == 1) {
+          lo_bc[idim] = hi_bc[idim] = LinOpBCType::reflect_odd;
+        } else {
+          lo_bc[idim] = hi_bc[idim] = LinOpBCType::Neumann;
+        }
+      }
     }
     poisson_vel_x.setDomainBC(lo_bc, hi_bc);
     poisson_vel_y.setDomainBC(lo_bc, hi_bc);
     poisson_vel_z.setDomainBC(lo_bc, hi_bc);
 
     // Need to apply the operator to ensure CF consistency with composite solve
-    int nGrowGrad = 0;                   // No need for ghost face on gradient
-    Vector<Array<MultiFab,AMREX_SPACEDIM> > grad_vel_x(Nlev);
-    Vector<Array<MultiFab,AMREX_SPACEDIM> > grad_vel_y(Nlev);
-    Vector<Array<MultiFab,AMREX_SPACEDIM> > grad_vel_z(Nlev);
+    int nGrowGrad = 0; // No need for ghost face on gradient
+    Vector<Array<MultiFab, AMREX_SPACEDIM>> grad_vel_x(Nlev);
+    Vector<Array<MultiFab, AMREX_SPACEDIM>> grad_vel_y(Nlev);
+    Vector<Array<MultiFab, AMREX_SPACEDIM>> grad_vel_z(Nlev);
     Vector<std::unique_ptr<MultiFab>> phi_vel_x;
     Vector<std::unique_ptr<MultiFab>> phi_vel_y;
     Vector<std::unique_ptr<MultiFab>> phi_vel_z;
@@ -233,18 +235,24 @@ main (int   argc,
     Vector<MultiFab> laps_vel_y;
     Vector<MultiFab> laps_vel_z;
     for (int lev = 0; lev < Nlev; ++lev) {
-      for (int idim = 0; idim <AMREX_SPACEDIM; idim++) {
-         const auto& ba = grids[lev];
-         grad_vel_x[lev][idim].define(amrex::convert(ba,IntVect::TheDimensionVector(idim)),
-                                dmap[lev], 1, nGrowGrad);
-         grad_vel_y[lev][idim].define(amrex::convert(ba,IntVect::TheDimensionVector(idim)),
-                                dmap[lev], 1, nGrowGrad);
-         grad_vel_z[lev][idim].define(amrex::convert(ba,IntVect::TheDimensionVector(idim)),
-                                dmap[lev], 1, nGrowGrad);
-      }    
-      phi_vel_x.push_back(std::make_unique<MultiFab> (state[lev],amrex::make_alias,ID_VEL_X,1));
-      phi_vel_y.push_back(std::make_unique<MultiFab> (state[lev],amrex::make_alias,ID_VEL_Y,1));
-      phi_vel_z.push_back(std::make_unique<MultiFab> (state[lev],amrex::make_alias,ID_VEL_Z,1));
+      for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+        const auto& ba = grids[lev];
+        grad_vel_x[lev][idim].define(
+          amrex::convert(ba, IntVect::TheDimensionVector(idim)), dmap[lev], 1,
+          nGrowGrad);
+        grad_vel_y[lev][idim].define(
+          amrex::convert(ba, IntVect::TheDimensionVector(idim)), dmap[lev], 1,
+          nGrowGrad);
+        grad_vel_z[lev][idim].define(
+          amrex::convert(ba, IntVect::TheDimensionVector(idim)), dmap[lev], 1,
+          nGrowGrad);
+      }
+      phi_vel_x.push_back(
+        std::make_unique<MultiFab>(state[lev], amrex::make_alias, ID_VEL_X, 1));
+      phi_vel_y.push_back(
+        std::make_unique<MultiFab>(state[lev], amrex::make_alias, ID_VEL_Y, 1));
+      phi_vel_z.push_back(
+        std::make_unique<MultiFab>(state[lev], amrex::make_alias, ID_VEL_Z, 1));
       poisson_vel_x.setLevelBC(lev, phi_vel_x[lev].get());
       poisson_vel_y.setLevelBC(lev, phi_vel_y[lev].get());
       poisson_vel_z.setLevelBC(lev, phi_vel_z[lev].get());
@@ -259,127 +267,174 @@ main (int   argc,
     mlmg_vel_x.apply(GetVecOfPtrs(laps_vel_x), GetVecOfPtrs(phi_vel_x));
     mlmg_vel_y.apply(GetVecOfPtrs(laps_vel_y), GetVecOfPtrs(phi_vel_y));
     mlmg_vel_z.apply(GetVecOfPtrs(laps_vel_z), GetVecOfPtrs(phi_vel_z));
-    mlmg_vel_x.getFluxes(GetVecOfArrOfPtrs(grad_vel_x), GetVecOfPtrs(phi_vel_x), MLMG::Location::FaceCenter);
-    mlmg_vel_y.getFluxes(GetVecOfArrOfPtrs(grad_vel_y), GetVecOfPtrs(phi_vel_y), MLMG::Location::FaceCenter);
-    mlmg_vel_z.getFluxes(GetVecOfArrOfPtrs(grad_vel_z), GetVecOfPtrs(phi_vel_z), MLMG::Location::FaceCenter);
+    mlmg_vel_x.getFluxes(
+      GetVecOfArrOfPtrs(grad_vel_x), GetVecOfPtrs(phi_vel_x),
+      MLMG::Location::FaceCenter);
+    mlmg_vel_y.getFluxes(
+      GetVecOfArrOfPtrs(grad_vel_y), GetVecOfPtrs(phi_vel_y),
+      MLMG::Location::FaceCenter);
+    mlmg_vel_z.getFluxes(
+      GetVecOfArrOfPtrs(grad_vel_z), GetVecOfPtrs(phi_vel_z),
+      MLMG::Location::FaceCenter);
 
     for (int lev = 0; lev < Nlev; ++lev) {
-        // Convert to cell avg gradient
-        MultiFab gradAlias_vel_x(state[lev], amrex::make_alias, idGr_vel_x, AMREX_SPACEDIM);
-        MultiFab gradAlias_vel_y(state[lev], amrex::make_alias, idGr_vel_y, AMREX_SPACEDIM);
-        MultiFab gradAlias_vel_z(state[lev], amrex::make_alias, idGr_vel_z, AMREX_SPACEDIM);
-        average_face_to_cellcenter(gradAlias_vel_x, 0, GetArrOfConstPtrs(grad_vel_x[lev]));
-        average_face_to_cellcenter(gradAlias_vel_y, 0, GetArrOfConstPtrs(grad_vel_y[lev]));
-        average_face_to_cellcenter(gradAlias_vel_z, 0, GetArrOfConstPtrs(grad_vel_z[lev]));
-        gradAlias_vel_x.mult(-1.0);
-        gradAlias_vel_y.mult(-1.0);
-        gradAlias_vel_z.mult(-1.0);
+      // Convert to cell avg gradient
+      MultiFab gradAlias_vel_x(
+        state[lev], amrex::make_alias, idGr_vel_x, AMREX_SPACEDIM);
+      MultiFab gradAlias_vel_y(
+        state[lev], amrex::make_alias, idGr_vel_y, AMREX_SPACEDIM);
+      MultiFab gradAlias_vel_z(
+        state[lev], amrex::make_alias, idGr_vel_z, AMREX_SPACEDIM);
+      average_face_to_cellcenter(
+        gradAlias_vel_x, 0, GetArrOfConstPtrs(grad_vel_x[lev]));
+      average_face_to_cellcenter(
+        gradAlias_vel_y, 0, GetArrOfConstPtrs(grad_vel_y[lev]));
+      average_face_to_cellcenter(
+        gradAlias_vel_z, 0, GetArrOfConstPtrs(grad_vel_z[lev]));
+      gradAlias_vel_x.mult(-1.0);
+      gradAlias_vel_y.mult(-1.0);
+      gradAlias_vel_z.mult(-1.0);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-        for (MFIter mfi(state[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-        {    
-           const Box& bx = mfi.tilebox();
-           auto const& grad_vel_x_a   = gradAlias_vel_x.const_array(mfi);
-           auto const& grad_vel_y_a   = gradAlias_vel_y.const_array(mfi);
-           auto const& grad_vel_z_a   = gradAlias_vel_z.const_array(mfi);
-           
-           // Intermediates:
-           MultiFab S_mf(state[lev].boxArray(), state[lev].DistributionMap(), 9, 0);
-           auto const& S_a = S_mf[mfi].array();
-           MultiFab S_abs_mf(state[lev].boxArray(), state[lev].DistributionMap(), 1, 0);
-           auto const& S_abs_a = S_abs_mf[mfi].array();
-           MultiFab Omega_mf(state[lev].boxArray(), state[lev].DistributionMap(), 9, 0);
-           auto const& Omega_a = Omega_mf[mfi].array();
-           MultiFab Omega_abs_mf(state[lev].boxArray(), state[lev].DistributionMap(), 1, 0);
-           auto const& Omega_abs_a = Omega_abs_mf[mfi].array();
+      for (MFIter mfi(state[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.tilebox();
+        auto const& grad_vel_x_a = gradAlias_vel_x.const_array(mfi);
+        auto const& grad_vel_y_a = gradAlias_vel_y.const_array(mfi);
+        auto const& grad_vel_z_a = gradAlias_vel_z.const_array(mfi);
 
-           auto const& Q = state[lev].array(mfi, idQ);
-           auto const& Q_norm = state[lev].array(mfi, idQNorm);
+        // Intermediates:
+        MultiFab S_mf(
+          state[lev].boxArray(), state[lev].DistributionMap(), 9, 0);
+        auto const& S_a = S_mf[mfi].array();
+        MultiFab S_abs_mf(
+          state[lev].boxArray(), state[lev].DistributionMap(), 1, 0);
+        auto const& S_abs_a = S_abs_mf[mfi].array();
+        MultiFab Omega_mf(
+          state[lev].boxArray(), state[lev].DistributionMap(), 9, 0);
+        auto const& Omega_a = Omega_mf[mfi].array();
+        MultiFab Omega_abs_mf(
+          state[lev].boxArray(), state[lev].DistributionMap(), 1, 0);
+        auto const& Omega_abs_a = Omega_abs_mf[mfi].array();
 
-           amrex::ParallelFor(bx, [=]
-           AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-           {
-              // Compute Strain Rate Tensor S_ij:
-              S_a(i,j,k,AMREX_SPACEDIM*0 + 0) = grad_vel_x_a(i,j,k,0);
-              S_a(i,j,k,AMREX_SPACEDIM*0 + 1) = 0.5 * (grad_vel_x_a(i,j,k,1) + grad_vel_y_a(i,j,k,0));
-              S_a(i,j,k,AMREX_SPACEDIM*0 + 2) = 0.5 * (grad_vel_x_a(i,j,k,2) + grad_vel_z_a(i,j,k,0));
-              
-              S_a(i,j,k,AMREX_SPACEDIM*1 + 0) = 0.5 * (grad_vel_y_a(i,j,k,0) + grad_vel_x_a(i,j,k,1));
-              S_a(i,j,k,AMREX_SPACEDIM*1 + 1) = grad_vel_y_a(i,j,k,1);
-              S_a(i,j,k,AMREX_SPACEDIM*1 + 2) = 0.5 * (grad_vel_y_a(i,j,k,2) + grad_vel_z_a(i,j,k,1));
+        auto const& Q = state[lev].array(mfi, idQ);
+        auto const& Q_norm = state[lev].array(mfi, idQNorm);
 
-              S_a(i,j,k,AMREX_SPACEDIM*2 + 0) = 0.5 * (grad_vel_z_a(i,j,k,0) + grad_vel_x_a(i,j,k,2));
-              S_a(i,j,k,AMREX_SPACEDIM*2 + 1) = 0.5 * (grad_vel_z_a(i,j,k,1) + grad_vel_y_a(i,j,k,2));
-              S_a(i,j,k,AMREX_SPACEDIM*2 + 2) = grad_vel_z_a(i,j,k,2);
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            // Compute Strain Rate Tensor S_ij:
+            S_a(i, j, k, AMREX_SPACEDIM * 0 + 0) = grad_vel_x_a(i, j, k, 0);
+            S_a(i, j, k, AMREX_SPACEDIM * 0 + 1) =
+              0.5 * (grad_vel_x_a(i, j, k, 1) + grad_vel_y_a(i, j, k, 0));
+            S_a(i, j, k, AMREX_SPACEDIM * 0 + 2) =
+              0.5 * (grad_vel_x_a(i, j, k, 2) + grad_vel_z_a(i, j, k, 0));
 
-              S_abs_a(i,j,k) = S_a(i,j,k,AMREX_SPACEDIM*0 + 0) * S_a(i,j,k,AMREX_SPACEDIM*0 + 0)
-                             + S_a(i,j,k,AMREX_SPACEDIM*0 + 1) * S_a(i,j,k,AMREX_SPACEDIM*0 + 1)
-                             + S_a(i,j,k,AMREX_SPACEDIM*0 + 2) * S_a(i,j,k,AMREX_SPACEDIM*0 + 2)
-                             + S_a(i,j,k,AMREX_SPACEDIM*1 + 0) * S_a(i,j,k,AMREX_SPACEDIM*1 + 0)
-                             + S_a(i,j,k,AMREX_SPACEDIM*1 + 1) * S_a(i,j,k,AMREX_SPACEDIM*1 + 1)
-                             + S_a(i,j,k,AMREX_SPACEDIM*1 + 2) * S_a(i,j,k,AMREX_SPACEDIM*1 + 2)
-                             + S_a(i,j,k,AMREX_SPACEDIM*2 + 0) * S_a(i,j,k,AMREX_SPACEDIM*2 + 0)
-                             + S_a(i,j,k,AMREX_SPACEDIM*2 + 1) * S_a(i,j,k,AMREX_SPACEDIM*2 + 1)
-                             + S_a(i,j,k,AMREX_SPACEDIM*2 + 2) * S_a(i,j,k,AMREX_SPACEDIM*2 + 2);
-              
-              // Compute Vorticity Tensor Omega_ij:
-              Omega_a(i,j,k,AMREX_SPACEDIM*0 + 0) = 0.0;
-              Omega_a(i,j,k,AMREX_SPACEDIM*0 + 1) = 0.5 * (grad_vel_x_a(i,j,k,1) - grad_vel_y_a(i,j,k,0));
-              Omega_a(i,j,k,AMREX_SPACEDIM*0 + 2) = 0.5 * (grad_vel_x_a(i,j,k,2) - grad_vel_z_a(i,j,k,0));
-              
-              Omega_a(i,j,k,AMREX_SPACEDIM*1 + 0) = 0.5 * (grad_vel_y_a(i,j,k,0) - grad_vel_x_a(i,j,k,1));
-              Omega_a(i,j,k,AMREX_SPACEDIM*1 + 1) = 0.0;
-              Omega_a(i,j,k,AMREX_SPACEDIM*1 + 2) = 0.5 * (grad_vel_y_a(i,j,k,2) - grad_vel_z_a(i,j,k,1));
+            S_a(i, j, k, AMREX_SPACEDIM * 1 + 0) =
+              0.5 * (grad_vel_y_a(i, j, k, 0) + grad_vel_x_a(i, j, k, 1));
+            S_a(i, j, k, AMREX_SPACEDIM * 1 + 1) = grad_vel_y_a(i, j, k, 1);
+            S_a(i, j, k, AMREX_SPACEDIM * 1 + 2) =
+              0.5 * (grad_vel_y_a(i, j, k, 2) + grad_vel_z_a(i, j, k, 1));
 
-              Omega_a(i,j,k,AMREX_SPACEDIM*2 + 0) = 0.5 * (grad_vel_z_a(i,j,k,0) - grad_vel_x_a(i,j,k,2));
-              Omega_a(i,j,k,AMREX_SPACEDIM*2 + 1) = 0.5 * (grad_vel_z_a(i,j,k,1) - grad_vel_y_a(i,j,k,2));
-              Omega_a(i,j,k,AMREX_SPACEDIM*2 + 2) = 0.0;
-              
-              Omega_abs_a(i,j,k) = Omega_a(i,j,k,AMREX_SPACEDIM*0 + 0) * Omega_a(i,j,k,AMREX_SPACEDIM*0 + 0)
-                                 + Omega_a(i,j,k,AMREX_SPACEDIM*0 + 1) * Omega_a(i,j,k,AMREX_SPACEDIM*0 + 1)
-                                 + Omega_a(i,j,k,AMREX_SPACEDIM*0 + 2) * Omega_a(i,j,k,AMREX_SPACEDIM*0 + 2)
-                                 + Omega_a(i,j,k,AMREX_SPACEDIM*1 + 0) * Omega_a(i,j,k,AMREX_SPACEDIM*1 + 0)
-                                 + Omega_a(i,j,k,AMREX_SPACEDIM*1 + 1) * Omega_a(i,j,k,AMREX_SPACEDIM*1 + 1)
-                                 + Omega_a(i,j,k,AMREX_SPACEDIM*1 + 2) * Omega_a(i,j,k,AMREX_SPACEDIM*1 + 2)
-                                 + Omega_a(i,j,k,AMREX_SPACEDIM*2 + 0) * Omega_a(i,j,k,AMREX_SPACEDIM*2 + 0)
-                                 + Omega_a(i,j,k,AMREX_SPACEDIM*2 + 1) * Omega_a(i,j,k,AMREX_SPACEDIM*2 + 1)
-                                 + Omega_a(i,j,k,AMREX_SPACEDIM*2 + 2) * Omega_a(i,j,k,AMREX_SPACEDIM*2 + 2);
-              
-              // Compute Q-criterion:
-              Q(i,j,k) = 0.5 * (Omega_abs_a(i,j,k) - S_abs_a(i,j,k));
-              Q_norm(i,j,k) = (Omega_abs_a(i,j,k) - S_abs_a(i,j,k)) / (Omega_abs_a(i,j,k) + S_abs_a(i,j,k));
-           });
-        } 
+            S_a(i, j, k, AMREX_SPACEDIM * 2 + 0) =
+              0.5 * (grad_vel_z_a(i, j, k, 0) + grad_vel_x_a(i, j, k, 2));
+            S_a(i, j, k, AMREX_SPACEDIM * 2 + 1) =
+              0.5 * (grad_vel_z_a(i, j, k, 1) + grad_vel_y_a(i, j, k, 2));
+            S_a(i, j, k, AMREX_SPACEDIM * 2 + 2) = grad_vel_z_a(i, j, k, 2);
+
+            S_abs_a(i, j, k) = S_a(i, j, k, AMREX_SPACEDIM * 0 + 0) *
+                                 S_a(i, j, k, AMREX_SPACEDIM * 0 + 0) +
+                               S_a(i, j, k, AMREX_SPACEDIM * 0 + 1) *
+                                 S_a(i, j, k, AMREX_SPACEDIM * 0 + 1) +
+                               S_a(i, j, k, AMREX_SPACEDIM * 0 + 2) *
+                                 S_a(i, j, k, AMREX_SPACEDIM * 0 + 2) +
+                               S_a(i, j, k, AMREX_SPACEDIM * 1 + 0) *
+                                 S_a(i, j, k, AMREX_SPACEDIM * 1 + 0) +
+                               S_a(i, j, k, AMREX_SPACEDIM * 1 + 1) *
+                                 S_a(i, j, k, AMREX_SPACEDIM * 1 + 1) +
+                               S_a(i, j, k, AMREX_SPACEDIM * 1 + 2) *
+                                 S_a(i, j, k, AMREX_SPACEDIM * 1 + 2) +
+                               S_a(i, j, k, AMREX_SPACEDIM * 2 + 0) *
+                                 S_a(i, j, k, AMREX_SPACEDIM * 2 + 0) +
+                               S_a(i, j, k, AMREX_SPACEDIM * 2 + 1) *
+                                 S_a(i, j, k, AMREX_SPACEDIM * 2 + 1) +
+                               S_a(i, j, k, AMREX_SPACEDIM * 2 + 2) *
+                                 S_a(i, j, k, AMREX_SPACEDIM * 2 + 2);
+
+            // Compute Vorticity Tensor Omega_ij:
+            Omega_a(i, j, k, AMREX_SPACEDIM * 0 + 0) = 0.0;
+            Omega_a(i, j, k, AMREX_SPACEDIM * 0 + 1) =
+              0.5 * (grad_vel_x_a(i, j, k, 1) - grad_vel_y_a(i, j, k, 0));
+            Omega_a(i, j, k, AMREX_SPACEDIM * 0 + 2) =
+              0.5 * (grad_vel_x_a(i, j, k, 2) - grad_vel_z_a(i, j, k, 0));
+
+            Omega_a(i, j, k, AMREX_SPACEDIM * 1 + 0) =
+              0.5 * (grad_vel_y_a(i, j, k, 0) - grad_vel_x_a(i, j, k, 1));
+            Omega_a(i, j, k, AMREX_SPACEDIM * 1 + 1) = 0.0;
+            Omega_a(i, j, k, AMREX_SPACEDIM * 1 + 2) =
+              0.5 * (grad_vel_y_a(i, j, k, 2) - grad_vel_z_a(i, j, k, 1));
+
+            Omega_a(i, j, k, AMREX_SPACEDIM * 2 + 0) =
+              0.5 * (grad_vel_z_a(i, j, k, 0) - grad_vel_x_a(i, j, k, 2));
+            Omega_a(i, j, k, AMREX_SPACEDIM * 2 + 1) =
+              0.5 * (grad_vel_z_a(i, j, k, 1) - grad_vel_y_a(i, j, k, 2));
+            Omega_a(i, j, k, AMREX_SPACEDIM * 2 + 2) = 0.0;
+
+            Omega_abs_a(i, j, k) = Omega_a(i, j, k, AMREX_SPACEDIM * 0 + 0) *
+                                     Omega_a(i, j, k, AMREX_SPACEDIM * 0 + 0) +
+                                   Omega_a(i, j, k, AMREX_SPACEDIM * 0 + 1) *
+                                     Omega_a(i, j, k, AMREX_SPACEDIM * 0 + 1) +
+                                   Omega_a(i, j, k, AMREX_SPACEDIM * 0 + 2) *
+                                     Omega_a(i, j, k, AMREX_SPACEDIM * 0 + 2) +
+                                   Omega_a(i, j, k, AMREX_SPACEDIM * 1 + 0) *
+                                     Omega_a(i, j, k, AMREX_SPACEDIM * 1 + 0) +
+                                   Omega_a(i, j, k, AMREX_SPACEDIM * 1 + 1) *
+                                     Omega_a(i, j, k, AMREX_SPACEDIM * 1 + 1) +
+                                   Omega_a(i, j, k, AMREX_SPACEDIM * 1 + 2) *
+                                     Omega_a(i, j, k, AMREX_SPACEDIM * 1 + 2) +
+                                   Omega_a(i, j, k, AMREX_SPACEDIM * 2 + 0) *
+                                     Omega_a(i, j, k, AMREX_SPACEDIM * 2 + 0) +
+                                   Omega_a(i, j, k, AMREX_SPACEDIM * 2 + 1) *
+                                     Omega_a(i, j, k, AMREX_SPACEDIM * 2 + 1) +
+                                   Omega_a(i, j, k, AMREX_SPACEDIM * 2 + 2) *
+                                     Omega_a(i, j, k, AMREX_SPACEDIM * 2 + 2);
+
+            // Compute Q-criterion:
+            Q(i, j, k) = 0.5 * (Omega_abs_a(i, j, k) - S_abs_a(i, j, k));
+            Q_norm(i, j, k) = (Omega_abs_a(i, j, k) - S_abs_a(i, j, k)) /
+                              (Omega_abs_a(i, j, k) + S_abs_a(i, j, k));
+          });
+      }
     }
 
     // ---------------------------------------------------------------------
     // Write the results
     // ---------------------------------------------------------------------
     Vector<std::string> nnames(nCompOut);
-    for (int i=0; i<nCompIn; ++i) {
+    for (int i = 0; i < nCompIn; ++i) {
       nnames[i] = inVarNames[i];
     }
-    nnames[idGr_vel_x+0] = gradVar_vel_x + "_gx";
-    nnames[idGr_vel_x+1] = gradVar_vel_x + "_gy";
-    nnames[idGr_vel_x+2] = gradVar_vel_x + "_gz";
-    nnames[idGr_vel_y+0] = gradVar_vel_y + "_gx";
-    nnames[idGr_vel_y+1] = gradVar_vel_y + "_gy";
-    nnames[idGr_vel_y+2] = gradVar_vel_y + "_gz";
-    nnames[idGr_vel_z+0] = gradVar_vel_z + "_gx";
-    nnames[idGr_vel_z+1] = gradVar_vel_z + "_gy";
-    nnames[idGr_vel_z+2] = gradVar_vel_z + "_gz";
+    nnames[idGr_vel_x + 0] = gradVar_vel_x + "_gx";
+    nnames[idGr_vel_x + 1] = gradVar_vel_x + "_gy";
+    nnames[idGr_vel_x + 2] = gradVar_vel_x + "_gz";
+    nnames[idGr_vel_y + 0] = gradVar_vel_y + "_gx";
+    nnames[idGr_vel_y + 1] = gradVar_vel_y + "_gy";
+    nnames[idGr_vel_y + 2] = gradVar_vel_y + "_gz";
+    nnames[idGr_vel_z + 0] = gradVar_vel_z + "_gx";
+    nnames[idGr_vel_z + 1] = gradVar_vel_z + "_gy";
+    nnames[idGr_vel_z + 2] = gradVar_vel_z + "_gz";
 
     nnames[idQ] = "Q";
     nnames[idQNorm] = "Q_norm";
 
-    std::string outfile(getFileRoot(infile) + "_qCriterion"); pp.query("outfile",outfile);
+    std::string outfile(getFileRoot(infile) + "_qCriterion");
+    pp.query("outfile", outfile);
 
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(state), nnames,
-                                   geoms, 0.0, isteps, refRatios);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(state), nnames, geoms, 0.0, isteps,
+      refRatios);
   }
   amrex::Finalize();
   return 0;

--- a/Src/regridPlt.cpp
+++ b/Src/regridPlt.cpp
@@ -11,45 +11,42 @@ using namespace amrex;
 #define Y_IN_PLOTFILE
 #undef Y_IN_PLOTFILE
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
-	std::cerr << "usage:\n";
-    std::cerr << argv[0] << " infile=<name> outfile=<> [options] \n\tOptions:\n";
-    exit(1);
+  std::cerr << "usage:\n";
+  std::cerr << argv[0] << " infile=<name> outfile=<> [options] \n\tOptions:\n";
+  exit(1);
 }
 
 std::string
 getFileRoot(const std::string& infile)
 {
-    vector<std::string> tokens = Tokenize(infile,std::string("/"));
-    return tokens[tokens.size()-1];
+  vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    amrex::Initialize(argc,argv);
-    {
+  amrex::Initialize(argc, argv);
+  {
     if (argc < 2)
-        print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-        print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
-        AmrData::SetVerbose(true);
+      AmrData::SetVerbose(true);
 
     std::string infile;
-    pp.get("infile",infile);
+    pp.get("infile", infile);
 
     std::string outfile;
-    pp.get("outfile",outfile);
+    pp.get("outfile", outfile);
 
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
@@ -58,94 +55,90 @@ main (int   argc,
     DataServices dataServices(infile, fileType);
 
     if (!dataServices.AmrDataOk())
-        //
-        // This calls ParallelDescriptor::EndParallel() and exit()
-        //
-        DataServices::Dispatch(DataServices::ExitRequest, NULL);
-    
+      //
+      // This calls ParallelDescriptor::EndParallel() and exit()
+      //
+      DataServices::Dispatch(DataServices::ExitRequest, NULL);
+
     AmrData& amrData = dataServices.AmrDataRef();
 
     int nComp = 0;
     Vector<int> comps;
-    if (int nc = pp.countval("comps"))
-    {
-        comps.resize(nc);
-        pp.getarr("comps",comps,0,nc);
-        nComp = comps.size();
-    }
-    else
-    {
-        int sComp = 0;
-        pp.query("sComp",sComp);
-        nComp = amrData.NComp();
-        pp.query("nComp",nComp);
-        AMREX_ASSERT(sComp+nComp <= amrData.NComp());
-        comps.resize(nComp);
-        for (int i=0; i<nComp; ++i)
-            comps[i] = sComp + i;
+    if (int nc = pp.countval("comps")) {
+      comps.resize(nc);
+      pp.getarr("comps", comps, 0, nc);
+      nComp = comps.size();
+    } else {
+      int sComp = 0;
+      pp.query("sComp", sComp);
+      nComp = amrData.NComp();
+      pp.query("nComp", nComp);
+      AMREX_ASSERT(sComp + nComp <= amrData.NComp());
+      comps.resize(nComp);
+      for (int i = 0; i < nComp; ++i)
+        comps[i] = sComp + i;
     }
 
     int finestLevel = amrData.FinestLevel();
     int Nlev = finestLevel + 1;
-    pp.query("finestLevel",finestLevel);
-    Nlev = std::max(0, std::min(Nlev, finestLevel+1));
+    pp.query("finestLevel", finestLevel);
+    Nlev = std::max(0, std::min(Nlev, finestLevel + 1));
 
     int max_grid_size = 128;
-    pp.query("max_grid_size",max_grid_size);
+    pp.query("max_grid_size", max_grid_size);
     Vector<MultiFab*> fileData(Nlev);
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-        BoxArray newba = amrData.boxArray(lev);
-        newba.maxSize(max_grid_size);
-        const DistributionMapping dm(newba);
-        fileData[lev] = new MultiFab(newba,dm,nComp,0);
+    for (int lev = 0; lev < Nlev; ++lev) {
+      BoxArray newba = amrData.boxArray(lev);
+      newba.maxSize(max_grid_size);
+      const DistributionMapping dm(newba);
+      fileData[lev] = new MultiFab(newba, dm, nComp, 0);
     }
     if (ParallelDescriptor::IOProcessor())
-        std::cerr << "Full MultiFab allocated " << std::endl;
+      std::cerr << "Full MultiFab allocated " << std::endl;
 
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-        for (int i=0; i<comps.size(); ++i)
-        {
-            fileData[lev]->copy(amrData.GetGrids(lev,comps[i]),0,i,1);
-            if (ParallelDescriptor::IOProcessor())
-                std::cerr << "After GetGrids: " << amrData.PlotVarNames()[comps[i]] << std::endl;
-            amrData.FlushGrids(comps[i]);
-            if (ParallelDescriptor::IOProcessor())
-                std::cerr << "AmrData flushed: " << amrData.PlotVarNames()[comps[i]] << std::endl;
-        }
+    for (int lev = 0; lev < Nlev; ++lev) {
+      for (int i = 0; i < comps.size(); ++i) {
+        fileData[lev]->copy(amrData.GetGrids(lev, comps[i]), 0, i, 1);
+        if (ParallelDescriptor::IOProcessor())
+          std::cerr << "After GetGrids: " << amrData.PlotVarNames()[comps[i]]
+                    << std::endl;
+        amrData.FlushGrids(comps[i]);
+        if (ParallelDescriptor::IOProcessor())
+          std::cerr << "AmrData flushed: " << amrData.PlotVarNames()[comps[i]]
+                    << std::endl;
+      }
     }
     if (ParallelDescriptor::IOProcessor())
-        std::cerr << "File data loaded" << std::endl;
+      std::cerr << "File data loaded" << std::endl;
 
     Vector<std::string> names(nComp);
-    for (int i=0; i<comps.size(); ++i)
-        names[i] = amrData.PlotVarNames()[comps[i]];
+    for (int i = 0; i < comps.size(); ++i)
+      names[i] = amrData.PlotVarNames()[comps[i]];
 
     Vector<Geometry> geoms(Nlev);
     Vector<int> levelSteps(Nlev);
-    Vector<IntVect> refRatio(Nlev-1);
+    Vector<IntVect> refRatio(Nlev - 1);
     Vector<const MultiFab*> dat(Nlev);
 
-    RealBox rb(&(amrData.ProbLo()[0]),
-               &(amrData.ProbHi()[0]));
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     int coord = 0;
 
-    for (int lev=0; lev<Nlev; ++lev)
-    {
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb,coord,&(is_per[0]));
+    for (int lev = 0; lev < Nlev; ++lev) {
+      geoms[lev] =
+        Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
       levelSteps[lev] = 666;
-      if (lev < Nlev-1) {
+      if (lev < Nlev - 1) {
         int r = amrData.RefRatio()[lev];
-        refRatio[lev] = IntVect(AMREX_D_DECL(r,r,r));
+        refRatio[lev] = IntVect(AMREX_D_DECL(r, r, r));
       }
       dat[lev] = fileData[lev];
     }
-    
-    WriteMultiLevelPlotfile(outfile,Nlev,dat,names,geoms,amrData.Time(),levelSteps,refRatio);
-    }
-    amrex::Finalize();
-    return 0;
+
+    WriteMultiLevelPlotfile(
+      outfile, Nlev, dat, names, geoms, amrData.Time(), levelSteps, refRatio);
+  }
+  amrex::Finalize();
+  return 0;
 }

--- a/Src/rmsVel.cpp
+++ b/Src/rmsVel.cpp
@@ -7,17 +7,17 @@
 using namespace amrex;
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     ParmParse pp;
 
     // Open first plotfile header and create an amrData object pointing into it
     int nPlotFiles = pp.countval("infiles");
-    AMREX_ALWAYS_ASSERT(nPlotFiles>0);
-    Vector<std::string> plotFileNames; pp.getarr("infiles",plotFileNames,0,nPlotFiles);
+    AMREX_ALWAYS_ASSERT(nPlotFiles > 0);
+    Vector<std::string> plotFileNames;
+    pp.getarr("infiles", plotFileNames, 0, nPlotFiles);
 
     int nVars(3);
     Vector<std::string> whichVar(nVars);
@@ -25,118 +25,126 @@ main (int   argc,
     whichVar[1] = "y_velocity";
     whichVar[2] = "z_velocity";
 
-    Vector<int>  destFills(nVars);
-    for (int c=0; c<nVars; c++)
-	destFills[c] = c;
+    Vector<int> destFills(nVars);
+    for (int c = 0; c < nVars; c++)
+      destFills[c] = c;
 
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-    Vector<DataServices *> dataServicesPtrVector(nPlotFiles);                                         // DataServices array for each plot
-    Vector<AmrData *>      amrDataPtrVector(nPlotFiles);                                              // DataPtrVector for each plot
-    Vector<Real>           time(nPlotFiles);
-    Vector<Real>           urms(nPlotFiles);
+    Vector<DataServices*> dataServicesPtrVector(
+      nPlotFiles); // DataServices array for each plot
+    Vector<AmrData*> amrDataPtrVector(
+      nPlotFiles); // DataPtrVector for each plot
+    Vector<Real> time(nPlotFiles);
+    Vector<Real> urms(nPlotFiles);
 
-    for(int iPlot = 0; iPlot < nPlotFiles; ++iPlot) {
-	if (ParallelDescriptor::IOProcessor())
-	    std::cout << "Loading " << plotFileNames[iPlot] << std::endl;
-	
-	dataServicesPtrVector[iPlot] = new DataServices(plotFileNames[iPlot], fileType);               // Populate DataServices array
-	
-	if( ! dataServicesPtrVector[iPlot]->AmrDataOk())                                               // Check AmrData ok
-	    DataServices::Dispatch(DataServices::ExitRequest, NULL);                                    // Exit if not
-	
-	amrDataPtrVector[iPlot] = &(dataServicesPtrVector[iPlot]->AmrDataRef());                        // Populate DataPtrVector
-	
-	time[iPlot] = amrDataPtrVector[iPlot]->Time();
-	
+    for (int iPlot = 0; iPlot < nPlotFiles; ++iPlot) {
+      if (ParallelDescriptor::IOProcessor())
+        std::cout << "Loading " << plotFileNames[iPlot] << std::endl;
+
+      dataServicesPtrVector[iPlot] = new DataServices(
+        plotFileNames[iPlot], fileType); // Populate DataServices array
+
+      if (!dataServicesPtrVector[iPlot]->AmrDataOk()) // Check AmrData ok
+        DataServices::Dispatch(DataServices::ExitRequest, NULL); // Exit if not
+
+      amrDataPtrVector[iPlot] =
+        &(dataServicesPtrVector[iPlot]->AmrDataRef()); // Populate DataPtrVector
+
+      time[iPlot] = amrDataPtrVector[iPlot]->Time();
     }
 
-    for (int iPlot=0; iPlot<nPlotFiles; iPlot++) {
-    
-	int finestLevel = amrDataPtrVector[iPlot]->FinestLevel();    
-	int inFinestLevel(-1);    pp.query("finestLevel",inFinestLevel);
-	if (inFinestLevel>-1 && inFinestLevel<finestLevel) {
-	    finestLevel = inFinestLevel;
-            if (ParallelDescriptor::IOProcessor())
-	        std::cout << "Finest level: " << finestLevel << std::endl;
-	}
+    for (int iPlot = 0; iPlot < nPlotFiles; iPlot++) {
 
-	Vector<Real> probLo=amrDataPtrVector[iPlot]->ProbLo();
-	Vector<Real> probHi=amrDataPtrVector[iPlot]->ProbHi();
-	const Real *dx = amrDataPtrVector[iPlot]->DxLevel()[finestLevel].dataPtr();
-	Real dxyz = dx[0]*dx[1]*dx[2];
-
-	int ngrow(0);
-	MultiFab mf;
-        const BoxArray& ba = amrDataPtrVector[iPlot]->boxArray(finestLevel);
-        DistributionMapping dm(ba);
-	mf.define(ba, dm, nVars, ngrow);
-
+      int finestLevel = amrDataPtrVector[iPlot]->FinestLevel();
+      int inFinestLevel(-1);
+      pp.query("finestLevel", inFinestLevel);
+      if (inFinestLevel > -1 && inFinestLevel < finestLevel) {
+        finestLevel = inFinestLevel;
         if (ParallelDescriptor::IOProcessor())
-	    std::cout << "Processing " << iPlot << "/" << nPlotFiles << std::endl;
-	amrDataPtrVector[iPlot]->FillVar(mf, finestLevel, whichVar, destFills);
-	for (int n=0; n<nVars; n++)
-	    amrDataPtrVector[iPlot]->FlushGrids(amrDataPtrVector[iPlot]->StateNumber(whichVar[n]));
+          std::cout << "Finest level: " << finestLevel << std::endl;
+      }
 
-	Real vol(0), uxb(0), uyb(0), uzb(0), ux2(0), uy2(0), uz2(0);
-	for(MFIter ntmfi(mf); ntmfi.isValid(); ++ntmfi) {
-	    const FArrayBox &myFab = mf[ntmfi];
-	    Vector<const Real *> varPtr(nVars);
-	    for (int v=0; v<nVars; v++)
-		varPtr[v] = myFab.dataPtr(v);
-            const Box& vbx = ntmfi.validbox();
-	    const int  *lo  = vbx.smallEnd().getVect();
-	    const int  *hi  = vbx.bigEnd().getVect();
+      Vector<Real> probLo = amrDataPtrVector[iPlot]->ProbLo();
+      Vector<Real> probHi = amrDataPtrVector[iPlot]->ProbHi();
+      const Real* dx =
+        amrDataPtrVector[iPlot]->DxLevel()[finestLevel].dataPtr();
+      Real dxyz = dx[0] * dx[1] * dx[2];
 
-	    int ix = hi[0]-lo[0]+1;
-	    int jx = hi[1]-lo[1]+1;
-	    int kx = hi[2]-lo[2]+1;
-	    for (int k=0; k<kx; k++) {
-		Real z=probLo[2] + dx[2]*(0.5+(Real)(k+lo[2]));
-		for (int j=0; j<jx; j++) {
-		    Real y=probLo[1] + dx[1]*(0.5+(Real)(j+lo[1]));
-		    for (int i=0; i<ix; i++) {
-			Real x=probLo[0] + dx[0]*(0.5+(Real)(i+lo[0]));
-			int cell = (k*jx+j)*ix+i;
-			Real ux = varPtr[0][cell];
-			Real uy = varPtr[1][cell];
-			Real uz = varPtr[2][cell];
-			vol += dxyz;
-			uxb += ux*dxyz;
-			uyb += uy*dxyz;
-			uzb += uz*dxyz;
-			ux2 += ux*ux*dxyz;
-			uy2 += uy*uy*dxyz;
-			uz2 += uz*uz*dxyz;
-		    }
-		}
-	    }
-	}
-	ParallelDescriptor::ReduceRealSum(vol);
-	ParallelDescriptor::ReduceRealSum(uxb);
-	ParallelDescriptor::ReduceRealSum(uyb);
-	ParallelDescriptor::ReduceRealSum(uzb);
-	ParallelDescriptor::ReduceRealSum(ux2);
-	ParallelDescriptor::ReduceRealSum(uy2);
-	ParallelDescriptor::ReduceRealSum(uz2);
-	uxb /= vol;	uyb /= vol;	uzb /= vol;
-	ux2 /= vol;	uy2 /= vol;	uz2 /= vol;
-	urms[iPlot] = sqrt( ( (ux2-uxb*uxb) + (uy2-uyb*uyb) + (uz2-uzb*uzb) ) / 3. );
+      int ngrow(0);
+      MultiFab mf;
+      const BoxArray& ba = amrDataPtrVector[iPlot]->boxArray(finestLevel);
+      DistributionMapping dm(ba);
+      mf.define(ba, dm, nVars, ngrow);
+
+      if (ParallelDescriptor::IOProcessor())
+        std::cout << "Processing " << iPlot << "/" << nPlotFiles << std::endl;
+      amrDataPtrVector[iPlot]->FillVar(mf, finestLevel, whichVar, destFills);
+      for (int n = 0; n < nVars; n++)
+        amrDataPtrVector[iPlot]->FlushGrids(
+          amrDataPtrVector[iPlot]->StateNumber(whichVar[n]));
+
+      Real vol(0), uxb(0), uyb(0), uzb(0), ux2(0), uy2(0), uz2(0);
+      for (MFIter ntmfi(mf); ntmfi.isValid(); ++ntmfi) {
+        const FArrayBox& myFab = mf[ntmfi];
+        Vector<const Real*> varPtr(nVars);
+        for (int v = 0; v < nVars; v++)
+          varPtr[v] = myFab.dataPtr(v);
+        const Box& vbx = ntmfi.validbox();
+        const int* lo = vbx.smallEnd().getVect();
+        const int* hi = vbx.bigEnd().getVect();
+
+        int ix = hi[0] - lo[0] + 1;
+        int jx = hi[1] - lo[1] + 1;
+        int kx = hi[2] - lo[2] + 1;
+        for (int k = 0; k < kx; k++) {
+          Real z = probLo[2] + dx[2] * (0.5 + (Real)(k + lo[2]));
+          for (int j = 0; j < jx; j++) {
+            Real y = probLo[1] + dx[1] * (0.5 + (Real)(j + lo[1]));
+            for (int i = 0; i < ix; i++) {
+              Real x = probLo[0] + dx[0] * (0.5 + (Real)(i + lo[0]));
+              int cell = (k * jx + j) * ix + i;
+              Real ux = varPtr[0][cell];
+              Real uy = varPtr[1][cell];
+              Real uz = varPtr[2][cell];
+              vol += dxyz;
+              uxb += ux * dxyz;
+              uyb += uy * dxyz;
+              uzb += uz * dxyz;
+              ux2 += ux * ux * dxyz;
+              uy2 += uy * uy * dxyz;
+              uz2 += uz * uz * dxyz;
+            }
+          }
+        }
+      }
+      ParallelDescriptor::ReduceRealSum(vol);
+      ParallelDescriptor::ReduceRealSum(uxb);
+      ParallelDescriptor::ReduceRealSum(uyb);
+      ParallelDescriptor::ReduceRealSum(uzb);
+      ParallelDescriptor::ReduceRealSum(ux2);
+      ParallelDescriptor::ReduceRealSum(uy2);
+      ParallelDescriptor::ReduceRealSum(uz2);
+      uxb /= vol;
+      uyb /= vol;
+      uzb /= vol;
+      ux2 /= vol;
+      uy2 /= vol;
+      uz2 /= vol;
+      urms[iPlot] =
+        sqrt(((ux2 - uxb * uxb) + (uy2 - uyb * uyb) + (uz2 - uzb * uzb)) / 3.);
     }
     if (ParallelDescriptor::IOProcessor())
-        std::cout << "   ...done." << std::endl;
+      std::cout << "   ...done." << std::endl;
 
     if (ParallelDescriptor::IOProcessor()) {
-	FILE *file = fopen("RmsVel.dat","w");
-	for (int iPlot=0; iPlot<nPlotFiles; iPlot++)
-	    fprintf(file,"%e %e\n",time[iPlot],urms[iPlot]);
-	fclose(file);
+      FILE* file = fopen("RmsVel.dat", "w");
+      for (int iPlot = 0; iPlot < nPlotFiles; iPlot++)
+        fprintf(file, "%e %e\n", time[iPlot], urms[iPlot]);
+      fclose(file);
     }
-
-
   }
   Finalize();
   return 0;
 }
-

--- a/Src/scaleMEF.cpp
+++ b/Src/scaleMEF.cpp
@@ -11,211 +11,205 @@
 
 using namespace amrex;
 
-using std::vector;
-using std::map;
-using std::string;
 using std::cerr;
-using std::endl;
 using std::cout;
+using std::endl;
+using std::map;
 using std::ofstream;
+using std::string;
+using std::vector;
 
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Vector<int>&       faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label);
+void read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Vector<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label);
 
-void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Vector<int>&    faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label);
+void write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Vector<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label);
 
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return Tokenize(line,std::string(", "));
+  std::string line;
+  std::getline(is, line);
+  return Tokenize(line, std::string(", "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return line;
+  std::string line;
+  std::getline(is, line);
+  return line;
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
 
-    ParmParse pp;
+  ParmParse pp;
 
-    int nElts;
-    string infile; pp.get("infile",infile);
-    string outfile; pp.get("outfile",outfile);
+  int nElts;
+  string infile;
+  pp.get("infile", infile);
+  string outfile;
+  pp.get("outfile", outfile);
 
-    FArrayBox nodes;
-    Vector<int> faceData;
-    vector<string> names;
-    string label;
-    read_iso(infile,nodes,faceData,nElts,names,label);
-    int nodesPerElt = faceData.size() / nElts;
-    AMREX_ASSERT(nodesPerElt*nElts == faceData.size());
+  FArrayBox nodes;
+  Vector<int> faceData;
+  vector<string> names;
+  string label;
+  read_iso(infile, nodes, faceData, nElts, names, label);
+  int nodesPerElt = faceData.size() / nElts;
+  AMREX_ASSERT(nodesPerElt * nElts == faceData.size());
 
-    nElts = faceData.size() / nodesPerElt;
-    int nCompMEF = nodes.nComp();
-    AMREX_ASSERT(nElts*nodesPerElt == faceData.size());
+  nElts = faceData.size() / nodesPerElt;
+  int nCompMEF = nodes.nComp();
+  AMREX_ASSERT(nElts * nodesPerElt == faceData.size());
 
-    Vector<int> comps;
-    if (pp.countval("comps"))
-    {
-        int nComp = pp.countval("comps");
-        comps.resize(nComp);
-        pp.getarr("comps",comps,0,nComp);
+  Vector<int> comps;
+  if (pp.countval("comps")) {
+    int nComp = pp.countval("comps");
+    comps.resize(nComp);
+    pp.getarr("comps", comps, 0, nComp);
+  } else {
+    int sComp = 0;
+    pp.query("sComp", sComp);
+    int nc = 1;
+    pp.query("nComp", nc);
+    AMREX_ASSERT(sComp + nc <= nCompMEF);
+    comps.resize(nc);
+    for (int i = 0; i < nc; ++i)
+      comps[i] = sComp + i;
+  }
+  int nComp = comps.size();
+
+  Vector<Real> vals(nComp);
+  AMREX_ASSERT(pp.countval("vals") == nComp);
+  pp.getarr("vals", vals, 0, nComp);
+
+  int nNodes = nodes.box().numPts();
+  for (int j = 0; j < nComp; ++j) {
+    AMREX_ASSERT(comps[j] < nCompMEF);
+    Real* dat = nodes.dataPtr(comps[j]);
+    for (int i = 0; i < nNodes; ++i)
+      dat[i] = dat[i] * vals[j];
+  }
+
+  if (pp.countval("newNames")) {
+    int numNew = pp.countval("newNames");
+    int numNewComps = pp.countval("newComps");
+    AMREX_ASSERT(numNew == numNewComps);
+
+    Vector<std::string> newNames(numNew);
+    Vector<int> newComps(numNewComps);
+    pp.getarr("newNames", newNames, 0, newNames.size());
+    pp.getarr("newComps", newComps, 0, newComps.size());
+
+    for (int i = 0; i < numNew; ++i) {
+      AMREX_ASSERT(newComps[i] <= names.size());
+      names[newComps[i]] = newNames[i];
     }
+  }
+
+  write_iso(outfile, nodes, faceData, nElts, names, label);
+
+  amrex::Finalize();
+  return 0;
+}
+
+void
+write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Vector<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label)
+{
+  // Rotate data to vary quickest on component
+  int nCompSurf = nodes.nComp();
+  int nNodes = nodes.box().numPts();
+
+  FArrayBox tnodes(nodes.box(), nCompSurf);
+  const Real** np = new const Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      ndat[j] = np[j][i];
+    }
+    ndat += nCompSurf;
+  }
+  delete[] np;
+
+  std::ofstream ofs;
+  ofs.open(outfile.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
+  ofs << label << endl;
+  for (int i = 0; i < nCompSurf; ++i) {
+    ofs << names[i];
+    if (i < nCompSurf - 1)
+      ofs << " ";
     else
-    {
-        int sComp = 0;
-        pp.query("sComp",sComp);
-        int nc = 1;
-        pp.query("nComp",nc);
-        AMREX_ASSERT(sComp+nc <= nCompMEF);
-        comps.resize(nc);
-        for (int i=0; i<nc; ++i)
-            comps[i] = sComp + i;
-    }
-    int nComp = comps.size();
-
-    Vector<Real> vals(nComp);
-    AMREX_ASSERT(pp.countval("vals")==nComp);
-    pp.getarr("vals",vals,0,nComp);
-
-    int nNodes = nodes.box().numPts();
-    for (int j=0; j<nComp; ++j)
-    {
-        AMREX_ASSERT(comps[j]<nCompMEF);
-        Real* dat=nodes.dataPtr(comps[j]);
-        for (int i=0; i<nNodes; ++i)
-            dat[i] = dat[i]*vals[j];
-    }
-
-    if (pp.countval("newNames"))
-    {
-        int numNew = pp.countval("newNames");
-        int numNewComps = pp.countval("newComps");
-        AMREX_ASSERT(numNew==numNewComps);
-
-        Vector<std::string> newNames(numNew);
-        Vector<int> newComps(numNewComps);
-        pp.getarr("newNames",newNames,0,newNames.size());
-        pp.getarr("newComps",newComps,0,newComps.size());
-
-        for (int i=0; i<numNew; ++i) {
-            AMREX_ASSERT(newComps[i] <= names.size());
-            names[newComps[i]] = newNames[i];
-        }       
-    }
-
-    write_iso(outfile,nodes,faceData,nElts,names,label);
-
-    amrex::Finalize();
-    return 0;
+      ofs << std::endl;
+  }
+  int nodesPerElt = faceData.size() / nElts;
+  ofs << nElts << " " << nodesPerElt << endl;
+  tnodes.writeOn(ofs);
+  ofs.write((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
+  ofs.close();
 }
 
 void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Vector<int>&    faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label)
+read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Vector<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label)
 {
-    // Rotate data to vary quickest on component
-    int nCompSurf = nodes.nComp();
-    int nNodes = nodes.box().numPts();
+  std::ifstream ifs;
+  ifs.open(infile.c_str(), std::ios::in | std::ios::binary);
+  label = parseTitle(ifs);
+  names = parseVarNames(ifs);
+  const int nCompSurf = names.size();
 
-    FArrayBox tnodes(nodes.box(),nCompSurf);
-    const Real** np = new const Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            ndat[j] = np[j][i];
-        }
-        ndat += nCompSurf;
-    }
-    delete [] np;
+  int nodesPerElt;
+  ifs >> nElts;
+  ifs >> nodesPerElt;
 
-    std::ofstream ofs;
-    ofs.open(outfile.c_str(),std::ios::out|std::ios::trunc|std::ios::binary);
-    ofs << label << endl;
-    for (int i=0; i<nCompSurf; ++i)
-    {
-        ofs << names[i];
-        if (i < nCompSurf-1)
-            ofs << " ";
-        else
-            ofs << std::endl;
+  FArrayBox tnodes;
+  tnodes.readFrom(ifs);
+  const int nNodes = tnodes.box().numPts();
+
+  // "rotate" the data so that the components are 'in the right spot for fab
+  // data'
+  nodes.resize(tnodes.box(), nCompSurf);
+  Real** np = new Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      np[j][i] = ndat[j];
     }
-    int nodesPerElt = faceData.size() / nElts;
-    ofs << nElts << " " << nodesPerElt << endl;
-    tnodes.writeOn(ofs);
-    ofs.write((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-    ofs.close();
+    ndat += nCompSurf;
+  }
+  delete[] np;
+  tnodes.clear();
+
+  faceData.resize(nElts * nodesPerElt, 0);
+  ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
 }
-
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Vector<int>&       faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label)
-{
-    std::ifstream ifs;
-    ifs.open(infile.c_str(),std::ios::in|std::ios::binary);
-    label = parseTitle(ifs);
-    names = parseVarNames(ifs);
-    const int nCompSurf = names.size();
-
-    int nodesPerElt;
-    ifs >> nElts;
-    ifs >> nodesPerElt;
-
-    FArrayBox tnodes;
-    tnodes.readFrom(ifs);
-    const int nNodes = tnodes.box().numPts();
-
-    // "rotate" the data so that the components are 'in the right spot for fab data'
-    nodes.resize(tnodes.box(),nCompSurf);
-    Real** np = new Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            np[j][i] = ndat[j];
-        }
-        ndat += nCompSurf;
-    }
-    delete [] np;
-    tnodes.clear();
-
-    faceData.resize(nElts*nodesPerElt,0);
-    ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-}
-

--- a/Src/sliceMEF.cpp
+++ b/Src/sliceMEF.cpp
@@ -12,539 +12,520 @@
 #include "DataServices.H"
 #include "Geometry.H"
 #include "Utility.H"
-using std::vector;
-using std::map;
-using std::set;
-using std::list;
-using std::pair;
-using std::string;
 using std::cerr;
-using std::endl;
 using std::cout;
+using std::endl;
+using std::list;
+using std::map;
 using std::ofstream;
+using std::pair;
+using std::set;
+using std::string;
+using std::vector;
 
 static Real epsilon_DEF = 1.e-8;
 
+void read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Array<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label);
 
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Array<int>&        faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label);
-
-void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Array<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label);
+void write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label);
 
 vector<std::string>
-Tokenize (const std::string& instr, const std::string& separators)
+Tokenize(const std::string& instr, const std::string& separators)
 {
-    vector<char*> ptr;
-    //
-    // Make copy of line that we can modify.
-    //
-    char* line = new char[instr.size()+1];
+  vector<char*> ptr;
+  //
+  // Make copy of line that we can modify.
+  //
+  char* line = new char[instr.size() + 1];
 
-    (void) strcpy(line, instr.c_str());
+  (void)strcpy(line, instr.c_str());
 
-    char* token = 0;
+  char* token = 0;
 
-    if (!((token = strtok(line, separators.c_str())) == 0))
-    {
-        ptr.push_back(token);
-        while (!((token = strtok(0, separators.c_str())) == 0))
-            ptr.push_back(token);
-    }
+  if (!((token = strtok(line, separators.c_str())) == 0)) {
+    ptr.push_back(token);
+    while (!((token = strtok(0, separators.c_str())) == 0))
+      ptr.push_back(token);
+  }
 
-    vector<std::string> tokens(ptr.size());
+  vector<std::string> tokens(ptr.size());
 
-    for (int i = 1; i < ptr.size(); i++)
-    {
-        char* p = ptr[i];
+  for (int i = 1; i < ptr.size(); i++) {
+    char* p = ptr[i];
 
-        while (strchr(separators.c_str(), *(p-1)) != 0)
-            *--p = 0;
-    }
+    while (strchr(separators.c_str(), *(p - 1)) != 0)
+      *--p = 0;
+  }
 
-    for (int i = 0; i < ptr.size(); i++)
-        tokens[i] = ptr[i];
+  for (int i = 0; i < ptr.size(); i++)
+    tokens[i] = ptr[i];
 
-    delete line;
+  delete line;
 
-    return tokens;
+  return tokens;
 }
 
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return Tokenize(line,std::string(", "));
+  std::string line;
+  std::getline(is, line);
+  return Tokenize(line, std::string(", "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return line;
+  std::string line;
+  std::getline(is, line);
+  return line;
 }
 
-static string rootName(const string inStr)
+static string
+rootName(const string inStr)
 {
 #ifdef WIN32
-    const string dirSep("\\");
+  const string dirSep("\\");
 #else
-    const string dirSep("/");
+  const string dirSep("/");
 #endif
-    vector<string> res = Tokenize(inStr,dirSep);
-    res = Tokenize(res[res.size()-1],string("."));
-    string result = res[0];
-    for (int i=1; i<res.size()-1; ++i)
-        result = result + string(".") + res[i];
-    return result;
+  vector<string> res = Tokenize(inStr, dirSep);
+  res = Tokenize(res[res.size() - 1], string("."));
+  string result = res[0];
+  for (int i = 1; i < res.size() - 1; ++i)
+    result = result + string(".") + res[i];
+  return result;
 }
 
 typedef Array<Real> Point;
 typedef list<Point> PointList;
 typedef vector<Point> PointVec;
-typedef pair<int,int> Edge;
-typedef map<Edge, pair<Point,int> > PMap;
+typedef pair<int, int> Edge;
+typedef map<Edge, pair<Point, int>> PMap;
 typedef PMap::iterator PMapIt;
 static PMap vertCache;
 vector<PMapIt> vertVec;
 
-
-
-
 struct Segment
 {
-    Segment() : p(2), mLength(-1) {}
-    Real Length ();
-    const PMapIt& operator[] (int n) const { return p[n]; }
-    PMapIt& operator[] (int n) { return p[n]; }
-    int ID_l () const {return (*p[0]).second.second;}
-    int ID_r () const {return (*p[1]).second.second;}
-    void flip ();
-    static int xComp,yComp;
-    Array<PMapIt> p;
-    
+  Segment() : p(2), mLength(-1) {}
+  Real Length();
+  const PMapIt& operator[](int n) const { return p[n]; }
+  PMapIt& operator[](int n) { return p[n]; }
+  int ID_l() const { return (*p[0]).second.second; }
+  int ID_r() const { return (*p[1]).second.second; }
+  void flip();
+  static int xComp, yComp;
+  Array<PMapIt> p;
+
 private:
-    void my_length();
-    Real mLength;
+  void my_length();
+  Real mLength;
 };
 
 typedef list<Segment> SegList;
 
-bool operator<(const Edge& lhs, const Edge& rhs)
+bool
+operator<(const Edge& lhs, const Edge& rhs)
 {
-    if (std::min(lhs.first,lhs.second) != std::min(rhs.first,rhs.second))
-    {
-        return (std::min(lhs.first,lhs.second) < std::min(rhs.first,rhs.second));
-    }
-    return std::max(lhs.first,lhs.second) < std::max(rhs.first,rhs.second);
+  if (std::min(lhs.first, lhs.second) != std::min(rhs.first, rhs.second)) {
+    return (std::min(lhs.first, lhs.second) < std::min(rhs.first, rhs.second));
+  }
+  return std::max(lhs.first, lhs.second) < std::max(rhs.first, rhs.second);
 }
 
 struct EdgeLess
 {
-    bool operator()(const Edge& lhs, const Edge& rhs) const
-        { return operator<(lhs,rhs); }
+  bool operator()(const Edge& lhs, const Edge& rhs) const
+  {
+    return operator<(lhs, rhs);
+  }
 };
 
-bool operator==(const Edge& lhs, const Edge& rhs)
+bool
+operator==(const Edge& lhs, const Edge& rhs)
 {
-    return (lhs.first == rhs.first && lhs.second == rhs.second) ||
-        (lhs.first == rhs.second && lhs.second == rhs.first);
+  return (lhs.first == rhs.first && lhs.second == rhs.second) ||
+         (lhs.first == rhs.second && lhs.second == rhs.first);
 }
 
-bool operator!=(const Edge& lhs, const Edge& rhs)
+bool
+operator!=(const Edge& lhs, const Edge& rhs)
 {
-    return !operator==(lhs,rhs);
+  return !operator==(lhs, rhs);
 }
 
-
-bool operator==(const Segment& lhs, const Segment& rhs)
+bool
+operator==(const Segment& lhs, const Segment& rhs)
 {
-    return lhs.ID_l() == rhs.ID_l() && lhs.ID_r() == rhs.ID_r();
+  return lhs.ID_l() == rhs.ID_l() && lhs.ID_r() == rhs.ID_r();
 }
 
-bool operator!=(const Segment& lhs, const Segment& rhs)
+bool
+operator!=(const Segment& lhs, const Segment& rhs)
 {
-    return !operator==(lhs,rhs);
+  return !operator==(lhs, rhs);
 }
 
-PMapIt VertexInterp(Real isoVal,int isoComp,const vector<Point>& pts,int p1,int p2);
+PMapIt VertexInterp(
+  Real isoVal, int isoComp, const vector<Point>& pts, int p1, int p2);
 
-Array<Segment> Segmentise(const vector<Point>& pts,
-                          const vector<int>&   elt,
-                          Real                 isoVal,
-                          int                  isoComp);
-
+Array<Segment> Segmentise(
+  const vector<Point>& pts, const vector<int>& elt, Real isoVal, int isoComp);
 
 SegList::iterator FindMySeg(SegList& segs, int idx);
 
-int Nreuse=0;
+int Nreuse = 0;
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    BoxLib::Initialize(argc,argv);
+  BoxLib::Initialize(argc, argv);
 
-    ParmParse pp;
+  ParmParse pp;
 
-    int nElts;
-    string infile; pp.get("infile",infile);
+  int nElts;
+  string infile;
+  pp.get("infile", infile);
 
-    FArrayBox nodes;
-    Array<int> faceData;
-    vector<string> names;
-    string label;
-    read_iso(infile,nodes,faceData,nElts,names,label);
-    int nodesPerElt = faceData.size() / nElts;
-    AMREX_ASSERT(nodesPerElt*nElts == faceData.size());
+  FArrayBox nodes;
+  Array<int> faceData;
+  vector<string> names;
+  string label;
+  read_iso(infile, nodes, faceData, nElts, names, label);
+  int nodesPerElt = faceData.size() / nElts;
+  AMREX_ASSERT(nodesPerElt * nElts == faceData.size());
 
-    nElts = faceData.size() / nodesPerElt;
-    int nComp = nodes.nComp();
-    AMREX_ASSERT(nElts*nodesPerElt == faceData.size());
+  nElts = faceData.size() / nodesPerElt;
+  int nComp = nodes.nComp();
+  AMREX_ASSERT(nElts * nodesPerElt == faceData.size());
 
-    int dir=0; pp.query("dir",dir);
-    Array<Real> loc(1,0);
-    if (int nloc = pp.countval("locs"))
-    {
-        loc.resize(nloc);
-        pp.getarr("locs",loc,0,nloc);
+  int dir = 0;
+  pp.query("dir", dir);
+  Array<Real> loc(1, 0);
+  if (int nloc = pp.countval("locs")) {
+    loc.resize(nloc);
+    pp.getarr("locs", loc, 0, nloc);
+  }
+
+  // Put data into more convenient structure (so I can steal code from elsewhere
+  // for this)
+  Array<const Real*> dat(nComp);
+  for (int i = 0; i < dat.size(); ++i)
+    dat[i] = nodes.dataPtr(i);
+
+  Real* nodeData = nodes.dataPtr();
+  const int nNodes = nodes.box().length(0);
+  vector<Point> GridPts(nNodes);
+  for (int i = 0; i < nNodes; ++i) {
+    GridPts[i].resize(nComp);
+    for (int j = 0; j < nComp; ++j) {
+      GridPts[i][j] = dat[j][i];
+    }
+  }
+
+  for (int k = 0; k < loc.size(); ++k) {
+    SegList segments;
+    vector<int> elt(3);
+    for (int i = 0; i < nElts; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        elt[j] = faceData[i * nodesPerElt + j] - 1;
+      }
+
+      Array<Segment> eltSegs = Segmentise(GridPts, elt, loc[k], dir);
+
+      for (int j = 0; j < eltSegs.size(); ++j) {
+        segments.push_back(eltSegs[j]);
+      }
+    }
+    cerr << names[dir] << "=" << loc[k] << " slice computed." << endl;
+
+    // Number the isosurface vertices
+    int cnt = 0;
+    for (PMapIt it = vertCache.begin(); it != vertCache.end(); ++it)
+      (*it).second.second = cnt++;
+
+    // Build a reverse vector into the vertCache
+    vertVec.resize(vertCache.size());
+    cnt = 0;
+    for (PMapIt it = vertCache.begin(); it != vertCache.end(); ++it)
+      vertVec[cnt++] = it;
+
+    // Find a segment with the specified vertex as one of its endpoints,
+    // then assemble the list of segments to form the contour line.  If
+    // we finish, and segments remain, start a new line.
+    SegList segList = segments;
+    list<SegList> cLines;
+    if (segList.size() > 0) {
+      int idx = segList.front().ID_l();
+      int newIdx;
+      cLines.push_back(SegList());
+
+      while (segList.begin() != segList.end()) {
+        SegList::iterator segIt = FindMySeg(segList, idx);
+        if (segIt != segList.end()) {
+          int idx_l = (*segIt).ID_l();
+          int idx_r = (*segIt).ID_r();
+          if (idx_l == idx) {
+            newIdx = idx_r;
+            cLines.back().push_back(*segIt);
+          } else {
+            newIdx = idx_l;
+            Segment newSeg = Segment(*segIt);
+            newSeg.flip();
+            cLines.back().push_back(newSeg);
+          }
+
+          segList.erase(segIt);
+        } else {
+          cLines.push_back(SegList());
+          newIdx = segList.front().ID_l();
+        }
+
+        idx = newIdx;
+      }
+
+      // Connect up the line fragments as much as possible
+      bool changed;
+      do {
+        changed = false;
+        for (std::list<SegList>::iterator it = cLines.begin();
+             it != cLines.end(); ++it) {
+          if (!(*it).empty()) {
+            const int idx_l = (*it).front().ID_l();
+            const int idx_r = (*it).back().ID_r();
+            for (std::list<SegList>::iterator it1 = cLines.begin();
+                 it1 != cLines.end(); ++it1) {
+              if (!(*it1).empty() && (*it).front() != (*it1).front()) {
+                if (idx_r == (*it1).front().ID_l()) {
+                  (*it).splice((*it).end(), *it1);
+                  changed = true;
+                } else if (idx_r == (*it1).back().ID_r()) {
+                  (*it1).reverse();
+                  for (SegList::iterator it2 = (*it1).begin();
+                       it2 != (*it1).end(); ++it2)
+                    (*it2).flip();
+                  (*it).splice((*it).end(), *it1);
+                  changed = true;
+                } else if (idx_l == (*it1).front().ID_l()) {
+                  (*it1).reverse();
+                  for (SegList::iterator it2 = (*it1).begin();
+                       it2 != (*it1).end(); ++it2)
+                    (*it2).flip();
+                  (*it).splice((*it).begin(), *it1);
+                  changed = true;
+                }
+              }
+            }
+          }
+        }
+      } while (changed);
     }
 
-    // Put data into more convenient structure (so I can steal code from elsewhere for this)
-    Array<const Real*> dat(nComp);
-    for (int i=0; i<dat.size(); ++i)
-        dat[i] = nodes.dataPtr(i);
-
-    Real* nodeData = nodes.dataPtr();
-    const int nNodes = nodes.box().length(0);
-    vector<Point> GridPts(nNodes);
-    for (int i=0; i<nNodes; ++i) {
-        GridPts[i].resize(nComp);
-        for (int j=0; j<nComp; ++j) {
-            GridPts[i][j] = dat[j][i];
-        }
+    for (std::list<SegList>::iterator it = cLines.begin();
+         it != cLines.end();) {
+      if ((*it).empty())
+        cLines.erase(it++);
+      else
+        it++;
     }
 
-    for (int k=0; k<loc.size(); ++k)
-    {        
-        SegList segments;
-        vector<int> elt(3);
-        for (int i=0; i<nElts; ++i)
-        {
-            for (int j=0; j<3; ++j)
-            {
-                elt[j] = faceData[i*nodesPerElt + j ] - 1;
-            }
+    string outfileRoot = rootName(infile);
 
-            Array<Segment> eltSegs = Segmentise(GridPts,elt,loc[k],dir);
+    char buf[72];
+    sprintf(buf, "%g", std::abs(loc[k]));
+    string locStr = (loc[k] < 0 ? "n" : (loc[k] > 0 ? "p" : "")) + string(buf);
+    outfileRoot += "_" + names[dir] + "_" + locStr;
+    bool write_tec = true;
+    pp.query("write_tec", write_tec);
+    if (write_tec) {
+      ofstream os;
+      string outfile = outfileRoot + ".dat";
+      cerr << "Writing contour (" << vertCache.size() << " nodes, "
+           << segments.size() << " segments, " << cLines.size() << " lines"
+           << ") to " << outfile << endl;
 
-            for (int j=0; j<eltSegs.size(); ++j)
-            {
-                segments.push_back(eltSegs[j]);
-            }
-        }
-        cerr << names[dir] << "=" << loc[k] << " slice computed." << endl;
+      os.open(outfile.c_str(), std::ios::out);
+      os << "VARIABLES = ";
+      for (int i = 0; i < names.size(); ++i)
+        os << "\"" << names[i] << "\" ";
+      os << endl;
 
-        // Number the isosurface vertices
-        int cnt=0;
-        for (PMapIt it=vertCache.begin(); it!=vertCache.end(); ++it)
-            (*it).second.second = cnt++;
-
-        // Build a reverse vector into the vertCache
-        vertVec.resize(vertCache.size());
-        cnt=0;
-        for (PMapIt it=vertCache.begin(); it!=vertCache.end(); ++it)
-            vertVec[cnt++] = it;
-
-        // Find a segment with the specified vertex as one of its endpoints,
-        // then assemble the list of segments to form the contour line.  If
-        // we finish, and segments remain, start a new line.
-        SegList segList = segments;
-        list<SegList> cLines;
-        if (segList.size()>0)
-        {
-            int idx = segList.front().ID_l();
-            int newIdx;
-            cLines.push_back(SegList());
-        
-            while (segList.begin() != segList.end())
-            {
-                SegList::iterator segIt = FindMySeg(segList,idx);
-                if (segIt != segList.end())
-                {
-                    int idx_l = (*segIt).ID_l();
-                    int idx_r = (*segIt).ID_r();
-                    if ( idx_l == idx )
-                    {
-                        newIdx = idx_r;
-                        cLines.back().push_back(*segIt);
-                    }
-                    else
-                    {
-                        newIdx = idx_l;
-                        Segment newSeg = Segment(*segIt); newSeg.flip();
-                        cLines.back().push_back(newSeg);
-                    }
-                
-                    segList.erase(segIt);
-                }
-                else
-                {
-                    cLines.push_back(SegList());
-                    newIdx = segList.front().ID_l();
-                }
-            
-                idx = newIdx;
-            }
-        
-            // Connect up the line fragments as much as possible
-            bool changed;
-            do
-            {
-                changed = false;
-                for (std::list<SegList>::iterator it = cLines.begin(); it!=cLines.end(); ++it)
-                {
-                    if (!(*it).empty())
-                    {
-                        const int idx_l = (*it).front().ID_l();
-                        const int idx_r = (*it).back().ID_r();
-                        for (std::list<SegList>::iterator it1 = cLines.begin(); it1!=cLines.end(); ++it1)
-                        {
-                            if (!(*it1).empty() && (*it).front()!=(*it1).front())
-                            {
-                                if (idx_r == (*it1).front().ID_l())
-                                {
-                                    (*it).splice((*it).end(),*it1);
-                                    changed = true;
-                                }
-                                else if (idx_r == (*it1).back().ID_r())
-                                {
-                                    (*it1).reverse();
-                                    for (SegList::iterator it2=(*it1).begin(); it2!=(*it1).end(); ++it2)
-                                        (*it2).flip();
-                                    (*it).splice((*it).end(),*it1);
-                                    changed = true;
-                                }
-                                else if (idx_l == (*it1).front().ID_l())
-                                {
-                                    (*it1).reverse();
-                                    for (SegList::iterator it2=(*it1).begin(); it2!=(*it1).end(); ++it2)
-                                        (*it2).flip();
-                                    (*it).splice((*it).begin(),*it1);
-                                    changed = true;
-                                }
-                            }
-                        }
-                    }
-                }
-            } while(changed);
-        }
-    
-        for (std::list<SegList>::iterator it = cLines.begin(); it!=cLines.end();)
-        {
-            if ((*it).empty())
-                cLines.erase(it++);
-            else
-                it++;
-        }
-
-        string outfileRoot = rootName(infile);
-
+      int Ccnt = 0;
+      for (std::list<SegList>::iterator it = cLines.begin(); it != cLines.end();
+           it++) {
         char buf[72];
-        sprintf(buf, "%g", std::abs(loc[k])); 
-        string locStr = (loc[k]<0 ? "n" : (loc[k] > 0 ? "p" : "" ) ) + string(buf);
-        outfileRoot += "_"+names[dir]+"_"+locStr;
-        bool write_tec = true; pp.query("write_tec",write_tec);
-        if (write_tec)
-        {
-            ofstream os;
-            string outfile=outfileRoot + ".dat";
-            cerr << "Writing contour (" << vertCache.size() << " nodes, "
-                 << segments.size() << " segments, " << cLines.size() << " lines" << ") to " << outfile << endl;
-        
-            os.open(outfile.c_str(),std::ios::out);
-            os << "VARIABLES = ";
-            for (int i=0; i<names.size(); ++i)
-                os << "\"" << names[i] << "\" ";
+        sprintf(buf, "%g", loc[k]);
+        string zoneName =
+          rootName(infile) + "_" + names[dir] + "_" + string(buf);
+        sprintf(buf, "%d", Ccnt++);
+        zoneName += "_" + string(buf);
+
+        os << "ZONE T=\"" << zoneName << "\", I=" << (*it).size() + 1 << endl;
+
+        int lcnt = 0;
+        for (SegList::const_iterator its = (*it).begin(); its != (*it).end();
+             ++its) {
+          if (its == (*it).begin()) {
+            const Point& p = (*(*its)[0]).second.first;
+            for (int i = 0; i < p.size(); ++i)
+              os << p[i] << " ";
             os << endl;
-        
-            int Ccnt = 0;
-            for (std::list<SegList>::iterator it = cLines.begin(); it!=cLines.end(); it++)
-            {
-                char buf[72];
-                sprintf(buf, "%g", loc[k]); 
-                string zoneName = rootName(infile)+"_"+names[dir]+"_"+string(buf);
-                sprintf(buf, "%d", Ccnt++);
-                zoneName += "_"+string(buf);
-            
-                os << "ZONE T=\"" << zoneName << "\", I=" << (*it).size() + 1 << endl;
-            
-                int lcnt=0;
-                for (SegList::const_iterator its=(*it).begin(); its!=(*it).end(); ++its)
-                {
-                    if (its==(*it).begin())
-                    {
-                        const Point& p = (*(*its)[0]).second.first;
-                        for (int i=0; i<p.size(); ++i)
-                            os << p[i] << " ";
-                        os << endl;
-                    }
-                    const Point& p = (*(*its)[1]).second.first;  
-                    for (int i=0; i<p.size(); ++i)
-                        os << p[i] << " ";
-                    os << endl;
-                    lcnt++;
-                }
-            }
+          }
+          const Point& p = (*(*its)[1]).second.first;
+          for (int i = 0; i < p.size(); ++i)
+            os << p[i] << " ";
+          os << endl;
+          lcnt++;
         }
-
-        bool write_mef = true; pp.query("write_mef",write_mef);
-        if (write_mef)
-        {
-            int Nslice_nodes = vertVec.size();
-            const Box slice_box(IntVect::TheZeroVector(),Nslice_nodes*BoxLib::BASISV(0));
-            FArrayBox slice_nodes(slice_box,nComp);
-            Array<Real*> slice_dat(nComp);
-            for (int i=0; i<slice_dat.size(); ++i)
-                slice_dat[i] = slice_nodes.dataPtr(i);        
-
-            for (int i=0; i<Nslice_nodes; ++i)
-            {
-                const Point& p = vertVec[i]->second.first;
-                for (int j=0; j<nComp; ++j)
-                    slice_dat[j][i] = p[j];
-            }
-
-            int Nsegs = segments.size();
-            Array<int> slice_segs(2*Nsegs);
-            cnt = 0;
-            for (SegList::const_iterator it=segments.begin(); it!=segments.end(); ++it)
-            {
-                slice_segs[cnt++] = it->ID_l() + 1;
-                slice_segs[cnt++] = it->ID_r() + 1;
-            }
-            string outfile=outfileRoot + ".mef";
-            write_iso(outfile,slice_nodes,slice_segs,Nsegs,names,label);
-        }
-
-        vertCache.clear();
+      }
     }
 
-    BoxLib::Finalize();
-    return 0;
+    bool write_mef = true;
+    pp.query("write_mef", write_mef);
+    if (write_mef) {
+      int Nslice_nodes = vertVec.size();
+      const Box slice_box(
+        IntVect::TheZeroVector(), Nslice_nodes * BoxLib::BASISV(0));
+      FArrayBox slice_nodes(slice_box, nComp);
+      Array<Real*> slice_dat(nComp);
+      for (int i = 0; i < slice_dat.size(); ++i)
+        slice_dat[i] = slice_nodes.dataPtr(i);
+
+      for (int i = 0; i < Nslice_nodes; ++i) {
+        const Point& p = vertVec[i]->second.first;
+        for (int j = 0; j < nComp; ++j)
+          slice_dat[j][i] = p[j];
+      }
+
+      int Nsegs = segments.size();
+      Array<int> slice_segs(2 * Nsegs);
+      cnt = 0;
+      for (SegList::const_iterator it = segments.begin(); it != segments.end();
+           ++it) {
+        slice_segs[cnt++] = it->ID_l() + 1;
+        slice_segs[cnt++] = it->ID_r() + 1;
+      }
+      string outfile = outfileRoot + ".mef";
+      write_iso(outfile, slice_nodes, slice_segs, Nsegs, names, label);
+    }
+
+    vertCache.clear();
+  }
+
+  BoxLib::Finalize();
+  return 0;
 }
 
 void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Array<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label)
+write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label)
 {
-    // Rotate data to vary quickest on component
-    int nCompSurf = nodes.nComp();
-    int nNodes = nodes.box().numPts();
+  // Rotate data to vary quickest on component
+  int nCompSurf = nodes.nComp();
+  int nNodes = nodes.box().numPts();
 
-    FArrayBox tnodes(nodes.box(),nCompSurf);
-    const Real** np = new const Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            ndat[j] = np[j][i];
-        }
-        ndat += nCompSurf;
+  FArrayBox tnodes(nodes.box(), nCompSurf);
+  const Real** np = new const Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      ndat[j] = np[j][i];
     }
-    delete [] np;
+    ndat += nCompSurf;
+  }
+  delete[] np;
 
-    std::ofstream ofs;
-    ofs.open(outfile.c_str(),std::ios::out|std::ios::trunc|std::ios::binary);
-    ofs << label << endl;
-    for (int i=0; i<nCompSurf; ++i)
-    {
-        ofs << names[i];
-        if (i < nCompSurf-1)
-            ofs << " ";
-        else
-            ofs << std::endl;
-    }
-    int nodesPerElt = faceData.size() / nElts;
-    ofs << nElts << " " << nodesPerElt << endl;
-    tnodes.writeOn(ofs);
-    ofs.write((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-    ofs.close();
+  std::ofstream ofs;
+  ofs.open(outfile.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
+  ofs << label << endl;
+  for (int i = 0; i < nCompSurf; ++i) {
+    ofs << names[i];
+    if (i < nCompSurf - 1)
+      ofs << " ";
+    else
+      ofs << std::endl;
+  }
+  int nodesPerElt = faceData.size() / nElts;
+  ofs << nElts << " " << nodesPerElt << endl;
+  tnodes.writeOn(ofs);
+  ofs.write((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
+  ofs.close();
 }
 
 void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Array<int>&        faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label)
+read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Array<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label)
 {
-    std::ifstream ifs;
-    ifs.open(infile.c_str(),std::ios::in|std::ios::binary);
-    label = parseTitle(ifs);
-    names = parseVarNames(ifs);
-    const int nCompSurf = names.size();
+  std::ifstream ifs;
+  ifs.open(infile.c_str(), std::ios::in | std::ios::binary);
+  label = parseTitle(ifs);
+  names = parseVarNames(ifs);
+  const int nCompSurf = names.size();
 
-    int nodesPerElt;
-    ifs >> nElts;
-    ifs >> nodesPerElt;
+  int nodesPerElt;
+  ifs >> nElts;
+  ifs >> nodesPerElt;
 
-    FArrayBox tnodes;
-    tnodes.readFrom(ifs);
-    const int nNodes = tnodes.box().numPts();
+  FArrayBox tnodes;
+  tnodes.readFrom(ifs);
+  const int nNodes = tnodes.box().numPts();
 
-    // "rotate" the data so that the components are 'in the right spot for fab data'
-    nodes.resize(tnodes.box(),nCompSurf);
-    Real** np = new Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
+  // "rotate" the data so that the components are 'in the right spot for fab
+  // data'
+  nodes.resize(tnodes.box(), nCompSurf);
+  Real** np = new Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
 
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            np[j][i] = ndat[j];
-        }
-        ndat += nCompSurf;
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      np[j][i] = ndat[j];
     }
-    delete [] np;
-    tnodes.clear();
+    ndat += nCompSurf;
+  }
+  delete[] np;
+  tnodes.clear();
 
-    faceData.resize(nElts*nodesPerElt,0);
-    ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
+  faceData.resize(nElts * nodesPerElt, 0);
+  ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
 }
 
-SegList::iterator FindMySeg(SegList& segs, int idx)
+SegList::iterator
+FindMySeg(SegList& segs, int idx)
 {
-    const PMapIt& vertToFind = vertVec[idx];
-    for (SegList::iterator it=segs.begin(); it!=segs.end(); ++it)
-    {
-        if ( ((*it)[0] == vertToFind) || ((*it)[1] == vertToFind) )
-            return it;
-    }
-    return segs.end();
+  const PMapIt& vertToFind = vertVec[idx];
+  for (SegList::iterator it = segs.begin(); it != segs.end(); ++it) {
+    if (((*it)[0] == vertToFind) || ((*it)[1] == vertToFind))
+      return it;
+  }
+  return segs.end();
 }
-
 
 int Segment::xComp = 0;
 int Segment::yComp = 1;
@@ -552,81 +533,82 @@ int Segment::yComp = 1;
 Real
 Segment::Length()
 {
-    if (mLength<0)
-        my_length();
-    return mLength;
+  if (mLength < 0)
+    my_length();
+  return mLength;
 }
 
 void
 Segment::my_length()
 {
-    const Point& p0 = (*p[0]).second.first;
-    const Point& p1 = (*p[1]).second.first;
-    mLength = std::sqrt(((p1[xComp] - p0[xComp])*(p1[xComp] - p0[xComp]))
-                        +((p1[yComp] - p0[yComp])*(p1[yComp] - p0[yComp])));
-}    
+  const Point& p0 = (*p[0]).second.first;
+  const Point& p1 = (*p[1]).second.first;
+  mLength = std::sqrt(
+    ((p1[xComp] - p0[xComp]) * (p1[xComp] - p0[xComp])) +
+    ((p1[yComp] - p0[yComp]) * (p1[yComp] - p0[yComp])));
+}
 
 void
 Segment::flip()
 {
-    PMapIt ptmp = p[0];
-    p[0] = p[1];
-    p[1] = ptmp;
-}    
+  PMapIt ptmp = p[0];
+  p[0] = p[1];
+  p[1] = ptmp;
+}
 
 /*
    Linearly interpolate the position where an isosurface cuts
    an edge between two vertices, each with their own scalar value
 */
-Point VI_doIt(Real isoVal,int isoComp,const vector<Point>& pts,int p1,int p2)
+Point
+VI_doIt(Real isoVal, int isoComp, const vector<Point>& pts, int p1, int p2)
 {
-    AMREX_ASSERT(p1<pts.size() && p2<pts.size());
-    const Point& pt1 = pts[p1];
-    const Point& pt2 = pts[p2];
+  AMREX_ASSERT(p1 < pts.size() && p2 < pts.size());
+  const Point& pt1 = pts[p1];
+  const Point& pt2 = pts[p2];
 
-    AMREX_ASSERT(isoComp!=pts.size() && isoComp<pt1.size() && pt1.size()==pt2.size());
+  AMREX_ASSERT(
+    isoComp != pts.size() && isoComp < pt1.size() && pt1.size() == pt2.size());
 
-    const Real valp1 = pt1[isoComp];
-    const Real valp2 = pt2[isoComp];
-    
-    if (std::abs(isoVal-valp1) < epsilon_DEF)
-        return pt1;
-    if (std::abs(isoVal-valp2) < epsilon_DEF)
-        return pt2;
-    if (std::abs(valp1-valp2) < epsilon_DEF)
-        return pt1;
-    
-    Point res(pt1.size());
-    const Real mu = (isoVal - valp1) / (valp2 - valp1);
-    for (int j=0; j<res.size(); ++j)
-        res[j] = pt1[j] + mu * (pt2[j] - pt1[j]);
-    
-    return res;
+  const Real valp1 = pt1[isoComp];
+  const Real valp2 = pt2[isoComp];
+
+  if (std::abs(isoVal - valp1) < epsilon_DEF)
+    return pt1;
+  if (std::abs(isoVal - valp2) < epsilon_DEF)
+    return pt2;
+  if (std::abs(valp1 - valp2) < epsilon_DEF)
+    return pt1;
+
+  Point res(pt1.size());
+  const Real mu = (isoVal - valp1) / (valp2 - valp1);
+  for (int j = 0; j < res.size(); ++j)
+    res[j] = pt1[j] + mu * (pt2[j] - pt1[j]);
+
+  return res;
 }
 
-PMapIt VertexInterp(Real isoVal,int isoComp,const vector<Point>& pts,int p1,int p2)
+PMapIt
+VertexInterp(Real isoVal, int isoComp, const vector<Point>& pts, int p1, int p2)
 {
-    Edge ppair(p1,p2);
-    PMapIt fwd,rev;
-    fwd = vertCache.find(ppair);
-    if (fwd == vertCache.end())
-    {
-        rev = vertCache.find(Edge(p2,p1));
-        
-        if (rev == vertCache.end())
-        {
-            return vertCache.insert(
-                std::make_pair(ppair,
-                std::make_pair(VI_doIt(isoVal,isoComp,pts,p1,p2),0))).first;
-        }
-        else
-        {
-            Nreuse++;
-            return rev;
-        }
+  Edge ppair(p1, p2);
+  PMapIt fwd, rev;
+  fwd = vertCache.find(ppair);
+  if (fwd == vertCache.end()) {
+    rev = vertCache.find(Edge(p2, p1));
+
+    if (rev == vertCache.end()) {
+      return vertCache
+        .insert(std::make_pair(
+          ppair, std::make_pair(VI_doIt(isoVal, isoComp, pts, p1, p2), 0)))
+        .first;
+    } else {
+      Nreuse++;
+      return rev;
     }
-    Nreuse++;
-    return fwd;
+  }
+  Nreuse++;
+  return fwd;
 }
 
 /*
@@ -634,48 +616,50 @@ PMapIt VertexInterp(Real isoVal,int isoComp,const vector<Point>& pts,int p1,int 
    required to represent the contour through the cell.
    Return an array of line segments
 */
-Array<Segment> Segmentise(const vector<Point>&  pts,
-                          const vector<int>&    elt,
-                          Real                  isoVal,
-                          int                   isoComp)
+Array<Segment>
+Segmentise(
+  const vector<Point>& pts, const vector<int>& elt, Real isoVal, int isoComp)
 {
-   AMREX_ASSERT(elt.size()==3);
-   Array<PMapIt> vertlist(2);
-   Array<Segment> segments;
+  AMREX_ASSERT(elt.size() == 3);
+  Array<PMapIt> vertlist(2);
+  Array<Segment> segments;
 
-   const int p0 = elt[0];
-   const int p1 = elt[1];
-   const int p2 = elt[2];
+  const int p0 = elt[0];
+  const int p1 = elt[1];
+  const int p2 = elt[2];
 
-   int segCase = 0;
-   if (pts[p0][isoComp] < isoVal) segCase |= 1;
-   if (pts[p1][isoComp] < isoVal) segCase |= 2;
-   if (pts[p2][isoComp] < isoVal) segCase |= 4;
+  int segCase = 0;
+  if (pts[p0][isoComp] < isoVal)
+    segCase |= 1;
+  if (pts[p1][isoComp] < isoVal)
+    segCase |= 2;
+  if (pts[p2][isoComp] < isoVal)
+    segCase |= 4;
 
-   if (segCase==0 || segCase==7)
-       return segments;
+  if (segCase == 0 || segCase == 7)
+    return segments;
 
-   switch (segCase) {
-   case 1:
-   case 6:
-       vertlist[0] = VertexInterp(isoVal,isoComp,pts,p0,p1);
-       vertlist[1] = VertexInterp(isoVal,isoComp,pts,p0,p2);
-       break;
-   case 2:
-   case 5:
-       vertlist[0] = VertexInterp(isoVal,isoComp,pts,p1,p0);
-       vertlist[1] = VertexInterp(isoVal,isoComp,pts,p1,p2);
-       break;
-   case 3:
-   case 4:
-       vertlist[0] = VertexInterp(isoVal,isoComp,pts,p2,p0);
-       vertlist[1] = VertexInterp(isoVal,isoComp,pts,p2,p1);
-       break;
-   }
+  switch (segCase) {
+  case 1:
+  case 6:
+    vertlist[0] = VertexInterp(isoVal, isoComp, pts, p0, p1);
+    vertlist[1] = VertexInterp(isoVal, isoComp, pts, p0, p2);
+    break;
+  case 2:
+  case 5:
+    vertlist[0] = VertexInterp(isoVal, isoComp, pts, p1, p0);
+    vertlist[1] = VertexInterp(isoVal, isoComp, pts, p1, p2);
+    break;
+  case 3:
+  case 4:
+    vertlist[0] = VertexInterp(isoVal, isoComp, pts, p2, p0);
+    vertlist[1] = VertexInterp(isoVal, isoComp, pts, p2, p1);
+    break;
+  }
 
-   segments.resize(1);
-   segments[0][0] = vertlist[0];
-   segments[0][1] = vertlist[1];
+  segments.resize(1);
+  segments[0][0] = vertlist[0];
+  segments[0][1] = vertlist[1];
 
-   return segments;
+  return segments;
 }

--- a/Src/slicePlot.cpp
+++ b/Src/slicePlot.cpp
@@ -7,84 +7,94 @@
 
 using namespace amrex;
 
-void STORE_PPM_STR (const std::string& file,
-                    int width, int height, int iimage[],
-                    const int r[], const int g[], const int b[]);
-void STORE_PGM_STR (const std::string& file,
-                    int width, int height, int iimage[]);
-void LOAD_PALETTE_STR (const std::string& file, int r[], int g[], int b[], int a[]);
-void pixelizeData(const FArrayBox& data, int slicedir, int sliceloc,
-                  BaseFab<int>& image, Real data_min, Real data_max, int nVals);
+void STORE_PPM_STR(
+  const std::string& file,
+  int width,
+  int height,
+  int iimage[],
+  const int r[],
+  const int g[],
+  const int b[]);
+void
+STORE_PGM_STR(const std::string& file, int width, int height, int iimage[]);
+void
+LOAD_PALETTE_STR(const std::string& file, int r[], int g[], int b[], int a[]);
+void pixelizeData(
+  const FArrayBox& data,
+  int slicedir,
+  int sliceloc,
+  BaseFab<int>& image,
+  Real data_min,
+  Real data_max,
+  int nVals);
 
 static std::string AND("_");
 static std::string PPM(".ppm");
 static std::string PGM(".pgm");
 static std::string FABF(".fab");
 
-int main(int argc, char* argv[])
+int
+main(int argc, char* argv[])
 {
-  amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
   {
     ParmParse pp;
     std::string file;
-    pp.get("file",file);
+    pp.get("file", file);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(file, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
 
-    const std::vector<std::string>& pieces = Tokenize(file,std::string("/"));
+    const std::vector<std::string>& pieces = Tokenize(file, std::string("/"));
 
     int slicedir, sliceloc;
-    pp.get("slicedir",slicedir);
-    pp.get("sliceloc",sliceloc);
+    pp.get("slicedir", slicedir);
+    pp.get("sliceloc", sliceloc);
     std::string varname;
-    pp.get("varname",varname);
+    pp.get("varname", varname);
     AMREX_ALWAYS_ASSERT(amrData.CanDerive(varname));
 
     Box domain = amrData.ProbDomain()[finestLevel];
-    domain.setSmall(slicedir,sliceloc);
-    domain.setBig(slicedir,sliceloc);
-    FArrayBox data(domain,1);
-    amrData.FillVar(&data,data.box(),finestLevel,varname,0);
+    domain.setSmall(slicedir, sliceloc);
+    domain.setBig(slicedir, sliceloc);
+    FArrayBox data(domain, 1);
+    amrData.FillVar(&data, data.box(), finestLevel, varname, 0);
     Print() << "min,max: " << data.min() << ", " << data.max() << std::endl;
 
-    std::string outtype("image"); pp.query("outtype",outtype);
-    if (outtype=="image" || outtype=="gray")
-    {
+    std::string outtype("image");
+    pp.query("outtype", outtype);
+    if (outtype == "image" || outtype == "gray") {
       Real data_min = data.min();
       Real data_max = data.max();
-      pp.query("min",data_min);
-      pp.query("max",data_max);
-      
+      pp.query("min", data_min);
+      pp.query("max", data_max);
+
       BaseFab<int> image;
       const int nVals = 256;
-      pixelizeData(data,slicedir,sliceloc,image,data_min,data_max,nVals);
-      
-      const int width = image.box().length(0);
-      const int height= image.box().length(1);
+      pixelizeData(data, slicedir, sliceloc, image, data_min, data_max, nVals);
 
-      if (outtype=="image")
-      {
+      const int width = image.box().length(0);
+      const int height = image.box().length(1);
+
+      if (outtype == "image") {
         std::string palfile;
-        pp.get("palette",palfile);
+        pp.get("palette", palfile);
         int r[256], g[256], b[256], t[256];
-        LOAD_PALETTE_STR(palfile,r,g,b,t);
-            
-        std::string outfile = pieces[pieces.size()-1] + PPM;
-        pp.query("outfile",outfile);
+        LOAD_PALETTE_STR(palfile, r, g, b, t);
+
+        std::string outfile = pieces[pieces.size() - 1] + PPM;
+        pp.query("outfile", outfile);
         STORE_PPM_STR(outfile, width, height, image.dataPtr(), r, g, b);
-      }
-      else
-      {
-        std::string outfile = pieces[pieces.size()-1] + PGM;
-        pp.query("outfile",outfile);
+      } else {
+        std::string outfile = pieces[pieces.size() - 1] + PGM;
+        pp.query("outfile", outfile);
         STORE_PGM_STR(outfile, width, height, image.dataPtr());
       }
     }
@@ -92,43 +102,50 @@ int main(int argc, char* argv[])
   amrex::Finalize();
 }
 
-void pixelizeData(const FArrayBox& data, int slicedir, int sliceloc,
-                  BaseFab<int>& image, Real data_min, Real data_max, int nVals)
+void
+pixelizeData(
+  const FArrayBox& data,
+  int slicedir,
+  int sliceloc,
+  BaseFab<int>& image,
+  Real data_min,
+  Real data_max,
+  int nVals)
 {
   const Box& box = data.box();
   const Real del = data_max - data_min;
-  AMREX_ASSERT(std::abs(del)>0.0);
-  const int nvm1 = nVals-1;
-  int cnt=0;
+  AMREX_ASSERT(std::abs(del) > 0.0);
+  const int nvm1 = nVals - 1;
+  int cnt = 0;
   int d[2];
-  for (int dir=0; dir<AMREX_SPACEDIM; ++dir)
+  for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
     if (dir != slicedir)
       d[cnt++] = dir;
 
   const IntVect se = box.smallEnd();
   const IntVect be = box.bigEnd();
 
-  Print() << Box(se,be) << std::endl;
+  Print() << Box(se, be) << std::endl;
 
-  IntVect img(AMREX_D_DECL(box.length(d[0]) - 1,box.length(d[1]) - 1,0));
-  image.resize(Box(IntVect::TheZeroVector(),img),1);
+  IntVect img(AMREX_D_DECL(box.length(d[0]) - 1, box.length(d[1]) - 1, 0));
+  image.resize(Box(IntVect::TheZeroVector(), img), 1);
 
   IntVect div;
-  if (slicedir>=0 && slicedir<AMREX_SPACEDIM)
-      div[slicedir] = sliceloc;
+  if (slicedir >= 0 && slicedir < AMREX_SPACEDIM)
+    div[slicedir] = sliceloc;
 
-  for (int i=se[d[0]]; i<=be[d[0]]; ++i) {
-    for (int j=se[d[1]]; j<=be[d[1]]; ++j) {
+  for (int i = se[d[0]]; i <= be[d[0]]; ++i) {
+    for (int j = se[d[1]]; j <= be[d[1]]; ++j) {
       div[d[0]] = i;
       div[d[1]] = j;
-      image(IntVect(AMREX_D_DECL(i - se[d[0]],j - se[d[1]],0)),0) =
-        std::max(0,(int)(nvm1*std::min( (data(div,0) - data_min)/del,1.0))); 
+      image(IntVect(AMREX_D_DECL(i - se[d[0]], j - se[d[1]], 0)), 0) = std::max(
+        0, (int)(nvm1 * std::min((data(div, 0) - data_min) / del, 1.0)));
     }
   }
-  //BaseFab<int> imageRev(image.box(), 1);
-  //imageRev.copy(image);
-  //int rMult(1);
-  //image.copyRev(image.box(), imageRev, image.box(), 1, &rMult);
+  // BaseFab<int> imageRev(image.box(), 1);
+  // imageRev.copy(image);
+  // int rMult(1);
+  // image.copyRev(image.box(), imageRev, image.box(), 1, &rMult);
 }
 
 #include <cstdlib>
@@ -139,106 +156,97 @@ static const char RPGM_MAGIC2 = '5';
 static const char RPGM_MAGIC3 = '6';
 
 void
-STORE_PPM_STR (const std::string& file, int width, int height, int iimage[],
-	       const int r[], const int g[], const int b[])
+STORE_PPM_STR(
+  const std::string& file,
+  int width,
+  int height,
+  int iimage[],
+  const int r[],
+  const int g[],
+  const int b[])
 {
-  FILE *image_fp;	/* file descriptor for image (output) */
-  
+  FILE* image_fp; /* file descriptor for image (output) */
+
   /* create image file */
-  if ((image_fp = fopen(file.c_str(), "w")) == NULL)
-  {
-      fprintf(stderr, "cannot open output file %s\n", file.c_str());
-      exit(1);
+  if ((image_fp = fopen(file.c_str(), "w")) == NULL) {
+    fprintf(stderr, "cannot open output file %s\n", file.c_str());
+    exit(1);
   }
-  
+
   /* translate Fortran image data to chars */
-  unsigned char* image = new unsigned char[3*width*height];
-  for (int i = 0; i < width*height; i++ )
-  {
-      const int j = iimage[i];
-      if ( j < 0 || j > 255 ) 
-      {
-	  fprintf(stderr,"out of bounds on image[%d] = %d\n", i, j);
-	  exit(1);
-      }
-      image[3*i+0] = r[j];
-      image[3*i+1] = g[j];
-      image[3*i+2] = b[j];
-  }
-  fprintf(image_fp, "%c%c\n%d %d\n%d\n", PGM_MAGIC1, RPGM_MAGIC3,
-	  width, height, 255);
-  fwrite(image, 1, 3*width*height, image_fp);
-  delete [] image;
-  fclose(image_fp);
-}
-
-void
-STORE_PGM_STR (const std::string& file, int width, int height, int iimage[])
-{
-  FILE *image_fp;	/* file descriptor for image (output) */
-
-  /* create image file */
-  if ((image_fp = fopen(file.c_str(), "w")) == NULL)
-    {
-      fprintf(stderr, "cannot open output file %s\n", file.c_str());
+  unsigned char* image = new unsigned char[3 * width * height];
+  for (int i = 0; i < width * height; i++) {
+    const int j = iimage[i];
+    if (j < 0 || j > 255) {
+      fprintf(stderr, "out of bounds on image[%d] = %d\n", i, j);
       exit(1);
     }
-
-  /* translate Fortran image data to chars */
-  unsigned char* image = new unsigned char[width*height];
-  for (int i = 0; i < width*height; ++i )
-  {
-      image[i] = iimage[i];
+    image[3 * i + 0] = r[j];
+    image[3 * i + 1] = g[j];
+    image[3 * i + 2] = b[j];
   }
-  fprintf(image_fp, "%c%c\n%d %d\n%d\n", PGM_MAGIC1, RPGM_MAGIC2,
-	  width, height, 255);
-  fwrite(image, 1, width*height, image_fp);
-  delete [] image;
+  fprintf(
+    image_fp, "%c%c\n%d %d\n%d\n", PGM_MAGIC1, RPGM_MAGIC3, width, height, 255);
+  fwrite(image, 1, 3 * width * height, image_fp);
+  delete[] image;
   fclose(image_fp);
 }
 
 void
-LOAD_PALETTE_STR (const std::string& file, int r[], int g[], int b[], int a[])
+STORE_PGM_STR(const std::string& file, int width, int height, int iimage[])
 {
-  FILE *pal_fp;	/* file descriptor for image (output) */
+  FILE* image_fp; /* file descriptor for image (output) */
+
+  /* create image file */
+  if ((image_fp = fopen(file.c_str(), "w")) == NULL) {
+    fprintf(stderr, "cannot open output file %s\n", file.c_str());
+    exit(1);
+  }
+
+  /* translate Fortran image data to chars */
+  unsigned char* image = new unsigned char[width * height];
+  for (int i = 0; i < width * height; ++i) {
+    image[i] = iimage[i];
+  }
+  fprintf(
+    image_fp, "%c%c\n%d %d\n%d\n", PGM_MAGIC1, RPGM_MAGIC2, width, height, 255);
+  fwrite(image, 1, width * height, image_fp);
+  delete[] image;
+  fclose(image_fp);
+}
+
+void
+LOAD_PALETTE_STR(const std::string& file, int r[], int g[], int b[], int a[])
+{
+  FILE* pal_fp; /* file descriptor for image (output) */
   unsigned char c[256];
   int i;
 
-  if ((pal_fp = fopen(file.c_str(), "rb")) == NULL)
-    {
-      fprintf(stderr, "cannot open palette file %s\n", file.c_str());
-      exit(1);
-    }
+  if ((pal_fp = fopen(file.c_str(), "rb")) == NULL) {
+    fprintf(stderr, "cannot open palette file %s\n", file.c_str());
+    exit(1);
+  }
   fread(c, 1, 256, pal_fp);
-  for ( i = 0; i < 256; ++i )
-    {
-      r[i] = c[i];
-    }
+  for (i = 0; i < 256; ++i) {
+    r[i] = c[i];
+  }
   fread(c, 1, 256, pal_fp);
-  for ( i = 0; i < 256; ++i )
-    {
-      g[i] = c[i];
-    }
+  for (i = 0; i < 256; ++i) {
+    g[i] = c[i];
+  }
   fread(c, 1, 256, pal_fp);
-  for ( i = 0; i < 256; ++i )
-    {
-      b[i] = c[i];
-    }
+  for (i = 0; i < 256; ++i) {
+    b[i] = c[i];
+  }
   i = fread(c, 1, 256, pal_fp);
-  if ( i == 256 )
-    {
-      for ( i = 0; i < 256; ++i )
-	{
-	  a[i] = c[i];
-	}
+  if (i == 256) {
+    for (i = 0; i < 256; ++i) {
+      a[i] = c[i];
     }
-  else
-    {
-      for ( i = 0; i < 256; ++i )
-	{
-	  a[i] = 0;
-	}
+  } else {
+    for (i = 0; i < 256; ++i) {
+      a[i] = 0;
     }
+  }
   fclose(pal_fp);
 }
-

--- a/Src/smoothMEF.cpp
+++ b/Src/smoothMEF.cpp
@@ -12,358 +12,351 @@
 #include "DataServices.H"
 #include "Geometry.H"
 #include "Utility.H"
-using std::vector;
+using std::cerr;
+using std::cout;
+using std::endl;
+using std::ofstream;
 using std::set;
 using std::string;
-using std::cerr;
-using std::endl;
-using std::cout;
-using std::ofstream;
+using std::vector;
 
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Array<int>&        faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label);
+void read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Array<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label);
 
-void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Array<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label);
+void write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label);
 
 vector<std::string>
-Tokenize (const std::string& instr, const std::string& separators)
+Tokenize(const std::string& instr, const std::string& separators)
 {
-    vector<char*> ptr;
-    //
-    // Make copy of line that we can modify.
-    //
-    char* line = new char[instr.size()+1];
+  vector<char*> ptr;
+  //
+  // Make copy of line that we can modify.
+  //
+  char* line = new char[instr.size() + 1];
 
-    (void) strcpy(line, instr.c_str());
+  (void)strcpy(line, instr.c_str());
 
-    char* token = 0;
+  char* token = 0;
 
-    if (!((token = strtok(line, separators.c_str())) == 0))
-    {
-        ptr.push_back(token);
-        while (!((token = strtok(0, separators.c_str())) == 0))
-            ptr.push_back(token);
-    }
+  if (!((token = strtok(line, separators.c_str())) == 0)) {
+    ptr.push_back(token);
+    while (!((token = strtok(0, separators.c_str())) == 0))
+      ptr.push_back(token);
+  }
 
-    vector<std::string> tokens(ptr.size());
+  vector<std::string> tokens(ptr.size());
 
-    for (int i = 1; i < ptr.size(); i++)
-    {
-        char* p = ptr[i];
+  for (int i = 1; i < ptr.size(); i++) {
+    char* p = ptr[i];
 
-        while (strchr(separators.c_str(), *(p-1)) != 0)
-            *--p = 0;
-    }
+    while (strchr(separators.c_str(), *(p - 1)) != 0)
+      *--p = 0;
+  }
 
-    for (int i = 0; i < ptr.size(); i++)
-        tokens[i] = ptr[i];
+  for (int i = 0; i < ptr.size(); i++)
+    tokens[i] = ptr[i];
 
-    delete line;
+  delete line;
 
-    return tokens;
+  return tokens;
 }
 
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return Tokenize(line,std::string(", "));
+  std::string line;
+  std::getline(is, line);
+  return Tokenize(line, std::string(", "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return line;
+  std::string line;
+  std::getline(is, line);
+  return line;
 }
 
-static 
-Array<Array<int> > 
-buildNodeNeighbors(const Array<int>& faceData,
-                   int               nNodes)
+static Array<Array<int>>
+buildNodeNeighbors(const Array<int>& faceData, int nNodes)
 {
-    Array<Array<int> > nodeNeighbors(nNodes);
-    int nElts = faceData.size()/3;
-    for (int i=0; i<nElts; ++i)
-    {
-        int offset=i*3;
-        for (int j=0; j<3; ++j)
-        {
-            Array<int>& neighbors = nodeNeighbors[ faceData[offset+j]-1 ];
-            neighbors.resize(neighbors.size()+1);
-            neighbors[neighbors.size()-1] = i; // b/c of how this is done, we know the list will be unique
-        }
+  Array<Array<int>> nodeNeighbors(nNodes);
+  int nElts = faceData.size() / 3;
+  for (int i = 0; i < nElts; ++i) {
+    int offset = i * 3;
+    for (int j = 0; j < 3; ++j) {
+      Array<int>& neighbors = nodeNeighbors[faceData[offset + j] - 1];
+      neighbors.resize(neighbors.size() + 1);
+      neighbors[neighbors.size() - 1] =
+        i; // b/c of how this is done, we know the list will be unique
     }
+  }
 
-    Array<Array<int> > cellNeighbors(nElts);
-    for (int i=0; i<nElts; ++i)
-    {
-        int offset=i*3;
-        set<int> n;
-        for (int j=0; j<3; ++j)
-        {
-            const Array<int>& neighbors = nodeNeighbors[ faceData[offset+j]-1 ];
-            for (int k=0; k<neighbors.size(); ++k)
-            {
-                int nc = neighbors[k];
-                if (nc != i)
-                    n.insert(nc);
-            }
-        }
-        cellNeighbors[i].resize(n.size());
-        int cnt=0;
-        for (std::set<int>::const_iterator it=n.begin(); it!=n.end(); ++it)
-            cellNeighbors[i][cnt++] = *it;
+  Array<Array<int>> cellNeighbors(nElts);
+  for (int i = 0; i < nElts; ++i) {
+    int offset = i * 3;
+    set<int> n;
+    for (int j = 0; j < 3; ++j) {
+      const Array<int>& neighbors = nodeNeighbors[faceData[offset + j] - 1];
+      for (int k = 0; k < neighbors.size(); ++k) {
+        int nc = neighbors[k];
+        if (nc != i)
+          n.insert(nc);
+      }
     }
-    return cellNeighbors;
+    cellNeighbors[i].resize(n.size());
+    int cnt = 0;
+    for (std::set<int>::const_iterator it = n.begin(); it != n.end(); ++it)
+      cellNeighbors[i][cnt++] = *it;
+  }
+  return cellNeighbors;
 }
 
 void
-smoothVals(Array<Real>&              newVals,
-           const Array<Real>&        vals,
-           const Array<Real>&        area,
-           const Array<Array<int> >& nodeNeighbors)
+smoothVals(
+  Array<Real>& newVals,
+  const Array<Real>& vals,
+  const Array<Real>& area,
+  const Array<Array<int>>& nodeNeighbors)
 {
-    int nElts = vals.size();
-    if (nElts!=newVals.size() || nElts!=area.size())
-        BoxLib::Abort("Data wrong size");
+  int nElts = vals.size();
+  if (nElts != newVals.size() || nElts != area.size())
+    BoxLib::Abort("Data wrong size");
 
-    for (int i=0; i<nElts; ++i)
-    {
-        const Array<int> neighbors = nodeNeighbors[i];
+  for (int i = 0; i < nElts; ++i) {
+    const Array<int> neighbors = nodeNeighbors[i];
 
-        Real accumArea = area[i];
-        for (int j=0; j<neighbors.size(); ++j)
-            accumArea += area[ neighbors[j] ];
+    Real accumArea = area[i];
+    for (int j = 0; j < neighbors.size(); ++j)
+      accumArea += area[neighbors[j]];
 
-        Real accumWt = vals[i];
-        for (int j=0; j<neighbors.size(); ++j)
-            accumWt += vals[ neighbors[j] ];
+    Real accumWt = vals[i];
+    for (int j = 0; j < neighbors.size(); ++j)
+      accumWt += vals[neighbors[j]];
 
-        newVals[i] = accumWt / accumArea;
-    }
+    newVals[i] = accumWt / accumArea;
+  }
 }
 
 void
-triangle_area(const Real*       x,
-              const Real*       y,
-              const Real*       z,
-              const Array<int>& faceData,
-              int               nElts,
-              int               nNodes,
-              Real*             area)
+triangle_area(
+  const Real* x,
+  const Real* y,
+  const Real* z,
+  const Array<int>& faceData,
+  int nElts,
+  int nNodes,
+  Real* area)
 {
-    Real R1[3], R2[3], R3[3];
-    const Real* loc[3];
-    loc[0] = x;
-    loc[1] = y;
-    loc[2] = z;
+  Real R1[3], R2[3], R3[3];
+  const Real* loc[3];
+  loc[0] = x;
+  loc[1] = y;
+  loc[2] = z;
 
-    for (int i=0; i<nElts; ++i)
-    {
-        int offset=i*3;
-        int pa = faceData[offset+0] - 1;
-        int pb = faceData[offset+1] - 1;
-        int pc = faceData[offset+2] - 1;
-        for (int j=0; j<3; ++j)
-        {
-            R1[j] = loc[j][pb] - loc[j][pa];
-            R2[j] = loc[j][pc] - loc[j][pa];
-        }
-        R3[0] = R1[1]*R2[2] - R2[1]*R1[2];
-        R3[1] = R1[2]*R2[0] - R2[2]*R1[0];
-        R3[2] = R1[0]*R2[1] - R2[0]*R1[1];
-
-        Real res=0;
-        for (int j=0; j<3; ++j)
-            res += R3[j]*R3[j];
-        area[i] = 0.5*std::sqrt(res);
+  for (int i = 0; i < nElts; ++i) {
+    int offset = i * 3;
+    int pa = faceData[offset + 0] - 1;
+    int pb = faceData[offset + 1] - 1;
+    int pc = faceData[offset + 2] - 1;
+    for (int j = 0; j < 3; ++j) {
+      R1[j] = loc[j][pb] - loc[j][pa];
+      R2[j] = loc[j][pc] - loc[j][pa];
     }
+    R3[0] = R1[1] * R2[2] - R2[1] * R1[2];
+    R3[1] = R1[2] * R2[0] - R2[2] * R1[0];
+    R3[2] = R1[0] * R2[1] - R2[0] * R1[1];
+
+    Real res = 0;
+    for (int j = 0; j < 3; ++j)
+      res += R3[j] * R3[j];
+    area[i] = 0.5 * std::sqrt(res);
+  }
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    BoxLib::Initialize(argc,argv);
+  BoxLib::Initialize(argc, argv);
 
-    ParmParse pp;
+  ParmParse pp;
 
-    int nElts;
-    string infile; pp.get("infile",infile);
-    string outfile; pp.get("outfile",outfile);
+  int nElts;
+  string infile;
+  pp.get("infile", infile);
+  string outfile;
+  pp.get("outfile", outfile);
 
-    FArrayBox nodes;
-    Array<int> faceData;
-    vector<string> names;
-    string label;
-    read_iso(infile,nodes,faceData,nElts,names,label);
-    int nodesPerElt = faceData.size() / nElts;
-    AMREX_ASSERT(nodesPerElt*nElts == faceData.size());
+  FArrayBox nodes;
+  Array<int> faceData;
+  vector<string> names;
+  string label;
+  read_iso(infile, nodes, faceData, nElts, names, label);
+  int nodesPerElt = faceData.size() / nElts;
+  AMREX_ASSERT(nodesPerElt * nElts == faceData.size());
 
-    nElts = faceData.size() / nodesPerElt;
-    int nNodes = nodes.box().numPts();
-    int nCompMEF = nodes.nComp();
-    AMREX_ASSERT(nElts*nodesPerElt == faceData.size());
+  nElts = faceData.size() / nodesPerElt;
+  int nNodes = nodes.box().numPts();
+  int nCompMEF = nodes.nComp();
+  AMREX_ASSERT(nElts * nodesPerElt == faceData.size());
 
-    int areaComp=-1; pp.query("areaComp",areaComp); // Treated as an area, rather than computing here on the fly
-    int comp=-1; pp.get("comp",comp); // Component to smooth
+  int areaComp = -1;
+  pp.query(
+    "areaComp",
+    areaComp); // Treated as an area, rather than computing here on the fly
+  int comp = -1;
+  pp.get("comp", comp); // Component to smooth
 
-    Array<Real> vals(nElts); // Begin with the assumption that we associate values on this surface with the elements (vs. nodes)
-    Array<Real> area(nElts);
+  Array<Real> vals(nElts); // Begin with the assumption that we associate values
+                           // on this surface with the elements (vs. nodes)
+  Array<Real> area(nElts);
 
-    // Initialize data by averaging node-based data to elements
-    Real* dataN = nodes.dataPtr(comp);
-    Array<Real> tmp(nElts);
-    Real* areaN;
-    if (areaComp>=0 && areaComp<nCompMEF)
-    {
-        areaN = nodes.dataPtr(areaComp);
+  // Initialize data by averaging node-based data to elements
+  Real* dataN = nodes.dataPtr(comp);
+  Array<Real> tmp(nElts);
+  Real* areaN;
+  if (areaComp >= 0 && areaComp < nCompMEF) {
+    areaN = nodes.dataPtr(areaComp);
+  } else {
+    int idX = 0;
+    int idY = 1;
+    int idZ = 2;
+
+    areaN = tmp.dataPtr();
+    triangle_area(
+      nodes.dataPtr(idX), nodes.dataPtr(idY), nodes.dataPtr(idZ), faceData,
+      nElts, nNodes, areaN);
+  }
+
+  for (int i = 0; i < nElts; ++i) {
+    int offset = i * nodesPerElt;
+    vals[i] = 0;
+    area[i] = 0;
+    for (int j = 0; j < nodesPerElt; ++j) {
+      area[i] += areaN[faceData[offset + j] - 1];
+      vals[i] += dataN[faceData[offset + j] - 1] * area[i];
     }
+    vals[i] *= 1. / nodesPerElt;
+    area[i] *= 1. / nodesPerElt;
+  }
+
+  Array<Array<int>> nodeNeighbors =
+    buildNodeNeighbors(faceData, nodes.box().numPts());
+
+  Array<Real> newVals(nElts);
+
+  int nSmooth = 1;
+  pp.query("nSmooth", nSmooth);
+
+  for (int j = 0; j < nSmooth; ++j) {
+    smoothVals(newVals, vals, area, nodeNeighbors);
+    for (int i = 0; i < nElts; ++i)
+      vals[i] = newVals[i];
+  }
+
+  for (int i = 0; i < nElts; ++i)
+    dataN[i] = vals[i] / area[i];
+
+  write_iso(outfile, nodes, faceData, nElts, names, label);
+
+  BoxLib::Finalize();
+  return 0;
+}
+
+void
+write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Array<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label)
+{
+  // Rotate data to vary quickest on component
+  int nCompSurf = nodes.nComp();
+  int nNodes = nodes.box().numPts();
+
+  FArrayBox tnodes(nodes.box(), nCompSurf);
+  const Real** np = new const Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      ndat[j] = np[j][i];
+    }
+    ndat += nCompSurf;
+  }
+  delete[] np;
+
+  std::ofstream ofs;
+  ofs.open(outfile.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
+  ofs << label << endl;
+  for (int i = 0; i < nCompSurf; ++i) {
+    ofs << names[i];
+    if (i < nCompSurf - 1)
+      ofs << " ";
     else
-    {
-        int idX=0;
-        int idY=1;
-        int idZ=2;
-
-        areaN = tmp.dataPtr();
-        triangle_area(nodes.dataPtr(idX),nodes.dataPtr(idY),nodes.dataPtr(idZ),faceData,nElts,nNodes,areaN);
-    }
-
-    for (int i=0; i<nElts; ++i)
-    {
-        int offset=i*nodesPerElt;
-        vals[i] = 0;
-        area[i] = 0;
-        for (int j=0; j<nodesPerElt; ++j)
-        {
-            area[i] += areaN[ faceData[offset+j]-1 ];
-            vals[i]  += dataN[ faceData[offset+j]-1 ] * area[i];
-        }
-        vals[i] *= 1./nodesPerElt;
-        area[i] *= 1./nodesPerElt;
-    }
-
-    Array<Array<int> > nodeNeighbors = buildNodeNeighbors(faceData,nodes.box().numPts());
-
-    Array<Real> newVals(nElts);
-
-    int nSmooth=1; pp.query("nSmooth",nSmooth);
-
-    for (int j=0; j<nSmooth; ++j)
-    {
-        smoothVals(newVals,vals,area,nodeNeighbors);
-        for (int i=0; i<nElts; ++i)
-            vals[i] = newVals[i];
-    }
-
-    for (int i=0; i<nElts; ++i)
-        dataN[i] = vals[i]/area[i];
-
-    write_iso(outfile,nodes,faceData,nElts,names,label);
-
-    BoxLib::Finalize();
-    return 0;
+      ofs << std::endl;
+  }
+  int nodesPerElt = faceData.size() / nElts;
+  ofs << nElts << " " << nodesPerElt << endl;
+  tnodes.writeOn(ofs);
+  ofs.write((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
+  ofs.close();
 }
 
 void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Array<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label)
+read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Array<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label)
 {
-    // Rotate data to vary quickest on component
-    int nCompSurf = nodes.nComp();
-    int nNodes = nodes.box().numPts();
+  std::ifstream ifs;
+  ifs.open(infile.c_str(), std::ios::in | std::ios::binary);
+  label = parseTitle(ifs);
+  names = parseVarNames(ifs);
+  const int nCompSurf = names.size();
 
-    FArrayBox tnodes(nodes.box(),nCompSurf);
-    const Real** np = new const Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            ndat[j] = np[j][i];
-        }
-        ndat += nCompSurf;
-    }
-    delete [] np;
+  int nodesPerElt;
+  ifs >> nElts;
+  ifs >> nodesPerElt;
 
-    std::ofstream ofs;
-    ofs.open(outfile.c_str(),std::ios::out|std::ios::trunc|std::ios::binary);
-    ofs << label << endl;
-    for (int i=0; i<nCompSurf; ++i)
-    {
-        ofs << names[i];
-        if (i < nCompSurf-1)
-            ofs << " ";
-        else
-            ofs << std::endl;
+  FArrayBox tnodes;
+  tnodes.readFrom(ifs);
+  const int nNodes = tnodes.box().numPts();
+
+  // "rotate" the data so that the components are 'in the right spot for fab
+  // data'
+  nodes.resize(tnodes.box(), nCompSurf);
+  Real** np = new Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      np[j][i] = ndat[j];
     }
-    int nodesPerElt = faceData.size() / nElts;
-    ofs << nElts << " " << nodesPerElt << endl;
-    tnodes.writeOn(ofs);
-    ofs.write((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-    ofs.close();
+    ndat += nCompSurf;
+  }
+  delete[] np;
+  tnodes.clear();
+
+  faceData.resize(nElts * nodesPerElt, 0);
+  ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
 }
-
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Array<int>&        faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label)
-{
-    std::ifstream ifs;
-    ifs.open(infile.c_str(),std::ios::in|std::ios::binary);
-    label = parseTitle(ifs);
-    names = parseVarNames(ifs);
-    const int nCompSurf = names.size();
-
-    int nodesPerElt;
-    ifs >> nElts;
-    ifs >> nodesPerElt;
-
-    FArrayBox tnodes;
-    tnodes.readFrom(ifs);
-    const int nNodes = tnodes.box().numPts();
-
-    // "rotate" the data so that the components are 'in the right spot for fab data'
-    nodes.resize(tnodes.box(),nCompSurf);
-    Real** np = new Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            np[j][i] = ndat[j];
-        }
-        ndat += nCompSurf;
-    }
-    delete [] np;
-    tnodes.clear();
-
-    faceData.resize(nElts*nodesPerElt,0);
-    ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-}
-

--- a/Src/stream2plt.cpp
+++ b/Src/stream2plt.cpp
@@ -12,116 +12,114 @@
 
 using namespace amrex;
 
-using std::vector;
-using std::map;
-using std::string;
 using std::cerr;
-using std::endl;
 using std::cout;
-using std::ofstream;
+using std::endl;
 using std::ios;
+using std::map;
+using std::ofstream;
+using std::string;
+using std::vector;
 
-static int NLINESMAX=32700;
+static int NLINESMAX = 32700;
 
-
-
-typedef std::list<std::pair<int,int> > SelectionMapList;
+typedef std::list<std::pair<int, int>> SelectionMapList;
 
 void
-downsampleStreamData(const StreamData&                stream,
-                     int&                             num_lines,
-                     Vector<BoxArray>&                 stream_data_layout,
-                     Vector<map<int,int> >&            map_selected_to_full_gidx,
-                     Vector<Vector<SelectionMapList> >& selectIdxPairs,
-                     bool                             verbose)
+downsampleStreamData(
+  const StreamData& stream,
+  int& num_lines,
+  Vector<BoxArray>& stream_data_layout,
+  Vector<map<int, int>>& map_selected_to_full_gidx,
+  Vector<Vector<SelectionMapList>>& selectIdxPairs,
+  bool verbose)
 {
-    // This routine is parallel (all do the same thing), but only IOProc will write anything
-    verbose = (ParallelDescriptor::IOProcessor() ? verbose : false);
+  // This routine is parallel (all do the same thing), but only IOProc will
+  // write anything
+  verbose = (ParallelDescriptor::IOProcessor() ? verbose : false);
 
-    double rval = (double)num_lines / stream.NLines(); // fraction of total to write
-    int nLev = stream.FinestLevel()+1;
+  double rval =
+    (double)num_lines / stream.NLines(); // fraction of total to write
+  int nLev = stream.FinestLevel() + 1;
 
-    selectIdxPairs.clear();
-    selectIdxPairs.resize(nLev);
+  selectIdxPairs.clear();
+  selectIdxPairs.resize(nLev);
 
-    stream_data_layout.clear();
-    stream_data_layout.resize(nLev);
+  stream_data_layout.clear();
+  stream_data_layout.resize(nLev);
 
-    map_selected_to_full_gidx.clear();
-    map_selected_to_full_gidx.resize(nLev);
+  map_selected_to_full_gidx.clear();
+  map_selected_to_full_gidx.resize(nLev);
 
-    int slo = stream.StreamIdxLo();
-    int shi = stream.StreamIdxHi();
+  int slo = stream.StreamIdxLo();
+  int shi = stream.StreamIdxHi();
 
-    int cnt = 0;
-    for (int lev=0; lev<nLev; ++lev)
-    {
-        const BoxArray& ba = stream.boxArray(lev);
-        int nBoxes = ba.size();
-        BoxList bldst;
-        int last_added_srcboxid=-1;
+  int cnt = 0;
+  for (int lev = 0; lev < nLev; ++lev) {
+    const BoxArray& ba = stream.boxArray(lev);
+    int nBoxes = ba.size();
+    BoxList bldst;
+    int last_added_srcboxid = -1;
 
-        // Easiest to build this first on map based on full ba indexing
-        map<int,SelectionMapList> map_baIdx_selectIdxPairs;
-        map<int,int>& m_sel_to_full = map_selected_to_full_gidx[lev];
+    // Easiest to build this first on map based on full ba indexing
+    map<int, SelectionMapList> map_baIdx_selectIdxPairs;
+    map<int, int>& m_sel_to_full = map_selected_to_full_gidx[lev];
 
-        for (int box_id=0; box_id<nBoxes; ++box_id)
-        {
-            const Vector<int>& in_lev = stream.InsideNodes(lev,box_id);
-            for (int i=0; i<in_lev.size(); ++i)
-            {
-                double doit = Random(); // Note: MUST override default cpu-dependent seed!
-                if (doit<rval)
-                {
-                    if (box_id!=last_added_srcboxid) {
-                        last_added_srcboxid = box_id;
-                        m_sel_to_full[m_sel_to_full.size()] = box_id;
-                    }
-                    int old_local_idx = i;
-                    int new_global_idx = cnt;
-                    map_baIdx_selectIdxPairs[box_id].push_back(
-                        std::pair<int,int>(new_global_idx,old_local_idx));
-                    cnt++;
-                }
-            }
-            int num_this_bx = map_baIdx_selectIdxPairs[box_id].size();
-            if (num_this_bx>0)
-            {
-                int first_idx = map_baIdx_selectIdxPairs[box_id].front().first;
-                int last_idx = map_baIdx_selectIdxPairs[box_id].back().first;
-                Box bx(IntVect(AMREX_D_DECL(first_idx,slo,0)),
-                       IntVect(AMREX_D_DECL(last_idx,shi,0)));
-                bldst.push_back(bx);
-            }
+    for (int box_id = 0; box_id < nBoxes; ++box_id) {
+      const Vector<int>& in_lev = stream.InsideNodes(lev, box_id);
+      for (int i = 0; i < in_lev.size(); ++i) {
+        double doit =
+          Random(); // Note: MUST override default cpu-dependent seed!
+        if (doit < rval) {
+          if (box_id != last_added_srcboxid) {
+            last_added_srcboxid = box_id;
+            m_sel_to_full[m_sel_to_full.size()] = box_id;
+          }
+          int old_local_idx = i;
+          int new_global_idx = cnt;
+          map_baIdx_selectIdxPairs[box_id].push_back(
+            std::pair<int, int>(new_global_idx, old_local_idx));
+          cnt++;
         }
-        stream_data_layout[lev] = BoxArray(bldst);
-
-        // Build final selection map based on reduced ba
-        int nSrcGrids = m_sel_to_full.size();
-        selectIdxPairs[lev].resize(nSrcGrids);
-        for (int k=0; k<nSrcGrids; ++k) {
-            int fgidx = m_sel_to_full[k];
-            selectIdxPairs[lev][k] = map_baIdx_selectIdxPairs[fgidx];
-        }
-
-        if (verbose)
-        {
-            for (int k=0; k<nSrcGrids; ++k) {
-                const SelectionMapList& idx_map = selectIdxPairs[lev][k];
-                int fgidx = m_sel_to_full[k];
-                int nAvail = ba[fgidx].length(0);
-                cout << k << " (" << idx_map.size() << "): " ;
-                for (SelectionMapList::const_iterator it=idx_map.begin(); it!=idx_map.end(); ++it)
-                {
-                    cout << " ( " << it->first << " from " << it->second << " ) ";
-                    AMREX_ASSERT(it->second < nAvail);
-                }
-                cout << " src data has " << nAvail << " particles" << endl;
-            }
-        }
+      }
+      int num_this_bx = map_baIdx_selectIdxPairs[box_id].size();
+      if (num_this_bx > 0) {
+        int first_idx = map_baIdx_selectIdxPairs[box_id].front().first;
+        int last_idx = map_baIdx_selectIdxPairs[box_id].back().first;
+        Box bx(
+          IntVect(AMREX_D_DECL(first_idx, slo, 0)),
+          IntVect(AMREX_D_DECL(last_idx, shi, 0)));
+        bldst.push_back(bx);
+      }
     }
-    num_lines = cnt;
-    ParallelDescriptor::Barrier(); // Make sure they all get here so nLines is uniform across procs
+    stream_data_layout[lev] = BoxArray(bldst);
+
+    // Build final selection map based on reduced ba
+    int nSrcGrids = m_sel_to_full.size();
+    selectIdxPairs[lev].resize(nSrcGrids);
+    for (int k = 0; k < nSrcGrids; ++k) {
+      int fgidx = m_sel_to_full[k];
+      selectIdxPairs[lev][k] = map_baIdx_selectIdxPairs[fgidx];
+    }
+
+    if (verbose) {
+      for (int k = 0; k < nSrcGrids; ++k) {
+        const SelectionMapList& idx_map = selectIdxPairs[lev][k];
+        int fgidx = m_sel_to_full[k];
+        int nAvail = ba[fgidx].length(0);
+        cout << k << " (" << idx_map.size() << "): ";
+        for (SelectionMapList::const_iterator it = idx_map.begin();
+             it != idx_map.end(); ++it) {
+          cout << " ( " << it->first << " from " << it->second << " ) ";
+          AMREX_ASSERT(it->second < nAvail);
+        }
+        cout << " src data has " << nAvail << " particles" << endl;
+      }
+    }
+  }
+  num_lines = cnt;
+  ParallelDescriptor::Barrier(); // Make sure they all get here so nLines is
+                                 // uniform across procs
 }
 
 #ifdef AMREX_WRITE_BINARY
@@ -129,97 +127,84 @@ downsampleStreamData(const StreamData&                stream,
 #include "TECIO.h"
 #define SIZET INTEGER4
 void
-write_tec_binary(const FArrayBox&     strm,
-                 const string&        outfile,
-                 const string&        file_label,
-                 const Vector<string>& names,
-                 const Vector<int>&    write_lines)
+write_tec_binary(
+  const FArrayBox& strm,
+  const string& outfile,
+  const string& file_label,
+  const Vector<string>& names,
+  const Vector<int>& write_lines)
 {
-    ofstream osf;
-    osf.open(outfile.c_str(),std::ios::out);
+  ofstream osf;
+  osf.open(outfile.c_str(), std::ios::out);
 
-    int Ncomp = names.size();
-    AMREX_ASSERT(Ncomp==strm.nComp());
+  int Ncomp = names.size();
+  AMREX_ASSERT(Ncomp == strm.nComp());
 
-    AMREX_ASSERT(write_lines.size()==strm.box().length(0));
+  AMREX_ASSERT(write_lines.size() == strm.box().length(0));
 
-    std::string vars = names[0];
-    for (int j=1; j<Ncomp; ++j)
-        vars += " " + names[j];
+  std::string vars = names[0];
+  for (int j = 1; j < Ncomp; ++j)
+    vars += " " + names[j];
 
-    bool verbose = true;
+  bool verbose = true;
 
-    INTEGER4 Debug = std::max(0,verbose-1);
-    INTEGER4 VIsDouble = 1;
-    TECINI100((char*)file_label.c_str(),
-              (char*)vars.c_str(),
-              (char*)binary_outfile.c_str(),
-              (char*)".",
-              &Debug,
-              &VIsDouble);
-    
-    INTEGER4 ZoneType  = 0;  /* ORDERED */
-    INTEGER4 ICellMax  = 0;  /* UNUSED (for FEBRICK ONLY) */
-    INTEGER4 JCellMax  = 0;  /* UNUSED (for FEBRICK ONLY) */
-    INTEGER4 KCellMax  = 0;  /* UNUSED (for FEBRICK ONLY) */
-    INTEGER4 IsBlock   = 1;
-    INTEGER4 NumFaceConnections = 0;
-    INTEGER4 FaceNeighborMode   = 0;
-    INTEGER4 ShareConnectivityFromZone = 0; /* UNUSED (for FE ZONES ONLY) */
+  INTEGER4 Debug = std::max(0, verbose - 1);
+  INTEGER4 VIsDouble = 1;
+  TECINI100(
+    (char*)file_label.c_str(), (char*)vars.c_str(),
+    (char*)binary_outfile.c_str(), (char*)".", &Debug, &VIsDouble);
 
-    Vector<Real> loc(AMREX_SPACEDIM);
-    const Box& box = strm.box();
-    const IntVect ivst = box.smallEnd();
-    const IntVect ivmid(AMREX_D_DECL(ivst[0],0,ivst[2]));
-    
-    int nLines = box.length(0);
-    int Npts = box.length(1);
-    INTEGER4 IMax = Npts;  /* Max number of nodes in I index direction */
-    INTEGER4 JMax = 1;     /* Max number of nodes in J index direction */
-    INTEGER4 KMax = 1;     /* Max number of nodes in K index direction, used for ORDERED data */
+  INTEGER4 ZoneType = 0; /* ORDERED */
+  INTEGER4 ICellMax = 0; /* UNUSED (for FEBRICK ONLY) */
+  INTEGER4 JCellMax = 0; /* UNUSED (for FEBRICK ONLY) */
+  INTEGER4 KCellMax = 0; /* UNUSED (for FEBRICK ONLY) */
+  INTEGER4 IsBlock = 1;
+  INTEGER4 NumFaceConnections = 0;
+  INTEGER4 FaceNeighborMode = 0;
+  INTEGER4 ShareConnectivityFromZone = 0; /* UNUSED (for FE ZONES ONLY) */
 
-    Vector<Real> dat(Npts*Ncomp);
-    const IntVect ivd = box.smallEnd();
-    for (int i=0; i<nLines; ++i)
-    {
-        if (write_lines[i] > 0)
-        {
-            int cnt=0;
-            for (int n=0; n<Ncomp; ++n)
-            {
-                for (int j=0; j<Npts; ++j)
-                {
-                    dat[cnt++] = strm(ivst+IntVect(i,j,0),n);
-                }
-            }
-                            
-            char buf[72];
-            sprintf(buf,"id%d",i);
-            string label = std::string(buf);
-            
-            if (verbose>1)
-                std::cerr << "Writing line: " << i << std::endl;
-            
-            TECZNE100((char*)label.c_str(),
-                      &ZoneType,
-                      &IMax,
-                      &JMax,
-                      &KMax,
-                      &ICellMax,
-                      &JCellMax,
-                      &KCellMax,
-                      &IsBlock,
-                      &NumFaceConnections,
-                      &FaceNeighborMode,
-                      NULL,      /* ValueLocation */
-                      NULL,      /* ShareVarFromZone */
-                      &ShareConnectivityFromZone);        
-            
-            INTEGER4 III = dat.size();
-            TECDAT100(&III,dat.dataPtr(),&VIsDouble);
+  Vector<Real> loc(AMREX_SPACEDIM);
+  const Box& box = strm.box();
+  const IntVect ivst = box.smallEnd();
+  const IntVect ivmid(AMREX_D_DECL(ivst[0], 0, ivst[2]));
+
+  int nLines = box.length(0);
+  int Npts = box.length(1);
+  INTEGER4 IMax = Npts; /* Max number of nodes in I index direction */
+  INTEGER4 JMax = 1;    /* Max number of nodes in J index direction */
+  INTEGER4 KMax =
+    1; /* Max number of nodes in K index direction, used for ORDERED data */
+
+  Vector<Real> dat(Npts * Ncomp);
+  const IntVect ivd = box.smallEnd();
+  for (int i = 0; i < nLines; ++i) {
+    if (write_lines[i] > 0) {
+      int cnt = 0;
+      for (int n = 0; n < Ncomp; ++n) {
+        for (int j = 0; j < Npts; ++j) {
+          dat[cnt++] = strm(ivst + IntVect(i, j, 0), n);
         }
+      }
+
+      char buf[72];
+      sprintf(buf, "id%d", i);
+      string label = std::string(buf);
+
+      if (verbose > 1)
+        std::cerr << "Writing line: " << i << std::endl;
+
+      TECZNE100(
+        (char*)label.c_str(), &ZoneType, &IMax, &JMax, &KMax, &ICellMax,
+        &JCellMax, &KCellMax, &IsBlock, &NumFaceConnections, &FaceNeighborMode,
+        NULL, /* ValueLocation */
+        NULL, /* ShareVarFromZone */
+        &ShareConnectivityFromZone);
+
+      INTEGER4 III = dat.size();
+      TECDAT100(&III, dat.dataPtr(), &VIsDouble);
     }
-    TECEND100(); 
+  }
+  TECEND100();
 
 #if 0        
         
@@ -265,487 +250,486 @@ write_tec_binary(const FArrayBox&     strm,
 
 #else
 void
-write_tec_ascii(const FArrayBox&     strm,
-                const string&        outfile,
-                const string&        file_label,
-                const Vector<string>& names,
-                const Vector<int>&    write_lines)
+write_tec_ascii(
+  const FArrayBox& strm,
+  const string& outfile,
+  const string& file_label,
+  const Vector<string>& names,
+  const Vector<int>& write_lines)
 {
-    ofstream osf;
-    osf.open(outfile.c_str(),std::ios::out);
+  ofstream osf;
+  osf.open(outfile.c_str(), std::ios::out);
 
-    int nComp = names.size();
-    AMREX_ASSERT(nComp==strm.nComp());
+  int nComp = names.size();
+  AMREX_ASSERT(nComp == strm.nComp());
 
-    osf << "VARIABLES = ";
-    for (int i=0; i<nComp; ++i)
-        osf << names[i] << " ";
-    osf << '\n';
+  osf << "VARIABLES = ";
+  for (int i = 0; i < nComp; ++i)
+    osf << names[i] << " ";
+  osf << '\n';
 
+  AMREX_ASSERT(write_lines.size() == strm.box().length(0));
 
-    AMREX_ASSERT(write_lines.size()==strm.box().length(0));
+  std::string vars = names[0];
+  for (int j = 1; j < nComp; ++j)
+    vars += " " + names[j];
 
-    std::string vars = names[0];
-    for (int j=1; j<nComp; ++j)
-        vars += " " + names[j];
-    
-    const Box& box = strm.box();
-    int nLines = box.length(0);
-    int Npts = box.length(1);
+  const Box& box = strm.box();
+  int nLines = box.length(0);
+  int Npts = box.length(1);
 
-    const IntVect ivst = box.smallEnd();
-    for (int i=0; i<nLines; ++i)
-    {
-        if (write_lines[i] > 0)
-        {
-            char buf[72];
-            sprintf(buf,"id%d",i);
-            string label = std::string(buf);
+  const IntVect ivst = box.smallEnd();
+  for (int i = 0; i < nLines; ++i) {
+    if (write_lines[i] > 0) {
+      char buf[72];
+      sprintf(buf, "id%d", i);
+      string label = std::string(buf);
 
-            osf << "ZONE T=" << label << " I=" << Npts << " F=POINT" << endl;;                    
-            for (int j=0; j<Npts; ++j)
-            {
-              IntVect ivt = ivst + IntVect(AMREX_D_DECL(i,j,0));
-              for (int n=0; n<nComp; ++n)
-                osf << strm(ivt,n) << " ";
-              osf << '\n';
-            }
-        }
+      osf << "ZONE T=" << label << " I=" << Npts << " F=POINT" << endl;
+      ;
+      for (int j = 0; j < Npts; ++j) {
+        IntVect ivt = ivst + IntVect(AMREX_D_DECL(i, j, 0));
+        for (int n = 0; n < nComp; ++n)
+          osf << strm(ivt, n) << " ";
+        osf << '\n';
+      }
     }
+  }
 
-    osf.close();
+  osf.close();
 }
 #endif
 
-static bool do_test(Real thisVal,
-                    const std::string& sgn,
-                    Real critVal);
+static bool do_test(Real thisVal, const std::string& sgn, Real critVal);
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    amrex::Initialize(argc,argv);
-    //
-    // Force everyone to have the same random sequence.
-    //
-    InitRandom(987654321);
+  amrex::Initialize(argc, argv);
+  //
+  // Force everyone to have the same random sequence.
+  //
+  InitRandom(987654321);
 
-    ParmParse pp;
+  ParmParse pp;
 
-    std::string infile; pp.get("infile",infile);
-    std::string outfile; pp.get("outfile",outfile);
+  std::string infile;
+  pp.get("infile", infile);
+  std::string outfile;
+  pp.get("outfile", outfile);
 
-    int verbose=0; pp.query("verbose",verbose);
+  int verbose = 0;
+  pp.query("verbose", verbose);
 
-    StreamData stream(infile);
-    int finestLevel=stream.FinestLevel(); pp.query("finestLevel",finestLevel);
+  StreamData stream(infile);
+  int finestLevel = stream.FinestLevel();
+  pp.query("finestLevel", finestLevel);
 
-    // How many lines in file
-    if (ParallelDescriptor::IOProcessor() && verbose)
-        std::cerr << "Found " << stream.NLines() << " streamlines in this file." << std::endl;
-    
-    const Vector<string>& names = stream.ComponentNames();
-    Vector<int> comps;
-    if (int nc = pp.countval("comps"))
-    {
-        comps.resize(nc);
-        pp.getarr("comps",comps,0,nc);
+  // How many lines in file
+  if (ParallelDescriptor::IOProcessor() && verbose)
+    std::cerr << "Found " << stream.NLines() << " streamlines in this file."
+              << std::endl;
+
+  const Vector<string>& names = stream.ComponentNames();
+  Vector<int> comps;
+  if (int nc = pp.countval("comps")) {
+    comps.resize(nc);
+    pp.getarr("comps", comps, 0, nc);
+  } else {
+    int sComp = 0;
+    pp.query("sComp", sComp);
+    int nComp = names.size();
+    pp.query("nComp", nComp);
+    AMREX_ASSERT(sComp + nComp <= names.size());
+    comps.resize(nComp);
+    for (int i = 0; i < nComp; ++i)
+      comps[i] = sComp + i;
+  }
+
+  Vector<string> selectedNames(comps.size());
+  for (int i = 0; i < comps.size(); ++i) {
+    selectedNames[i] = names[comps[i]];
+  }
+
+  int distComp = -1;
+  pp.query("distComp", distComp);
+  Real distVal;
+  if (distComp >= 0) {
+    pp.get("distVal", distVal);
+    AMREX_ASSERT(distComp < comps.size());
+    char buf[64];
+    sprintf(buf, "%g", distVal);
+    string distName =
+      "distance_from_" + names[comps[distComp]] + "_eq_" + string(buf);
+    selectedNames.resize(selectedNames.size() + 1);
+    selectedNames[selectedNames.size() - 1] = distName;
+  }
+
+  bool no_filter = false;
+  pp.query("no_filter", no_filter); // Explicitly shut off all filters
+
+  int nLines = 0;
+  pp.query("nLines", nLines);
+  nLines = std::min(nLines, NLINESMAX);
+
+  if (ParallelDescriptor::IOProcessor() && verbose)
+    std::cerr << "  Looking to extract approximately " << nLines << " of them."
+              << std::endl;
+
+  Real RXY = -1;
+  pp.query("RXY", RXY);
+  string RXYsgn = "";
+  pp.query("RXYsgn", RXYsgn);
+
+  Vector<Real> maxVals;
+  Vector<string> maxSgns;
+  Vector<int> maxComps;
+  if (int nmax = pp.countval("maxComps")) {
+    maxComps.resize(nmax);
+    maxVals.resize(nmax);
+    maxSgns.resize(nmax);
+    pp.getarr("maxComps", maxComps, 0, nmax);
+    pp.getarr("maxVals", maxVals, 0, nmax);
+    pp.getarr("maxSgns", maxSgns, 0, nmax);
+  }
+
+  Vector<Real> minVals;
+  Vector<string> minSgns;
+  Vector<int> minComps;
+  if (int nmin = pp.countval("minComps")) {
+    minComps.resize(nmin);
+    minVals.resize(nmin);
+    minSgns.resize(nmin);
+    pp.getarr("minComps", minComps, 0, nmin);
+    pp.getarr("minVals", minVals, 0, nmin);
+    pp.getarr("minSgns", minSgns, 0, nmin);
+  }
+
+  // Where fab(atComp)=valAt, fab(compAt) atSgn atVal
+  Vector<Real> compAt;
+  Vector<Real> valAt;
+  Vector<Real> atVal;
+  Vector<string> atSgns;
+  Vector<int> atComps;
+  if (int nat = pp.countval("atComps")) {
+    compAt.resize(nat);
+    atComps.resize(nat);
+    valAt.resize(nat);
+    atVal.resize(nat);
+    atSgns.resize(nat);
+    pp.getarr("compAt", compAt, 0, nat);
+    pp.getarr("atComps", atComps, 0, nat);
+    pp.getarr("valAt", valAt, 0, nat);
+    pp.getarr("atVal", atVal, 0, nat);
+    pp.getarr("atSgns", atSgns, 0, nat);
+  }
+
+  string condStr = "";
+  if (ParallelDescriptor::IOProcessor() && verbose) {
+    cout << "Preparing to extract/write the following components (i,idx,name): "
+         << endl;
+    for (int i = 0; i < comps.size(); ++i) {
+      cout << "(" << i << "," << comps[i] << "," << names[comps[i]] << ") ";
     }
-    else
-    {
-        int sComp = 0; pp.query("sComp",sComp);
-        int nComp = names.size(); pp.query("nComp",nComp);
-        AMREX_ASSERT(sComp+nComp <= names.size());
-        comps.resize(nComp);
-        for (int i=0; i<nComp; ++i)
-            comps[i] = sComp + i;
+    cout << endl;
+
+    if (selectedNames.size() > comps.size()) {
+      cout << "....appending the following component(s): ";
+      for (int i = comps.size(); i < selectedNames.size(); ++i) {
+        cout << selectedNames[i] << endl;
+      }
     }
 
-    Vector<string> selectedNames(comps.size());
-    for (int i=0; i<comps.size(); ++i) {
-        selectedNames[i] = names[comps[i]];
+    for (int i = 0; i < maxComps.size(); ++i) {
+      char buf[64];
+      sprintf(buf, "%g", maxVals[i]);
+      condStr += "Max(" + names[comps[maxComps[i]]] + ") " + maxSgns[i] + " " +
+                 string(buf) + "; ";
     }
 
-    int distComp=-1; pp.query("distComp",distComp);
-    Real distVal; 
-    if (distComp>=0) {
-        pp.get("distVal",distVal);
-        AMREX_ASSERT(distComp<comps.size());
-        char buf[64]; sprintf(buf,"%g",distVal);
-        string distName = "distance_from_" + names[comps[distComp]] + "_eq_" + string(buf);
-        selectedNames.resize(selectedNames.size()+1);
-        selectedNames[selectedNames.size()-1] = distName;
+    for (int i = 0; i < minComps.size(); ++i) {
+      char buf[64];
+      sprintf(buf, "%g", minVals[i]);
+      condStr += "Min(" + names[comps[minComps[i]]] + ") " + minSgns[i] + " " +
+                 string(buf) + "; ";
     }
 
-    bool no_filter = false;
-    pp.query("no_filter",no_filter); // Explicitly shut off all filters
+    for (int i = 0; i < atComps.size(); ++i) {
+      char buf1[64];
+      sprintf(buf1, "%g", atVal[i]);
+      char buf2[64];
+      sprintf(buf2, "%g", valAt[i]);
 
-
-    int nLines = 0; pp.query("nLines",nLines);
-    nLines = std::min(nLines,NLINESMAX);
-
-    if (ParallelDescriptor::IOProcessor() && verbose)
-        std::cerr << "  Looking to extract approximately " << nLines << " of them." << std::endl;
-
-    Real RXY = -1; pp.query("RXY",RXY);
-    string RXYsgn = ""; pp.query("RXYsgn",RXYsgn);
-
-    Vector<Real> maxVals;
-    Vector<string> maxSgns;
-    Vector<int> maxComps;
-    if (int nmax = pp.countval("maxComps"))
-    {
-        maxComps.resize(nmax);
-        maxVals.resize(nmax);
-        maxSgns.resize(nmax);
-        pp.getarr("maxComps",maxComps,0,nmax);
-        pp.getarr("maxVals",maxVals,0,nmax);
-        pp.getarr("maxSgns",maxSgns,0,nmax);
+      condStr += names[comps[compAt[i]]] + "(" + names[comps[atComps[i]]] +
+                 " = " + string(buf1) + ") " + atSgns[i] + " " + string(buf2) +
+                 "; ";
     }
 
-    Vector<Real> minVals;
-    Vector<string> minSgns;
-    Vector<int> minComps;
-    if (int nmin = pp.countval("minComps"))
-    {
-        minComps.resize(nmin);
-        minVals.resize(nmin);
-        minSgns.resize(nmin);
-        pp.getarr("minComps",minComps,0,nmin);
-        pp.getarr("minVals",minVals,0,nmin);
-        pp.getarr("minSgns",minSgns,0,nmin);
+    if (RXY > 0) {
+      char buf[64];
+      sprintf(buf, "%g", RXY);
+      condStr += "radiusXY " + RXYsgn + " " + string(buf) + " ";
     }
 
-    // Where fab(atComp)=valAt, fab(compAt) atSgn atVal
-    Vector<Real> compAt;
-    Vector<Real> valAt;
-    Vector<Real> atVal;
-    Vector<string> atSgns;
-    Vector<int> atComps;
-    if (int nat = pp.countval("atComps"))
-    {
-        compAt.resize(nat);
-        atComps.resize(nat);
-        valAt.resize(nat);
-        atVal.resize(nat);
-        atSgns.resize(nat);
-        pp.getarr("compAt",compAt,0,nat);
-        pp.getarr("atComps",atComps,0,nat);
-        pp.getarr("valAt",valAt,0,nat);
-        pp.getarr("atVal",atVal,0,nat);
-        pp.getarr("atSgns",atSgns,0,nat);
-    }
+    if (condStr != "")
+      std::cout << " ...subject to: " << condStr << std::endl;
+  }
 
-    string condStr = "";
-    if (ParallelDescriptor::IOProcessor() && verbose)
-    {
-        cout << "Preparing to extract/write the following components (i,idx,name): " << endl;
-        for (int i=0; i<comps.size(); ++i) {
-            cout << "(" << i << "," << comps[i] << "," << names[comps[i]] << ") ";
+  Vector<BoxArray> stream_data_layout;
+  Vector<Vector<SelectionMapList>> selectIdxPairs;
+  Vector<map<int, int>> map_selected_to_full_gidx;
+
+  downsampleStreamData(
+    stream, nLines, stream_data_layout, map_selected_to_full_gidx,
+    selectIdxPairs, verbose);
+  if (ParallelDescriptor::IOProcessor()) {
+    cout << "Reduced dataset has " << nLines << " lines " << std::endl;
+  }
+
+  int slo = stream.StreamIdxLo();
+  int shi = stream.StreamIdxHi();
+
+  Box finalBox(
+    IntVect(AMREX_D_DECL(0, slo, 0)),
+    IntVect(AMREX_D_DECL(nLines - 1, shi, 0)));
+  BoxArray finalBa(finalBox);
+  DistributionMapping dmfinal(finalBa);
+  MultiFab finalMF(finalBa, dmfinal, selectedNames.size(), 0);
+
+  for (int lev = 0; lev <= finestLevel; ++lev) {
+    const BoxArray& dstBa = stream_data_layout[lev];
+
+    if (ParallelDescriptor::IOProcessor() && verbose) {
+      cout << "Reduced  dataset has " << dstBa.size() << " boxes (original has "
+           << stream.boxArray(lev).size() << ") at level = " << lev << endl;
+    }
+    if (dstBa.size() > 0) {
+      MultiFab dst(dstBa, DistributionMapping(dstBa), comps.size(), 0);
+      for (MFIter mfi(dst); mfi.isValid(); ++mfi) {
+        int gidx = mfi.index();
+        FArrayBox& dstFab = dst[mfi];
+        const SelectionMapList& line_map = selectIdxPairs[lev][gidx];
+        int srcIdx = map_selected_to_full_gidx[lev][gidx];
+
+        for (int n = 0; n < comps.size(); ++n) {
+          const FArrayBox& srcFab = *(stream.getFab(lev, srcIdx, comps[n]));
+          for (SelectionMapList::const_iterator it = line_map.begin();
+               it != line_map.end(); ++it) {
+            int old_local_idx = it->second;
+            Box srcBox(
+              IntVect(AMREX_D_DECL(old_local_idx, slo, 0)),
+              IntVect(AMREX_D_DECL(old_local_idx, shi, 0)));
+
+            int new_global_idx = it->first;
+            AMREX_ASSERT(new_global_idx < nLines);
+            Box dstBox(
+              IntVect(AMREX_D_DECL(new_global_idx, slo, 0)),
+              IntVect(AMREX_D_DECL(new_global_idx, shi, 0)));
+
+            AMREX_ASSERT(srcFab.box().contains(srcBox));
+            AMREX_ASSERT(dstFab.box().contains(dstBox));
+
+            dstFab.copy(srcFab, srcBox, 0, dstBox, n, 1);
+          }
         }
-        cout << endl;
+      } // mfi
 
-        if (selectedNames.size() > comps.size()) {
-            cout << "....appending the following component(s): ";
-            for (int i=comps.size(); i<selectedNames.size(); ++i) {
-                cout << selectedNames[i] << endl;
+      finalMF.copy(dst);
+    }
+  }
+
+  int procWithFab = finalMF.DistributionMap()[0];
+
+  if (ParallelDescriptor::MyProc() == procWithFab) {
+    FArrayBox& fab = finalMF[0];
+
+    // Scan downselected streamlines for criteria
+    Vector<int> write_lines(nLines, 1);
+
+    if (no_filter) {
+      for (int i = 0; i < write_lines.size(); ++i) {
+        write_lines[i] = 1;
+      }
+    } else {
+      IntVect se = finalBox.smallEnd();
+      int nvals = shi - slo + 1;
+
+      // Check criteria on maximum values
+      for (int n = 0; n < maxComps.size(); ++n) {
+        int nc = maxComps[n];
+        for (int i = 0; i < nLines; ++i) {
+          Real maxVal = fab(se, nc);
+          for (int j = 0; j < nvals; ++j) {
+            IntVect iv = se + i * BASISV(0) + j * BASISV(1);
+            maxVal = std::max(fab(iv, nc), maxVal);
+          }
+          if (!do_test(maxVal, maxSgns[n], maxVals[n])) {
+            write_lines[i] = 0;
+          }
+        }
+      }
+
+      // Check criteria on minimum values
+      for (int n = 0; n < minComps.size(); ++n) {
+        int nc = minComps[n];
+        for (int i = 0; i < nLines; ++i) {
+          Real minVal = fab(se, nc);
+          for (int j = 0; j < nvals; ++j) {
+            IntVect iv = se + i * BASISV(0) + j * BASISV(1);
+            minVal = std::min(fab(iv, nc), minVal);
+          }
+          if (!do_test(minVal, minSgns[n], minVals[n])) {
+            write_lines[i] = 0;
+          }
+        }
+      }
+
+      // Check criteria on radius of seed point
+      AMREX_ASSERT(comps.size() > 2);
+      if (RXY > 0) {
+        for (int i = 0; i < nLines; ++i) {
+          IntVect ivs(AMREX_D_DECL(i, 0.5 * (slo + shi), 0));
+          Real radius = 0;
+          for (int n = 0; n < 2; ++n) {
+            Real val = fab(ivs, n);
+            radius += val * val;
+          }
+          radius = std::sqrt(radius);
+          if (!do_test(radius, RXYsgn, RXY)) {
+            write_lines[i] = 0;
+          }
+        }
+      }
+
+      // Check criteria on "atVals"
+      for (int n = 0; n < atComps.size(); ++n) {
+        int loc_comp = atComps[n];
+        Real loc_val = atVal[n];
+        int test_comp = compAt[n];
+        Real test_val = valAt[n];
+
+        for (int i = 0; i < nLines; ++i) {
+          bool found_it = false;
+          IntVect ivl, ivh;
+          Real loc_val_lo, loc_val_hi;
+          for (int j = 0; j < nvals - 1 && !found_it; ++j) {
+            ivl = se + i * BASISV(0) + j * BASISV(1);
+            ivh = se + i * BASISV(0) + (j + 1) * BASISV(1);
+            loc_val_lo = fab(ivl, loc_comp);
+            loc_val_hi = fab(ivh, loc_comp);
+            if (
+              ((loc_val_lo > loc_val) && (loc_val_hi < loc_val)) ||
+              ((loc_val_lo < loc_val) && (loc_val_hi > loc_val))) {
+              Real alpha = (loc_val - loc_val_lo) / (loc_val_hi - loc_val_lo);
+              AMREX_ASSERT(alpha >= 0 && alpha <= 1);
+              Real val_lo = fab(ivl, test_comp);
+              Real val_hi = fab(ivh, test_comp);
+              Real val_test = val_lo + alpha * (val_hi - val_lo);
+              write_lines[i] = do_test(val_test, atSgns[n], test_val);
+              found_it = true;
             }
+          }
         }
+      }
 
-        for (int i=0; i<maxComps.size(); ++i) {
-            char buf[64]; sprintf(buf,"%g",maxVals[i]);
-            condStr += "Max(" + names[comps[maxComps[i]]] + ") " + maxSgns[i] + " " + string(buf) + "; ";
+      // Add auxiliary quantities
+      if (distComp >= 0) {
+        // Compute relative to the start of the streamline, then shift
+        int nDist = comps.size();
+        int loc_comp = distComp;
+        Real loc_val = distVal;
+        Real loc_offset = 0;
+
+        IntVect ivl, ivh;
+        AMREX_ASSERT(comps.size() > AMREX_SPACEDIM);
+        for (int i = 0; i < nLines; ++i) {
+          ivl = se + i * BASISV(0);
+          fab(ivl, nDist) = 0;
+          for (int j = 1; j < nvals; ++j) {
+            ivl = se + i * BASISV(0) + (j - 1) * BASISV(1);
+            ivh = se + i * BASISV(0) + j * BASISV(1);
+            Real ds = 0;
+            for (int n = 0; n < AMREX_SPACEDIM; ++n) {
+              Real dx = fab(ivh, n) - fab(ivl, n);
+              ds += dx * dx;
+            }
+            ds = std::sqrt(ds);
+            fab(ivh, nDist) = fab(ivl, nDist) + ds;
+          }
+
+          bool found_it = false;
+          for (int j = 0; j < nvals - 1 && !found_it; ++j) {
+            ivl = se + i * BASISV(0) + j * BASISV(1);
+            ivh = se + i * BASISV(0) + (j + 1) * BASISV(1);
+            Real loc_val_lo = fab(ivl, loc_comp);
+            Real loc_val_hi = fab(ivh, loc_comp);
+            if (
+              ((loc_val_lo > loc_val) && (loc_val_hi < loc_val)) ||
+              ((loc_val_lo < loc_val) && (loc_val_hi > loc_val))) {
+              Real alpha = (loc_val - loc_val_lo) / (loc_val_hi - loc_val_lo);
+              AMREX_ASSERT(alpha >= 0 && alpha <= 1);
+              Real val_lo = fab(ivl, nDist);
+              Real val_hi = fab(ivh, nDist);
+              loc_offset = val_lo + alpha * (val_hi - val_lo);
+              // Do the shift
+              for (int jj = 0; jj < nvals; ++jj) {
+                IntVect iv = se + i * BASISV(0) + jj * BASISV(1);
+                fab(iv, nDist) = fab(iv, nDist) - loc_offset;
+              }
+              found_it = true;
+            }
+          }
+
+          if (!found_it) {
+            // set all distance values to something off the line
+            Real err_val =
+              fab(
+                IntVect(se + i * BASISV(0) + (nvals - 1) * BASISV(1)), nDist) *
+              2;
+            for (int j = 0; j < nvals; ++j) {
+              IntVect iv = se + i * BASISV(0) + j * BASISV(1);
+              fab(iv, nDist) = err_val;
+            }
+          }
         }
-
-        for (int i=0; i<minComps.size(); ++i) {
-            char buf[64]; sprintf(buf,"%g",minVals[i]);
-            condStr += "Min(" + names[comps[minComps[i]]] + ") " + minSgns[i] + " " + string(buf) + "; ";
-        }
-
-        for (int i=0; i<atComps.size(); ++i) {
-            char buf1[64]; sprintf(buf1,"%g",atVal[i]);
-            char buf2[64]; sprintf(buf2,"%g",valAt[i]);
-
-            condStr += names[comps[compAt[i]]] + "(" + names[comps[atComps[i]]]
-                + " = " + string(buf1) + ") " + atSgns[i] + " " + string(buf2) + "; ";
-        }
-
-        if (RXY>0) {
-            char buf[64]; sprintf(buf,"%g",RXY);
-            condStr += "radiusXY " + RXYsgn + " " + string(buf) + " ";
-        }
-
-        if (condStr != "")
-            std::cout << " ...subject to: " << condStr << std::endl;
-
+      }
     }
 
-    Vector<BoxArray> stream_data_layout;
-    Vector<Vector<SelectionMapList> > selectIdxPairs;
-    Vector<map<int,int> > map_selected_to_full_gidx;
-
-    downsampleStreamData(stream,nLines,stream_data_layout,
-                         map_selected_to_full_gidx,selectIdxPairs,verbose);
-    if (ParallelDescriptor::IOProcessor()) {
-        cout << "Reduced dataset has " << nLines << " lines " << std::endl;
-    }
-
-    int slo = stream.StreamIdxLo();
-    int shi = stream.StreamIdxHi();
-
-    Box finalBox(IntVect(AMREX_D_DECL(0,slo,0)),
-                 IntVect(AMREX_D_DECL(nLines-1,shi,0)));
-    BoxArray finalBa(finalBox);
-    DistributionMapping dmfinal(finalBa);
-    MultiFab finalMF(finalBa,dmfinal,selectedNames.size(),0);
-
-    for (int lev=0; lev<=finestLevel; ++lev)
-    {
-        const BoxArray& dstBa=stream_data_layout[lev];
-
-        if (ParallelDescriptor::IOProcessor() && verbose)
-        {
-            cout << "Reduced  dataset has " << dstBa.size() << " boxes (original has "
-                 << stream.boxArray(lev).size() << ") at level = " << lev << endl; 
-        }
-        if (dstBa.size()>0) 
-        {
-            MultiFab dst(dstBa,DistributionMapping(dstBa),comps.size(),0);
-            for (MFIter mfi(dst); mfi.isValid(); ++mfi)
-            {
-                int gidx = mfi.index();
-                FArrayBox& dstFab = dst[mfi];
-                const SelectionMapList& line_map = selectIdxPairs[lev][gidx];
-                int srcIdx = map_selected_to_full_gidx[lev][gidx];
-                
-                for (int n=0; n<comps.size(); ++n)
-                {
-                    const FArrayBox& srcFab = *(stream.getFab(lev,srcIdx,comps[n]));
-                    for (SelectionMapList::const_iterator it = line_map.begin(); it!=line_map.end(); ++it)
-                    {
-                        int old_local_idx = it->second;                
-                        Box srcBox(IntVect(AMREX_D_DECL(old_local_idx,slo,0)),
-                                   IntVect(AMREX_D_DECL(old_local_idx,shi,0)));
-                        
-                        int new_global_idx = it->first;
-                        AMREX_ASSERT(new_global_idx < nLines);
-                        Box dstBox(IntVect(AMREX_D_DECL(new_global_idx,slo,0)),
-                                   IntVect(AMREX_D_DECL(new_global_idx,shi,0)));
-                        
-                        AMREX_ASSERT(srcFab.box().contains(srcBox));
-                        AMREX_ASSERT(dstFab.box().contains(dstBox));
-                        
-                        dstFab.copy(srcFab,srcBox,0,dstBox,n,1);
-                    }
-                }
-            } // mfi
-            
-            finalMF.copy(dst);
-        }
-    }
-    
-    int procWithFab = finalMF.DistributionMap()[0];
-
-    if (ParallelDescriptor::MyProc()==procWithFab)
-    {
-        FArrayBox& fab=finalMF[0];
-
-        // Scan downselected streamlines for criteria
-        Vector<int> write_lines(nLines,1);
-
-        if (no_filter) {
-            for (int i=0; i<write_lines.size(); ++i) {
-                write_lines[i] = 1;
-            }
-        }
-        else
-        {
-            IntVect se=finalBox.smallEnd();
-            int nvals = shi-slo+1;
-
-            // Check criteria on maximum values
-            for (int n=0; n<maxComps.size(); ++n) 
-            {
-                int nc = maxComps[n];
-                for (int i=0; i<nLines; ++i)
-                {
-                    Real maxVal=fab(se,nc);
-                    for (int j=0; j<nvals; ++j) {
-                        IntVect iv = se + i*BASISV(0) + j*BASISV(1);
-                        maxVal = std::max(fab(iv,nc),maxVal);
-                    }
-                    if ( ! do_test(maxVal,maxSgns[n],maxVals[n]) ) {
-                        write_lines[i] = 0;
-                    }
-                }
-            }
-
-            // Check criteria on minimum values
-            for (int n=0; n<minComps.size(); ++n) 
-            {
-                int nc = minComps[n];
-                for (int i=0; i<nLines; ++i)
-                {
-                    Real minVal=fab(se,nc);
-                    for (int j=0; j<nvals; ++j) {
-                        IntVect iv = se + i*BASISV(0) + j*BASISV(1);
-                        minVal = std::min(fab(iv,nc),minVal);
-                    }
-                    if ( ! do_test(minVal,minSgns[n],minVals[n]) ) {
-                        write_lines[i] = 0;
-                    }
-                }
-            }
-
-            // Check criteria on radius of seed point
-            AMREX_ASSERT(comps.size()>2);
-            if (RXY>0)
-            {
-                for (int i=0; i<nLines; ++i)
-                {
-                    IntVect ivs(AMREX_D_DECL(i,0.5*(slo+shi),0));
-                    Real radius = 0;
-                    for (int n=0; n<2; ++n) {
-                        Real val = fab(ivs,n);
-                        radius += val*val;
-                    }
-                    radius = std::sqrt(radius);
-                    if ( ! do_test(radius,RXYsgn,RXY) ) {
-                        write_lines[i] = 0;
-                    }
-                }
-            }
-
-            // Check criteria on "atVals"
-            for (int n=0; n<atComps.size(); ++n) 
-            {
-                int loc_comp = atComps[n];
-                Real loc_val = atVal[n];
-                int test_comp = compAt[n];
-                Real test_val = valAt[n];
-
-                for (int i=0; i<nLines; ++i)
-                {
-                    bool found_it = false;
-                    IntVect ivl, ivh;
-                    Real loc_val_lo, loc_val_hi;
-                    for (int j=0; j<nvals-1 && !found_it; ++j) {
-                        ivl = se + i*BASISV(0) + j*BASISV(1);
-                        ivh = se + i*BASISV(0) + (j+1)*BASISV(1);
-                        loc_val_lo = fab(ivl,loc_comp);
-                        loc_val_hi = fab(ivh,loc_comp);
-                        if ( ( (loc_val_lo > loc_val)  && (loc_val_hi < loc_val) ) ||
-                             ( (loc_val_lo < loc_val)  && (loc_val_hi > loc_val) ) ) {
-                            Real alpha = (loc_val - loc_val_lo)/(loc_val_hi-loc_val_lo);
-                            AMREX_ASSERT(alpha>=0 && alpha<=1);
-                            Real val_lo = fab(ivl,test_comp);
-                            Real val_hi = fab(ivh,test_comp);
-                            Real val_test = val_lo + alpha*(val_hi-val_lo);
-                            write_lines[i] = do_test(val_test,atSgns[n],test_val);
-                            found_it = true;
-                        }
-                    }
-                }
-            }
-
-            // Add auxiliary quantities
-            if (distComp>=0)
-            {
-                // Compute relative to the start of the streamline, then shift
-                int nDist = comps.size();
-                int loc_comp = distComp;
-                Real loc_val = distVal;
-                Real loc_offset = 0;
-
-                IntVect ivl, ivh;
-                AMREX_ASSERT(comps.size()>AMREX_SPACEDIM);
-                for (int i=0; i<nLines; ++i)
-                {
-                    ivl = se + i*BASISV(0);
-                    fab(ivl,nDist) = 0;
-                    for (int j=1; j<nvals; ++j) {
-                        ivl = se + i*BASISV(0) + (j-1)*BASISV(1);
-                        ivh = se + i*BASISV(0) +   j  *BASISV(1);
-                        Real ds = 0;
-                        for (int n=0; n<AMREX_SPACEDIM; ++n) {
-                            Real dx = fab(ivh,n) - fab(ivl,n);
-                            ds += dx*dx;
-                        }
-                        ds = std::sqrt(ds);
-                        fab(ivh,nDist) = fab(ivl,nDist) + ds;
-                    }                    
-
-                    bool found_it = false;
-                    for (int j=0; j<nvals-1 && !found_it; ++j) {
-                        ivl = se + i*BASISV(0) + j*BASISV(1);
-                        ivh = se + i*BASISV(0) + (j+1)*BASISV(1);
-                        Real loc_val_lo = fab(ivl,loc_comp);
-                        Real loc_val_hi = fab(ivh,loc_comp);
-                        if ( ( (loc_val_lo > loc_val)  && (loc_val_hi < loc_val) ) ||
-                             ( (loc_val_lo < loc_val)  && (loc_val_hi > loc_val) ) ) {
-                            Real alpha = (loc_val - loc_val_lo)/(loc_val_hi-loc_val_lo);
-                            AMREX_ASSERT(alpha>=0 && alpha<=1);
-                            Real val_lo = fab(ivl,nDist);
-                            Real val_hi = fab(ivh,nDist);
-                            loc_offset = val_lo + alpha*(val_hi-val_lo);
-                            // Do the shift
-                            for (int jj=0; jj<nvals; ++jj) {
-                                IntVect iv = se + i*BASISV(0) + jj*BASISV(1);
-                                fab(iv,nDist) = fab(iv,nDist) - loc_offset;
-                            }                        
-                            found_it = true;
-                        }
-                    }
-
-                    if (!found_it) {
-                        // set all distance values to something off the line
-                        Real err_val=fab(IntVect(se + i*BASISV(0) + (nvals-1)*BASISV(1)),nDist) * 2;
-                        for (int j=0; j<nvals; ++j) {
-                            IntVect iv = se + i*BASISV(0) + j*BASISV(1);
-                            fab(iv,nDist) = err_val;
-                        }
-                    }
-                }
-
-
-            }
-        }
-
-        char buf1[64]; sprintf(buf1,"%d",nLines);
-        char buf2[64]; sprintf(buf2,"%d",stream.NLines());
-        string file_label="streamlines from " + infile + " selected from a subset ("
-            + string(buf1) + " of " + string(buf2) + ")";
-        if (condStr != "")
-            file_label += " and further conditioned such that: " + condStr;
+    char buf1[64];
+    sprintf(buf1, "%d", nLines);
+    char buf2[64];
+    sprintf(buf2, "%d", stream.NLines());
+    string file_label = "streamlines from " + infile +
+                        " selected from a subset (" + string(buf1) + " of " +
+                        string(buf2) + ")";
+    if (condStr != "")
+      file_label += " and further conditioned such that: " + condStr;
 #ifdef AMREX_WRITE_BINARY
-        write_tec_binary(fab,outfile,file_label,selectedNames,write_lines);
+    write_tec_binary(fab, outfile, file_label, selectedNames, write_lines);
 #else
-        write_tec_ascii(fab,outfile,file_label,selectedNames,write_lines);
+    write_tec_ascii(fab, outfile, file_label, selectedNames, write_lines);
 #endif
-    }
-    amrex::Finalize();
-    return 0;
+  }
+  amrex::Finalize();
+  return 0;
 }
 
-static bool do_test(Real thisVal,
-                    const std::string& sgn,
-                    Real critVal)
+static bool
+do_test(Real thisVal, const std::string& sgn, Real critVal)
 {
-    bool retVal = false;
-    if (sgn=="ge") {
-        retVal =  thisVal >= critVal;
-    } else if (sgn=="gt") {
-        retVal =  thisVal > critVal;
-    } else if (sgn=="lt") {
-        retVal =  thisVal < critVal;
-    } else if (sgn=="le") {
-        retVal =  thisVal <= critVal;
-    } else if (sgn=="eq") {
-        retVal =  thisVal == critVal;
-    } else if (sgn=="ne") {
-        retVal =  thisVal != critVal;
-    }
-    return retVal;
+  bool retVal = false;
+  if (sgn == "ge") {
+    retVal = thisVal >= critVal;
+  } else if (sgn == "gt") {
+    retVal = thisVal > critVal;
+  } else if (sgn == "lt") {
+    retVal = thisVal < critVal;
+  } else if (sgn == "le") {
+    retVal = thisVal <= critVal;
+  } else if (sgn == "eq") {
+    retVal = thisVal == critVal;
+  } else if (sgn == "ne") {
+    retVal = thisVal != critVal;
+  }
+  return retVal;
 }
-

--- a/Src/streamBinTubeStats.cpp
+++ b/Src/streamBinTubeStats.cpp
@@ -11,28 +11,27 @@ using namespace amrex;
 #include <streamBinTubeStats.H>
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
 
-  if (ParallelDescriptor::NProcs()>1)
+  if (ParallelDescriptor::NProcs() > 1)
     Abort("Code is not yet parallel safe");
-  
+
   ParmParse pp;
 
   // read infile name from inputs
   std::string infile;
-  pp.get("infile",infile);
+  pp.get("infile", infile);
 
   // parse what files to write
   int writeStreamsToMatlab(0);
-  pp.query("writeStreamsToMatlab",writeStreamsToMatlab);
+  pp.query("writeStreamsToMatlab", writeStreamsToMatlab);
   int writeTecplotSurfaceFromStream(0);
-  pp.query("writeTecplotSurfaceFromStream",writeTecplotSurfaceFromStream);
+  pp.query("writeTecplotSurfaceFromStream", writeTecplotSurfaceFromStream);
   int writeBasic(0);
-  pp.query("writeBasic",writeBasic);
-  
+  pp.query("writeBasic", writeBasic);
+
   // declare size and data holders
   int nStreams, nElts, nPtsOnStream, nComps;
   std::vector<std::string> variableNames;
@@ -40,44 +39,48 @@ main (int   argc,
   Vector<Vector<Real>> streamData;
 
   // Read file
-  readStreamBin(infile, nStreams, nElts, nPtsOnStream, nComps,
-		variableNames, faceData, streamData);
+  readStreamBin(
+    infile, nStreams, nElts, nPtsOnStream, nComps, variableNames, faceData,
+    streamData);
   // report
   Print() << "nStreams      = " << nStreams << std::endl;
   Print() << "nElements     = " << nElts << std::endl;
   Print() << "nPtsOnStreams = " << nPtsOnStream << std::endl;
   Print() << "nComps        = " << nComps << std::endl;
   Print() << "Variable names:" << std::endl;
-  for (int iComp=0; iComp<nComps; iComp++)
+  for (int iComp = 0; iComp < nComps; iComp++)
     Print() << "   " << iComp << ": " << variableNames[iComp] << std::endl;
 
   // let's write a matlab file for each variable
   if (writeStreamsToMatlab) {
     Print() << "Writing streams as matlab files..." << std::endl;
-    writeStreamsMatlab(infile,nStreams,nPtsOnStream,nComps,variableNames,streamData);
+    writeStreamsMatlab(
+      infile, nStreams, nPtsOnStream, nComps, variableNames, streamData);
   }
-  
+
   // let's output a surface
   if (writeTecplotSurfaceFromStream) {
     Print() << "Writing a tecplot surface..." << std::endl;
-    writeSurfaceFromStreamTecplot(infile,nStreams,nElts,nPtsOnStream,nComps,
-				  variableNames,faceData,streamData);
+    writeSurfaceFromStreamTecplot(
+      infile, nStreams, nElts, nPtsOnStream, nComps, variableNames, faceData,
+      streamData);
   }
 
   // parse which variables to average
   int nAvg = pp.countval("avgComps");
   Vector<std::string> avgComps;
   Vector<int> avgIdx(nAvg);
-  if (nAvg>0) {
-    pp.getarr("avgComps",avgComps);
+  if (nAvg > 0) {
+    pp.getarr("avgComps", avgComps);
     Print() << "Average components:" << std::endl;
-    for (int iAvg=0; iAvg<nAvg; iAvg++) {
-      avgIdx[iAvg]=-1;
-      for (int iComp=0; iComp<nComps; iComp++)
-	if (variableNames[iComp]==avgComps[iAvg]) avgIdx[iAvg]=iComp;
-      if (avgIdx[iAvg]==-1) {
-	std::string msg="avgComp (" + avgComps[iAvg] + ") not in stream file";
-	Abort(msg);
+    for (int iAvg = 0; iAvg < nAvg; iAvg++) {
+      avgIdx[iAvg] = -1;
+      for (int iComp = 0; iComp < nComps; iComp++)
+        if (variableNames[iComp] == avgComps[iAvg])
+          avgIdx[iAvg] = iComp;
+      if (avgIdx[iAvg] == -1) {
+        std::string msg = "avgComp (" + avgComps[iAvg] + ") not in stream file";
+        Abort(msg);
       }
       Print() << "   " << avgIdx[iAvg] << ": " << avgComps[iAvg] << std::endl;
     }
@@ -87,16 +90,17 @@ main (int   argc,
   int nInt = pp.countval("intComps");
   Vector<std::string> intComps;
   Vector<int> intIdx(nInt);
-  if (nInt>0) {
-    pp.getarr("intComps",intComps);
+  if (nInt > 0) {
+    pp.getarr("intComps", intComps);
     Print() << "Integral components:" << std::endl;
-    for (int iInt=0; iInt<nInt; iInt++) {
-      intIdx[iInt]=-1;
-      for (int iComp=0; iComp<nComps; iComp++)
-	if (variableNames[iComp]==intComps[iInt]) intIdx[iInt]=iComp;
-      if (intIdx[iInt]==-1) {
-	std::string msg="intComp (" + intComps[iInt] + ") not in stream file";
-	Abort(msg);
+    for (int iInt = 0; iInt < nInt; iInt++) {
+      intIdx[iInt] = -1;
+      for (int iComp = 0; iComp < nComps; iComp++)
+        if (variableNames[iComp] == intComps[iInt])
+          intIdx[iInt] = iComp;
+      if (intIdx[iInt] == -1) {
+        std::string msg = "intComp (" + intComps[iInt] + ") not in stream file";
+        Abort(msg);
       }
       Print() << "   " << intIdx[iInt] << ": " << intComps[iInt] << std::endl;
     }
@@ -105,307 +109,324 @@ main (int   argc,
   // parse derived quantities (e.g. principal curvature zone)
   int nDer = pp.countval("derComps");
   Vector<std::string> derComps;
-  if (nDer>0) pp.getarr("derComps",derComps);
-  
+  if (nDer > 0)
+    pp.getarr("derComps", derComps);
+
   // make space to hold output surface
-  // for each element (i.e. triangle), we have three coordinates and one set of data
-  // data will be written in triplicate, but no need to store all that
+  // for each element (i.e. triangle), we have three coordinates and one set of
+  // data data will be written in triplicate, but no need to store all that
   // connectivity follows naturally from construction
-  Vector<Real>         eltArea(nElts);
-  Vector<Real>         eltVol(nElts);
+  Vector<Real> eltArea(nElts);
+  Vector<Real> eltVol(nElts);
   Vector<Vector<dim3>> surfLocs(nElts);
   Vector<Vector<Real>> surfAvg(nElts);
   Vector<Vector<Real>> surfInt(nElts);
   Vector<Vector<Real>> surfDer(nElts);
-  for (int iElt=0; iElt<nElts; iElt++) {
+  for (int iElt = 0; iElt < nElts; iElt++) {
     surfLocs[iElt].resize(AMREX_SPACEDIM);
     surfAvg[iElt].resize(nAvg);
     surfInt[iElt].resize(nInt);
     surfDer[iElt].resize(nDer);
   }
- 
+
   // get the three stream indices from connectivity faceData
   Print() << "Making triangles from connectivity data ..." << std::endl;
   Vector<int3> sIdx(nElts);
-  for (int iElt=0; iElt<nElts; iElt++)
-    for (int iCorner=0; iCorner<AMREX_SPACEDIM; iCorner++) 
-      sIdx[iElt][iCorner] = faceData[iElt*AMREX_SPACEDIM+iCorner];
-  
+  for (int iElt = 0; iElt < nElts; iElt++)
+    for (int iCorner = 0; iCorner < AMREX_SPACEDIM; iCorner++)
+      sIdx[iElt][iCorner] = faceData[iElt * AMREX_SPACEDIM + iCorner];
+
   // the surface is the mid point of the stream
-  int surfPt = (nPtsOnStream-1)/2; // stream data location counts from zero
+  int surfPt = (nPtsOnStream - 1) / 2; // stream data location counts from zero
 
   // set locations
   Print() << "Setting locations ..." << std::endl;
-  for (int iElt=0; iElt<nElts; iElt++) {
+  for (int iElt = 0; iElt < nElts; iElt++) {
     // define the spatial location of the three corners of the triangle
-    for (int iCorner=0; iCorner<AMREX_SPACEDIM; iCorner++) { // three corners (streams)
-      int iStream=faceData[iElt*AMREX_SPACEDIM+iCorner];
-      for (int d=0; d<AMREX_SPACEDIM; d++) { // three components of location
-	surfLocs[iElt][iCorner][d] = streamData[iStream][nPtsOnStream*d+surfPt];
+    for (int iCorner = 0; iCorner < AMREX_SPACEDIM;
+         iCorner++) { // three corners (streams)
+      int iStream = faceData[iElt * AMREX_SPACEDIM + iCorner];
+      for (int d = 0; d < AMREX_SPACEDIM; d++) { // three components of location
+        surfLocs[iElt][iCorner][d] =
+          streamData[iStream][nPtsOnStream * d + surfPt];
       }
     }
   }
 
   // evaluate area
   Print() << "Evaluating areas ..." << std::endl;
-  Real surfaceArea=0.;
-  for (int iElt=0; iElt<nElts; iElt++) {
+  Real surfaceArea = 0.;
+  for (int iElt = 0; iElt < nElts; iElt++) {
     int3 iStream; // stream indices that make up this element
-    for (int iCorner=0; iCorner<AMREX_SPACEDIM; iCorner++) 
-      iStream[iCorner]=sIdx[iElt][iCorner];
+    for (int iCorner = 0; iCorner < AMREX_SPACEDIM; iCorner++)
+      iStream[iCorner] = sIdx[iElt][iCorner];
     // set up triangle ABC
     dim3 A, B, C;
-    for (int d=0; d<AMREX_SPACEDIM; d++) { // three components of location
-      A[d] = streamData[iStream[0]][nPtsOnStream*d+surfPt];
-      B[d] = streamData[iStream[1]][nPtsOnStream*d+surfPt];
-      C[d] = streamData[iStream[2]][nPtsOnStream*d+surfPt];
+    for (int d = 0; d < AMREX_SPACEDIM; d++) { // three components of location
+      A[d] = streamData[iStream[0]][nPtsOnStream * d + surfPt];
+      B[d] = streamData[iStream[1]][nPtsOnStream * d + surfPt];
+      C[d] = streamData[iStream[2]][nPtsOnStream * d + surfPt];
     }
     // find area
-    eltArea[iElt] = wedge_area(A,B,C);
+    eltArea[iElt] = wedge_area(A, B, C);
     // keep a running total
-    surfaceArea+=eltArea[iElt];
+    surfaceArea += eltArea[iElt];
   }
   Print() << "   ... total surface area = " << surfaceArea << std::endl;
 
   // evaluate volume
   Print() << "Evaluating volumes ..." << std::endl;
-  for (int iElt=0; iElt<nElts; iElt++) {
+  for (int iElt = 0; iElt < nElts; iElt++) {
     int3 iStream; // stream indices that make up this element
-    for (int iCorner=0; iCorner<AMREX_SPACEDIM; iCorner++) 
-      iStream[iCorner]=sIdx[iElt][iCorner];
-    eltVol[iElt]=0.;
-    for (int iPt=1; iPt<nPtsOnStream; iPt++) {
+    for (int iCorner = 0; iCorner < AMREX_SPACEDIM; iCorner++)
+      iStream[iCorner] = sIdx[iElt][iCorner];
+    eltVol[iElt] = 0.;
+    for (int iPt = 1; iPt < nPtsOnStream; iPt++) {
       dim3 A, B, C, D, E, F;
-      for (int d=0; d<AMREX_SPACEDIM; d++) { // three components of location
-	A[d] = streamData[iStream[0]][nPtsOnStream*d+iPt-1];
-	B[d] = streamData[iStream[1]][nPtsOnStream*d+iPt-1];
-	C[d] = streamData[iStream[2]][nPtsOnStream*d+iPt-1];
-	D[d] = streamData[iStream[0]][nPtsOnStream*d+iPt];
-	E[d] = streamData[iStream[1]][nPtsOnStream*d+iPt];
-	F[d] = streamData[iStream[2]][nPtsOnStream*d+iPt];
+      for (int d = 0; d < AMREX_SPACEDIM; d++) { // three components of location
+        A[d] = streamData[iStream[0]][nPtsOnStream * d + iPt - 1];
+        B[d] = streamData[iStream[1]][nPtsOnStream * d + iPt - 1];
+        C[d] = streamData[iStream[2]][nPtsOnStream * d + iPt - 1];
+        D[d] = streamData[iStream[0]][nPtsOnStream * d + iPt];
+        E[d] = streamData[iStream[1]][nPtsOnStream * d + iPt];
+        F[d] = streamData[iStream[2]][nPtsOnStream * d + iPt];
       }
-      eltVol[iElt] += wedge_volume(A,B,C,D,E,F);
+      eltVol[iElt] += wedge_volume(A, B, C, D, E, F);
     }
   }
 
   // calculate averages
   Print() << "Calculating averages ..." << std::endl;
-  for (int iElt=0; iElt<nElts; iElt++) {
+  for (int iElt = 0; iElt < nElts; iElt++) {
     // evaluate average of each component over the three points
-    for (int iAvg=0; iAvg<nAvg; iAvg++) {
-      int iComp=avgIdx[iAvg]; // component index that we're averaging
+    for (int iAvg = 0; iAvg < nAvg; iAvg++) {
+      int iComp = avgIdx[iAvg]; // component index that we're averaging
       Real avgVal(0.);
-      for (int iCorner=0; iCorner<AMREX_SPACEDIM; iCorner++) {
-	int iStream=sIdx[iElt][iCorner];
-	avgVal += streamData[iStream][nPtsOnStream*iComp+surfPt];
+      for (int iCorner = 0; iCorner < AMREX_SPACEDIM; iCorner++) {
+        int iStream = sIdx[iElt][iCorner];
+        avgVal += streamData[iStream][nPtsOnStream * iComp + surfPt];
       }
-      surfAvg[iElt][iAvg] = avgVal*third;
+      surfAvg[iElt][iAvg] = avgVal * third;
     }
   }
-  
+
   // calculate integrals
   Print() << "Calculating integrals ..." << std::endl;
-  for (int iElt=0; iElt<nElts; iElt++) {
+  for (int iElt = 0; iElt < nElts; iElt++) {
     int3 iStream; // stream indices that make up this element
-    for (int iCorner=0; iCorner<AMREX_SPACEDIM; iCorner++) 
-      iStream[iCorner]=sIdx[iElt][iCorner];
+    for (int iCorner = 0; iCorner < AMREX_SPACEDIM; iCorner++)
+      iStream[iCorner] = sIdx[iElt][iCorner];
     // set integral to zero
-    for (int iInt=0; iInt<nInt; iInt++) 
+    for (int iInt = 0; iInt < nInt; iInt++)
       surfInt[iElt][iInt] = 0.;
     // integrate
-    for (int iPt=1; iPt<nPtsOnStream; iPt++) {
+    for (int iPt = 1; iPt < nPtsOnStream; iPt++) {
       dim3 A, B, C, D, E, F;
-      for (int d=0; d<AMREX_SPACEDIM; d++) { // three components of location
-	A[d] = streamData[iStream[0]][nPtsOnStream*d+iPt-1];
-	B[d] = streamData[iStream[1]][nPtsOnStream*d+iPt-1];
-	C[d] = streamData[iStream[2]][nPtsOnStream*d+iPt-1];
-	D[d] = streamData[iStream[0]][nPtsOnStream*d+iPt];
-	E[d] = streamData[iStream[1]][nPtsOnStream*d+iPt];
-	F[d] = streamData[iStream[2]][nPtsOnStream*d+iPt];
+      for (int d = 0; d < AMREX_SPACEDIM; d++) { // three components of location
+        A[d] = streamData[iStream[0]][nPtsOnStream * d + iPt - 1];
+        B[d] = streamData[iStream[1]][nPtsOnStream * d + iPt - 1];
+        C[d] = streamData[iStream[2]][nPtsOnStream * d + iPt - 1];
+        D[d] = streamData[iStream[0]][nPtsOnStream * d + iPt];
+        E[d] = streamData[iStream[1]][nPtsOnStream * d + iPt];
+        F[d] = streamData[iStream[2]][nPtsOnStream * d + iPt];
       }
-      
-      for (int iInt=0; iInt<nInt; iInt++) {
-	int iComp = intIdx[iInt];
-	Real vA = streamData[iStream[0]][nPtsOnStream*iComp+iPt-1];
-	Real vB = streamData[iStream[1]][nPtsOnStream*iComp+iPt-1];
-	Real vC = streamData[iStream[2]][nPtsOnStream*iComp+iPt-1];
-	Real vD = streamData[iStream[0]][nPtsOnStream*iComp+iPt];
-	Real vE = streamData[iStream[1]][nPtsOnStream*iComp+iPt];
-	Real vF = streamData[iStream[2]][nPtsOnStream*iComp+iPt];
-	surfInt[iElt][iInt] += wedge_volume_int(A,vA,B,vB,C,vC,D,vD,E,vE,F,vF);
+
+      for (int iInt = 0; iInt < nInt; iInt++) {
+        int iComp = intIdx[iInt];
+        Real vA = streamData[iStream[0]][nPtsOnStream * iComp + iPt - 1];
+        Real vB = streamData[iStream[1]][nPtsOnStream * iComp + iPt - 1];
+        Real vC = streamData[iStream[2]][nPtsOnStream * iComp + iPt - 1];
+        Real vD = streamData[iStream[0]][nPtsOnStream * iComp + iPt];
+        Real vE = streamData[iStream[1]][nPtsOnStream * iComp + iPt];
+        Real vF = streamData[iStream[2]][nPtsOnStream * iComp + iPt];
+        surfInt[iElt][iInt] +=
+          wedge_volume_int(A, vA, B, vB, C, vC, D, vD, E, vE, F, vF);
       }
     }
-    for (int iInt=0; iInt<nInt; iInt++) 
+    for (int iInt = 0; iInt < nInt; iInt++)
       surfInt[iElt][iInt] /= eltArea[iElt];
   }
-  
+
   // calculate derived
   Print() << "Calculating derived quanities ..." << std::endl;
-  for (int iDer=0; iDer<nDer; iDer++) {
+  for (int iDer = 0; iDer < nDer; iDer++) {
 
     //
     // local flame thickness
     //
-    if (derComps[iDer]=="flameThickness") {
+    if (derComps[iDer] == "flameThickness") {
       Print() << "   Evaluating local flame thermal thickness..." << std::endl;
-      
+
       // need reactant and product temperatures
       Real reacTemp, prodTemp;
-      pp.get("reacTemp",reacTemp);
-      pp.get("prodTemp",prodTemp);
-      Real deltaT=prodTemp-reacTemp;
-      
+      pp.get("reacTemp", reacTemp);
+      pp.get("prodTemp", prodTemp);
+      Real deltaT = prodTemp - reacTemp;
+
       // also need to know which variable to use as temperature gradient
       std::string tempGradVar;
-      pp.get("tempGradVar",tempGradVar);
-      int tempGradComp=-1;
-      for (int iComp=0; iComp<nComps; iComp++)
-	if (variableNames[iComp]==tempGradVar) tempGradComp=iComp;
-      if (tempGradComp==-1) {
-	std::string msg="tempGradComp (" + tempGradVar + ") not in stream file";
-	Abort(msg);
+      pp.get("tempGradVar", tempGradVar);
+      int tempGradComp = -1;
+      for (int iComp = 0; iComp < nComps; iComp++)
+        if (variableNames[iComp] == tempGradVar)
+          tempGradComp = iComp;
+      if (tempGradComp == -1) {
+        std::string msg =
+          "tempGradComp (" + tempGradVar + ") not in stream file";
+        Abort(msg);
       }
       Print() << "      " << tempGradComp << ": " << tempGradVar << std::endl
-	      << "      " << "deltaT = " << prodTemp << " - " << reacTemp
-	      << " = " << deltaT << std::endl;
+              << "      " << "deltaT = " << prodTemp << " - " << reacTemp
+              << " = " << deltaT << std::endl;
 
       // mean local thermal thickness
       Real ls(0.);
-      for (int iElt=0; iElt<nElts; iElt++) {
-	Real maxModGradT(0.);
-	for (int iPt=1; iPt<nPtsOnStream; iPt++) {
-	  Real avgModGradT(0.);
-	  for (int iCorner=0; iCorner<AMREX_SPACEDIM; iCorner++) {
-	    int iStream=sIdx[iElt][iCorner];
-	    avgModGradT += streamData[iStream][nPtsOnStream*tempGradComp+iPt];
-	  }
-	  avgModGradT *= third;
-	  maxModGradT = max(maxModGradT,avgModGradT);
-	}
-	// local thermal thicnkess
-	surfDer[iElt][iDer] = deltaT/maxModGradT;
-	// sum for mean
-	ls += surfDer[iElt][iDer] * eltArea[iElt];
+      for (int iElt = 0; iElt < nElts; iElt++) {
+        Real maxModGradT(0.);
+        for (int iPt = 1; iPt < nPtsOnStream; iPt++) {
+          Real avgModGradT(0.);
+          for (int iCorner = 0; iCorner < AMREX_SPACEDIM; iCorner++) {
+            int iStream = sIdx[iElt][iCorner];
+            avgModGradT +=
+              streamData[iStream][nPtsOnStream * tempGradComp + iPt];
+          }
+          avgModGradT *= third;
+          maxModGradT = max(maxModGradT, avgModGradT);
+        }
+        // local thermal thicnkess
+        surfDer[iElt][iDer] = deltaT / maxModGradT;
+        // sum for mean
+        ls += surfDer[iElt][iDer] * eltArea[iElt];
       }
       ls /= surfaceArea;
-      Print () << "      mean local thermal thickness = " << ls << std::endl;
+      Print() << "      mean local thermal thickness = " << ls << std::endl;
     }
 
     //
     // principal curvature zone
     //
-    if (derComps[iDer]=="principalCurvatureZone") {
+    if (derComps[iDer] == "principalCurvatureZone") {
       Print() << "   Evaluating principal curvature zone..." << std::endl;
       // need a length scale to define "flat"
       Real pkzLength;
-      pp.get("pkzLength",pkzLength);
-      Real pkzFF = half/pkzLength;
+      pp.get("pkzLength", pkzLength);
+      Real pkzFF = half / pkzLength;
 
       // also need to know which variable to use as mean and gaussian curvature
       std::string pkzMkVar, pkzGkVar;
-      pp.get("pkzMkVar",pkzMkVar);
-      pp.get("pkzGkVar",pkzGkVar);
-      int pkzMkComp=-1;
-      int pkzGkComp=-1;
-      for (int iComp=0; iComp<nComps; iComp++) {
-	if (variableNames[iComp]==pkzMkVar) pkzMkComp=iComp;
-	if (variableNames[iComp]==pkzGkVar) pkzGkComp=iComp;
+      pp.get("pkzMkVar", pkzMkVar);
+      pp.get("pkzGkVar", pkzGkVar);
+      int pkzMkComp = -1;
+      int pkzGkComp = -1;
+      for (int iComp = 0; iComp < nComps; iComp++) {
+        if (variableNames[iComp] == pkzMkVar)
+          pkzMkComp = iComp;
+        if (variableNames[iComp] == pkzGkVar)
+          pkzGkComp = iComp;
       }
-      if (pkzMkComp==-1) {
-	std::string msg="pkzMkComp (" + pkzMkVar + ") not in stream file";
-	Abort(msg);
+      if (pkzMkComp == -1) {
+        std::string msg = "pkzMkComp (" + pkzMkVar + ") not in stream file";
+        Abort(msg);
       }
-      if (pkzGkComp==-1) {
-	std::string msg="pkzGkComp (" + pkzGkVar + ") not in stream file";
-	Abort(msg);
+      if (pkzGkComp == -1) {
+        std::string msg = "pkzGkComp (" + pkzGkVar + ") not in stream file";
+        Abort(msg);
       }
       Print() << "      " << pkzMkComp << ": " << pkzMkVar << std::endl
-	      << "      " << pkzGkComp << ": " << pkzGkVar << std::endl
-	      << "      " << "pkzLength = " << pkzLength << std::endl;
+              << "      " << pkzGkComp << ": " << pkzGkVar << std::endl
+              << "      " << "pkzLength = " << pkzLength << std::endl;
 
-      for (int iElt=0; iElt<nElts; iElt++) {
-	Real avgMk(0.);
-	Real avgGk(0.);
-	for (int iCorner=0; iCorner<AMREX_SPACEDIM; iCorner++) {
-	  int iStream=sIdx[iElt][iCorner];
-	  avgMk += streamData[iStream][nPtsOnStream*pkzMkComp+surfPt];
-	  avgGk += streamData[iStream][nPtsOnStream*pkzGkComp+surfPt];
-	}
-	avgMk *= third;
-	avgGk *= third;
-	Real det = sqrt(fabs(avgMk*avgMk-avgGk));
-	Real k1 = avgMk + det;
-	Real k2 = avgMk - det;
-	Real zone(0);
-	if   ( sqrt(k1*k1+k2*k2) <  pkzFF         )  zone = 1; // FF
-	else {
-	  if (                k2 >  half*k1       )  zone = 2; // LP
-	  if (       fabs(k2/k1) <= half          )  zone = 3; // LE
-	  if (        (-2*k1<k2) && (k2<-half*k1) )  zone = 4; // SP
-	  if (       fabs(k1/k2) <= half          )  zone = 5; // TE
-	  if (                k1 <  half*k2       )  zone = 6; // TP
-	}
-	surfDer[iElt][iDer] = zone;
+      for (int iElt = 0; iElt < nElts; iElt++) {
+        Real avgMk(0.);
+        Real avgGk(0.);
+        for (int iCorner = 0; iCorner < AMREX_SPACEDIM; iCorner++) {
+          int iStream = sIdx[iElt][iCorner];
+          avgMk += streamData[iStream][nPtsOnStream * pkzMkComp + surfPt];
+          avgGk += streamData[iStream][nPtsOnStream * pkzGkComp + surfPt];
+        }
+        avgMk *= third;
+        avgGk *= third;
+        Real det = sqrt(fabs(avgMk * avgMk - avgGk));
+        Real k1 = avgMk + det;
+        Real k2 = avgMk - det;
+        Real zone(0);
+        if (sqrt(k1 * k1 + k2 * k2) < pkzFF)
+          zone = 1; // FF
+        else {
+          if (k2 > half * k1)
+            zone = 2; // LP
+          if (fabs(k2 / k1) <= half)
+            zone = 3; // LE
+          if ((-2 * k1 < k2) && (k2 < -half * k1))
+            zone = 4; // SP
+          if (fabs(k1 / k2) <= half)
+            zone = 5; // TE
+          if (k1 < half * k2)
+            zone = 6; // TP
+        }
+        surfDer[iElt][iDer] = zone;
       }
     } // pkz
-    
   }
-  
+
   // write surface
   Print() << "Writing surface ..." << std::endl;
-  writeSurfaceTecplot(infile,
-		      nElts, eltArea,  eltVol,  surfLocs,
-		      nAvg,  avgComps, surfAvg,
-		      nInt,  intComps, surfInt,
-		      nDer,  derComps, surfDer);
+  writeSurfaceTecplot(
+    infile, nElts, eltArea, eltVol, surfLocs, nAvg, avgComps, surfAvg, nInt,
+    intComps, surfInt, nDer, derComps, surfDer);
   Print() << "   ... done" << std::endl;
 
   // write basic
   if (writeBasic) {
     Print() << "Writing basic file ..." << std::endl;
-    writeSurfaceBasic(infile,
-		      nElts, eltArea,  eltVol,  surfLocs,
-		      nAvg,  avgComps, surfAvg,
-		      nInt,  intComps, surfInt,
-		      nDer,  derComps, surfDer);
+    writeSurfaceBasic(
+      infile, nElts, eltArea, eltVol, surfLocs, nAvg, avgComps, surfAvg, nInt,
+      intComps, surfInt, nDer, derComps, surfDer);
     Print() << "   ... done" << std::endl;
   }
 
-  return(0);
+  return (0);
 }
-  
+
 //
 // break up the variable list
 //
-std::vector<std::string> parseVarNames(std::istream& is)
+std::vector<std::string>
+parseVarNames(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return amrex::Tokenize(line,std::string(" "));
+  std::string line;
+  std::getline(is, line);
+  return amrex::Tokenize(line, std::string(" "));
 }
 
 //
 // routine to read aja's binary stream files
 //
 
-void readStreamBin(std::string infile,
-		   int& nStreams, int& nElts, int& nPtsOnStream, int& nComps,
-		   std::vector<std::string>& variableNames,
-		   Vector<int>& faceData,
-		   Vector<Vector<Real>> &streamData)
+void
+readStreamBin(
+  std::string infile,
+  int& nStreams,
+  int& nElts,
+  int& nPtsOnStream,
+  int& nComps,
+  std::vector<std::string>& variableNames,
+  Vector<int>& faceData,
+  Vector<Vector<Real>>& streamData)
 {
   // Open header file
   std::string headerName = infile + "/Header";
   Print() << "Opening " << headerName << std::endl;
   std::ifstream ifs(headerName.c_str());
-  std::istream* is = (infile=="-" ? (std::istream*)(&std::cin) : (std::istream*)(&ifs) );
+  std::istream* is =
+    (infile == "-" ? (std::istream*)(&std::cin) : (std::istream*)(&ifs));
 
   // read dummy header line
   std::string dummy;
-  std::getline(ifs,dummy);
+  std::getline(ifs, dummy);
 
   // number of files to read
-  int nFiles(-1);  
+  int nFiles(-1);
   ifs >> nFiles;
   Print() << "nFiles = " << nFiles << std::endl;
 
@@ -422,23 +443,23 @@ void readStreamBin(std::string infile,
   Print() << "nComps = " << nComps << std::endl;
 
   // next line
-  std::getline(ifs,dummy);
+  std::getline(ifs, dummy);
 
   // read variable names
   variableNames.resize(nComps);
   variableNames = parseVarNames(*is);
-  if (nComps!=variableNames.size())
+  if (nComps != variableNames.size())
     Abort("nComps != variableNames.size()");
 
   // connectivity data
   int fds;
   ifs >> fds;
   Print() << "faceDataSize = " << fds << std::endl;
-  std::getline(ifs,dummy);
+  std::getline(ifs, dummy);
   faceData.resize(fds);
-  ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
+  ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
 
-  nElts = fds/3;
+  nElts = fds / 3;
   Print() << "nElts = " << nElts << std::endl;
 
   // close header
@@ -447,65 +468,69 @@ void readStreamBin(std::string infile,
   //
   // give the streams a home
   //
-  streamData.resize(nStreams+1);
-  for (int iStream=0; iStream<=nStreams; iStream++)
-    streamData[iStream].resize(nPtsOnStream*nComps);
-  
+  streamData.resize(nStreams + 1);
+  for (int iStream = 0; iStream <= nStreams; iStream++)
+    streamData[iStream].resize(nPtsOnStream * nComps);
+
   // keep fread happy
   size_t read_size;
 
   //
   // now loop over binary files
   //
-  for (int iFile=0; iFile<nFiles; iFile++) {
+  for (int iFile = 0; iFile < nFiles; iFile++) {
     // read binary stream file
     std::string rootName = infile + "/str_";
-    std::string fileName = Concatenate(rootName,iFile) + ".bin";
-    FILE *file=fopen(fileName.c_str(),"r");
+    std::string fileName = Concatenate(rootName, iFile) + ".bin";
+    FILE* file = fopen(fileName.c_str(), "r");
 
     int nFileStreams;
-    read_size = fread(&(nFileStreams),sizeof(int),1,file);
+    read_size = fread(&(nFileStreams), sizeof(int), 1, file);
 
     // loop over particle streams as written by pti (i.e. mangled order)
-    for (int pindex=0; pindex<nFileStreams; pindex++) {
+    for (int pindex = 0; pindex < nFileStreams; pindex++) {
       // use the particle id to load data into right memory destination
       int iStream;
-      read_size = fread(&(iStream),sizeof(int),1,file); // id
-      
-      for (int iComp=0; iComp<nComps; iComp++) {
-	// by loading into [iStream] index, we're unmangling the parrallel particles
-	int offset = iComp*nPtsOnStream;
-	read_size = fread(&(streamData[iStream][offset]),sizeof(Real),nPtsOnStream,file);
-      }      
+      read_size = fread(&(iStream), sizeof(int), 1, file); // id
+
+      for (int iComp = 0; iComp < nComps; iComp++) {
+        // by loading into [iStream] index, we're unmangling the parrallel
+        // particles
+        int offset = iComp * nPtsOnStream;
+        read_size = fread(
+          &(streamData[iStream][offset]), sizeof(Real), nPtsOnStream, file);
+      }
     }
-    
+
     fclose(file);
 
   } // iFiles
 
   Print() << "Finished reading stream data." << std::endl;
-  
 }
 
 //
 // write the stream data to matlab
 //
 void
-writeStreamsMatlab(std::string infile,
-		   int& nStreams, int& nPtsOnStream, int& nComps,
-		   std::vector<std::string>& variableNames,
-		   Vector<Vector<Real>>& streamData)
+writeStreamsMatlab(
+  std::string infile,
+  int& nStreams,
+  int& nPtsOnStream,
+  int& nComps,
+  std::vector<std::string>& variableNames,
+  Vector<Vector<Real>>& streamData)
 {
-  FILE *file;
+  FILE* file;
   std::string filename;
-  for (int iComp=0; iComp<nComps; iComp++) {
-    filename = infile+"/"+variableNames[iComp]+".dat";
-    file = fopen(filename.c_str(),"w");
-    for (int iStream=1; iStream<=nStreams; iStream++) {
-      for (int iPt=0; iPt<nPtsOnStream; iPt++) {
-	fprintf(file,"%e ",streamData[iStream][nPtsOnStream*iComp+iPt]);
+  for (int iComp = 0; iComp < nComps; iComp++) {
+    filename = infile + "/" + variableNames[iComp] + ".dat";
+    file = fopen(filename.c_str(), "w");
+    for (int iStream = 1; iStream <= nStreams; iStream++) {
+      for (int iPt = 0; iPt < nPtsOnStream; iPt++) {
+        fprintf(file, "%e ", streamData[iStream][nPtsOnStream * iComp + iPt]);
       }
-      fprintf(file,"\n");
+      fprintf(file, "\n");
     }
     fclose(file);
   }
@@ -516,44 +541,44 @@ writeStreamsMatlab(std::string infile,
 // write the stream data (midpoint surface) straight to a tecplot file
 //
 void
-writeSurfaceFromStreamTecplot(std::string infile,
-			      int& nStreams, int& nElts, int& nPtsOnStream, int& nComps,
-			      std::vector<std::string>& variableNames,
-			      Vector<int>& faceData,
-			      Vector<Vector<Real>>& streamData)
+writeSurfaceFromStreamTecplot(
+  std::string infile,
+  int& nStreams,
+  int& nElts,
+  int& nPtsOnStream,
+  int& nComps,
+  std::vector<std::string>& variableNames,
+  Vector<int>& faceData,
+  Vector<Vector<Real>>& streamData)
 {
-  std::string filename=infile+"_surfTec.dat";
+  std::string filename = infile + "_surfTec.dat";
 
-  std::ofstream os(filename.c_str(),std::ios::out);
+  std::ofstream os(filename.c_str(), std::ios::out);
 
   std::string vars("VARIABLES =");
-  for (int iComp=0; iComp<nComps; iComp++)
+  for (int iComp = 0; iComp < nComps; iComp++)
     vars += " " + variableNames[iComp];
   os << vars << std::endl;
 
-  os << "ZONE T=\"streamBinTubeSurface\""
-     << " N=" << nStreams
-     << " E=" << nElts
-     << " F=FEPOINT ET= TRIANGLE"
-     << std::endl;
+  os << "ZONE T=\"streamBinTubeSurface\"" << " N=" << nStreams << " E=" << nElts
+     << " F=FEPOINT ET= TRIANGLE" << std::endl;
 
-  int iPt=(nPtsOnStream-1)/2;
-  for (int iStream=1; iStream<=nStreams; iStream++) {
-    for (int iComp=0; iComp<nComps; iComp++) {
-      os << streamData[iStream][nPtsOnStream*iComp+iPt] << " ";
+  int iPt = (nPtsOnStream - 1) / 2;
+  for (int iStream = 1; iStream <= nStreams; iStream++) {
+    for (int iComp = 0; iComp < nComps; iComp++) {
+      os << streamData[iStream][nPtsOnStream * iComp + iPt] << " ";
     }
     os << std::endl;
   }
 
-  for (int iElt=0; iElt<nElts; iElt++) {
-    int offset=iElt*3;
-    os << faceData[offset] << " "
-       << faceData[offset+1] << " "
-       << faceData[offset+2] << std::endl;
+  for (int iElt = 0; iElt < nElts; iElt++) {
+    int offset = iElt * 3;
+    os << faceData[offset] << " " << faceData[offset + 1] << " "
+       << faceData[offset + 2] << std::endl;
   }
 
   os.close();
-  
+
   return;
 }
 
@@ -561,58 +586,64 @@ writeSurfaceFromStreamTecplot(std::string infile,
 // write all the surface quantities to a tecplot file
 //
 void
-writeSurfaceTecplot(std::string infile,
-		    int& nElts, Vector<Real>&        eltArea,  Vector<Real>&        eltVol,
-		    Vector<Vector<dim3>>& surfLocs,
-		    int& nAvg,  Vector<std::string>& avgComps, Vector<Vector<Real>>& surfAvg,
-		    int& nInt,  Vector<std::string>& intComps, Vector<Vector<Real>>& surfInt,
-		    int& nDer,  Vector<std::string>& derComps, Vector<Vector<Real>>& surfDer)
+writeSurfaceTecplot(
+  std::string infile,
+  int& nElts,
+  Vector<Real>& eltArea,
+  Vector<Real>& eltVol,
+  Vector<Vector<dim3>>& surfLocs,
+  int& nAvg,
+  Vector<std::string>& avgComps,
+  Vector<Vector<Real>>& surfAvg,
+  int& nInt,
+  Vector<std::string>& intComps,
+  Vector<Vector<Real>>& surfInt,
+  int& nDer,
+  Vector<std::string>& derComps,
+  Vector<Vector<Real>>& surfDer)
 {
-  std::string filename=infile+"_binVolInt.dat";
+  std::string filename = infile + "_binVolInt.dat";
 
-  std::ofstream os(filename.c_str(),std::ios::out);
+  std::ofstream os(filename.c_str(), std::ios::out);
 
   std::string vars("VARIABLES = X Y Z area volume");
-  for (int iAvg=0; iAvg<nAvg; iAvg++)
+  for (int iAvg = 0; iAvg < nAvg; iAvg++)
     vars += " " + avgComps[iAvg] + "_avg";
-  for (int iInt=0; iInt<nInt; iInt++)
+  for (int iInt = 0; iInt < nInt; iInt++)
     vars += " " + intComps[iInt] + "_volInt";
-  for (int iDer=0; iDer<nDer; iDer++)
+  for (int iDer = 0; iDer < nDer; iDer++)
     vars += " " + derComps[iDer];
   os << vars << std::endl;
 
-  os << "ZONE T=\"streamBinTubeSurface\""
-     << " N=" << nElts*AMREX_SPACEDIM
-     << " E=" << nElts
-     << " F=FEPOINT ET=TRIANGLE"
-     << std::endl;
+  os << "ZONE T=\"streamBinTubeSurface\"" << " N=" << nElts * AMREX_SPACEDIM
+     << " E=" << nElts << " F=FEPOINT ET=TRIANGLE" << std::endl;
 
   // write averages
   os << std::setprecision(12);
-  for (int iElt=0; iElt<nElts; iElt++) {
-    for (int iCorner=0; iCorner<AMREX_SPACEDIM; iCorner++) {
+  for (int iElt = 0; iElt < nElts; iElt++) {
+    for (int iCorner = 0; iCorner < AMREX_SPACEDIM; iCorner++) {
       // coordinate
-      for (int d=0; d<AMREX_SPACEDIM; d++)
-	os << surfLocs[iElt][iCorner][d] << " ";
+      for (int d = 0; d < AMREX_SPACEDIM; d++)
+        os << surfLocs[iElt][iCorner][d] << " ";
       // area
       os << eltArea[iElt] << " ";
       // volume
       os << eltVol[iElt] << " ";
       // averages
-      for (int iAvg=0; iAvg<nAvg; iAvg++)
-	os << surfAvg[iElt][iAvg] << " ";
+      for (int iAvg = 0; iAvg < nAvg; iAvg++)
+        os << surfAvg[iElt][iAvg] << " ";
       // integrals
-      for (int iInt=0; iInt<nInt; iInt++)
-	os << surfInt[iElt][iInt] << " ";
+      for (int iInt = 0; iInt < nInt; iInt++)
+        os << surfInt[iElt][iInt] << " ";
       // derived
-      for (int iDer=0; iDer<nDer; iDer++)
-	os << surfDer[iElt][iDer] << " ";
+      for (int iDer = 0; iDer < nDer; iDer++)
+        os << surfDer[iElt][iDer] << " ";
       os << std::endl;
     }
   }
 
   // write connectivity
-  for (int iElt=1; iElt<3*nElts;)
+  for (int iElt = 1; iElt < 3 * nElts;)
     os << iElt++ << " " << iElt++ << " " << iElt++ << std::endl;
 
   os.close();
@@ -622,37 +653,46 @@ writeSurfaceTecplot(std::string infile,
 // write all the surface quantities to a tecplot file
 //
 void
-writeSurfaceBasic(std::string infile,
-		  int& nElts, Vector<Real>&        eltArea,  Vector<Real>&        eltVol,
-		  Vector<Vector<dim3>>& surfLocs,
-		  int& nAvg,  Vector<std::string>& avgComps, Vector<Vector<Real>>& surfAvg,
-		  int& nInt,  Vector<std::string>& intComps, Vector<Vector<Real>>& surfInt,
-		  int& nDer,  Vector<std::string>& derComps, Vector<Vector<Real>>& surfDer)
+writeSurfaceBasic(
+  std::string infile,
+  int& nElts,
+  Vector<Real>& eltArea,
+  Vector<Real>& eltVol,
+  Vector<Vector<dim3>>& surfLocs,
+  int& nAvg,
+  Vector<std::string>& avgComps,
+  Vector<Vector<Real>>& surfAvg,
+  int& nInt,
+  Vector<std::string>& intComps,
+  Vector<Vector<Real>>& surfInt,
+  int& nDer,
+  Vector<std::string>& derComps,
+  Vector<Vector<Real>>& surfDer)
 {
-  std::string filename=infile+"_binVolInt.dat";
+  std::string filename = infile + "_binVolInt.dat";
 
-  std::ofstream os(filename.c_str(),std::ios::out);
+  std::ofstream os(filename.c_str(), std::ios::out);
 
   // write averages
   os << std::setprecision(12);
-  for (int iElt=0; iElt<nElts; iElt++) {
-    for (int iCorner=0; iCorner<AMREX_SPACEDIM; iCorner++) {
+  for (int iElt = 0; iElt < nElts; iElt++) {
+    for (int iCorner = 0; iCorner < AMREX_SPACEDIM; iCorner++) {
       // coordinate
-      for (int d=0; d<AMREX_SPACEDIM; d++)
-	os << surfLocs[iElt][iCorner][d] << " ";
+      for (int d = 0; d < AMREX_SPACEDIM; d++)
+        os << surfLocs[iElt][iCorner][d] << " ";
       // area
       os << eltArea[iElt] << " ";
       // volume
       os << eltVol[iElt] << " ";
       // averages
-      for (int iAvg=0; iAvg<nAvg; iAvg++)
-	os << surfAvg[iElt][iAvg] << " ";
+      for (int iAvg = 0; iAvg < nAvg; iAvg++)
+        os << surfAvg[iElt][iAvg] << " ";
       // integrals
-      for (int iInt=0; iInt<nInt; iInt++)
-	os << surfInt[iElt][iInt] << " ";
+      for (int iInt = 0; iInt < nInt; iInt++)
+        os << surfInt[iElt][iInt] << " ";
       // derived
-      for (int iDer=0; iDer<nDer; iDer++)
-	os << surfDer[iElt][iDer] << " ";
+      for (int iDer = 0; iDer < nDer; iDer++)
+        os << surfDer[iElt][iDer] << " ";
       os << std::endl;
     }
   }
@@ -664,27 +704,25 @@ writeSurfaceBasic(std::string infile,
 // area of the triangle
 //
 Real
-wedge_area(const dim3& A,
-	   const dim3& B,
-	   const dim3& C)
+wedge_area(const dim3& A, const dim3& B, const dim3& C)
 {
-  Real result;  
+  Real result;
   Real R1[3], R2[3], R3[3];
-  
-  for (int i=0; i<3; ++i) {
+
+  for (int i = 0; i < 3; ++i) {
     R1[i] = B[i] - A[i];
     R2[i] = C[i] - A[i];
   }
-  
-  R3[0] = R1[1]*R2[2] - R2[1]*R1[2];
-  R3[1] = R1[2]*R2[0] - R2[2]*R1[0];
-  R3[2] = R1[0]*R2[1] - R2[0]*R1[1];
 
-  result=0;
-  for (int i=0; i<3; ++i) {
-    result += R3[i]*R3[i];
+  R3[0] = R1[1] * R2[2] - R2[1] * R1[2];
+  R3[1] = R1[2] * R2[0] - R2[2] * R1[0];
+  R3[2] = R1[0] * R2[1] - R2[0] * R1[1];
+
+  result = 0;
+  for (int i = 0; i < 3; ++i) {
+    result += R3[i] * R3[i];
   }
-  result = half*std::sqrt(result);
+  result = half * std::sqrt(result);
 
   return result;
 }
@@ -695,44 +733,47 @@ wedge_area(const dim3& A,
 Real
 tetVol(const dim3& A, const dim3& B, const dim3& C, const dim3& D)
 {
-    Real R1[3], R2[3], R3[3], R4[3];
+  Real R1[3], R2[3], R3[3], R4[3];
 
-    for (int i=0; i<3; ++i)
-    {
-        R1[i] = D[i] - A[i];
-        R2[i] = B[i] - A[i];
-        R3[i] = C[i] - A[i];
-    }
+  for (int i = 0; i < 3; ++i) {
+    R1[i] = D[i] - A[i];
+    R2[i] = B[i] - A[i];
+    R3[i] = C[i] - A[i];
+  }
 
-    for (int i=0; i<3; ++i)
-    {
-        R4[0] = R2[1]*R3[2] - R3[1]*R2[2];
-        R4[1] = R2[2]*R3[0] - R3[2]*R2[0];
-        R4[2] = R2[0]*R3[1] - R3[0]*R2[1];
-    }
-    
-    Real res=0;
-    for (int i=0; i<3; ++i)
-        res += R1[i]*R4[i];
+  for (int i = 0; i < 3; ++i) {
+    R4[0] = R2[1] * R3[2] - R3[1] * R2[2];
+    R4[1] = R2[2] * R3[0] - R3[2] * R2[0];
+    R4[2] = R2[0] * R3[1] - R3[0] * R2[1];
+  }
 
-    return std::abs(res*sixth);
+  Real res = 0;
+  for (int i = 0; i < 3; ++i)
+    res += R1[i] * R4[i];
+
+  return std::abs(res * sixth);
 }
 
 //
 // volume of the irregular triangular prism
 //
 Real
-wedge_volume(const dim3& A, const dim3& B, const dim3& C,
-	     const dim3& D, const dim3& E, const dim3& F)
+wedge_volume(
+  const dim3& A,
+  const dim3& B,
+  const dim3& C,
+  const dim3& D,
+  const dim3& E,
+  const dim3& F)
 {
   Real result;
-  
-  const Real vol_EABC = tetVol(A,B,C,E);
-  const Real vol_ADEF = tetVol(A,D,E,F);
-  const Real vol_ACEF = tetVol(C,E,F,A);
-  
+
+  const Real vol_EABC = tetVol(A, B, C, E);
+  const Real vol_ADEF = tetVol(A, D, E, F);
+  const Real vol_ACEF = tetVol(C, E, F, A);
+
   result = (vol_EABC + vol_ADEF + vol_ACEF);
-  
+
   return result;
 }
 
@@ -740,54 +781,66 @@ wedge_volume(const dim3& A, const dim3& B, const dim3& C,
 // integral over the irregular triangular prism
 //
 Real
-wedge_volume_int(const dim3& A, const Real vA,
-		 const dim3& B, const Real vB,
-		 const dim3& C, const Real vC,
-		 const dim3& D, const Real vD,
-		 const dim3& E, const Real vE,
-		 const dim3& F, const Real vF)
+wedge_volume_int(
+  const dim3& A,
+  const Real vA,
+  const dim3& B,
+  const Real vB,
+  const dim3& C,
+  const Real vC,
+  const dim3& D,
+  const Real vD,
+  const dim3& E,
+  const Real vE,
+  const dim3& F,
+  const Real vF)
 {
   Real result;
 
-  const Real vol_EABC = tetVol(A,B,C,E);
-  const Real vol_ADEF = tetVol(A,D,E,F);
-  const Real vol_ACEF = tetVol(C,E,F,A);
-  const Real vol_DABC = tetVol(A,B,C,D);
-  const Real vol_FABC = tetVol(A,B,C,F);
-  const Real vol_BDEF = tetVol(B,D,E,F);
-  const Real vol_CDEF = tetVol(C,D,E,F);
-  const Real vol_ACED = tetVol(C,E,D,A);
-  const Real vol_BCDF = tetVol(B,C,D,F);
-  const Real vol_BCDE = tetVol(B,C,D,E);
-  const Real vol_ABDF = tetVol(B,D,F,A);
-  const Real vol_ABEF = tetVol(B,E,F,A);
-  
-  const Real int_1 = ( (vD+vA+vB+vC)*vol_DABC + 
-		       (vB+vD+vE+vF)*vol_BDEF + 
-		       (vB+vC+vD+vF)*vol_BCDF )*quarter;
-  
-  const Real int_2 = ( (vD+vA+vB+vC)*vol_DABC + 
-		       (vC+vD+vE+vF)*vol_CDEF + 
-		       (vB+vC+vD+vE)*vol_BCDE )*quarter;
-  
-  const Real int_3 = ( (vE+vA+vB+vC)*vol_EABC + 
-		       (vA+vD+vE+vF)*vol_ADEF + 
-		       (vA+vC+vE+vF)*vol_ACEF )*quarter;
-  
-  const Real int_4 = ( (vE+vA+vB+vC)*vol_EABC + 
-		       (vC+vD+vE+vF)*vol_CDEF + 
-		       (vA+vC+vE+vD)*vol_ACED )*quarter;
-  
-  const Real int_5 = ( (vF+vA+vB+vC)*vol_FABC + 
-		       (vA+vD+vE+vF)*vol_ADEF + 
-		       (vA+vB+vE+vF)*vol_ABEF )*quarter;
-  
-  const Real int_6 = ( (vF+vA+vB+vC)*vol_FABC + 
-		       (vB+vD+vE+vF)*vol_BDEF + 
-		       (vA+vB+vD+vF)*vol_ABDF )*quarter;
-  
-  result = (int_1 + int_2 + int_3 + int_4 + int_5 + int_6)*sixth;
-  
+  const Real vol_EABC = tetVol(A, B, C, E);
+  const Real vol_ADEF = tetVol(A, D, E, F);
+  const Real vol_ACEF = tetVol(C, E, F, A);
+  const Real vol_DABC = tetVol(A, B, C, D);
+  const Real vol_FABC = tetVol(A, B, C, F);
+  const Real vol_BDEF = tetVol(B, D, E, F);
+  const Real vol_CDEF = tetVol(C, D, E, F);
+  const Real vol_ACED = tetVol(C, E, D, A);
+  const Real vol_BCDF = tetVol(B, C, D, F);
+  const Real vol_BCDE = tetVol(B, C, D, E);
+  const Real vol_ABDF = tetVol(B, D, F, A);
+  const Real vol_ABEF = tetVol(B, E, F, A);
+
+  const Real int_1 =
+    ((vD + vA + vB + vC) * vol_DABC + (vB + vD + vE + vF) * vol_BDEF +
+     (vB + vC + vD + vF) * vol_BCDF) *
+    quarter;
+
+  const Real int_2 =
+    ((vD + vA + vB + vC) * vol_DABC + (vC + vD + vE + vF) * vol_CDEF +
+     (vB + vC + vD + vE) * vol_BCDE) *
+    quarter;
+
+  const Real int_3 =
+    ((vE + vA + vB + vC) * vol_EABC + (vA + vD + vE + vF) * vol_ADEF +
+     (vA + vC + vE + vF) * vol_ACEF) *
+    quarter;
+
+  const Real int_4 =
+    ((vE + vA + vB + vC) * vol_EABC + (vC + vD + vE + vF) * vol_CDEF +
+     (vA + vC + vE + vD) * vol_ACED) *
+    quarter;
+
+  const Real int_5 =
+    ((vF + vA + vB + vC) * vol_FABC + (vA + vD + vE + vF) * vol_ADEF +
+     (vA + vB + vE + vF) * vol_ABEF) *
+    quarter;
+
+  const Real int_6 =
+    ((vF + vA + vB + vC) * vol_FABC + (vB + vD + vE + vF) * vol_BDEF +
+     (vA + vB + vD + vF) * vol_ABDF) *
+    quarter;
+
+  result = (int_1 + int_2 + int_3 + int_4 + int_5 + int_6) * sixth;
+
   return result;
 }
-

--- a/Src/subPlt.cpp
+++ b/Src/subPlt.cpp
@@ -4,46 +4,45 @@
 #include "AMReX_Utility.H"
 #include "AMReX_WritePlotFile.H"
 
+using std::cerr;
 using std::cout;
 using std::endl;
-using std::cerr;
 using namespace amrex;
 
-const bool verbose_DEF   = false;
+const bool verbose_DEF = false;
 
-static
-void
-PrintUsage (const char* progName)
+static void
+PrintUsage(const char* progName)
 {
-    cout << '\n';
-    cout << "Usage:" << '\n';
-    cout << progName << '\n';
-    cout << "    infile=inFileName" << '\n';
-    cout << "   [outfile=outFileName <defaults to <inFileName>_section>]" << '\n';
-    cout << "   [-sComp=N <defaults to 0, unless \"comps\" used]" << '\n';
-    cout << "   [-nComp=N <defaults to all in <inFileName>, unless comps used]" << '\n';
-    cout << "   [-comps=\"N1 N2 N3...\"]" << '\n';
-    cout << "   [-help]" << '\n';
-    cout << "   [-verbose]" << '\n';
-    cout << '\n';
-    exit(1);
+  cout << '\n';
+  cout << "Usage:" << '\n';
+  cout << progName << '\n';
+  cout << "    infile=inFileName" << '\n';
+  cout << "   [outfile=outFileName <defaults to <inFileName>_section>]" << '\n';
+  cout << "   [-sComp=N <defaults to 0, unless \"comps\" used]" << '\n';
+  cout << "   [-nComp=N <defaults to all in <inFileName>, unless comps used]"
+       << '\n';
+  cout << "   [-comps=\"N1 N2 N3...\"]" << '\n';
+  cout << "   [-help]" << '\n';
+  cout << "   [-verbose]" << '\n';
+  cout << '\n';
+  exit(1);
 }
 
-static Vector< Vector<int> > contigLists(const Vector<int> orig);
+static Vector<Vector<int>> contigLists(const Vector<int> orig);
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    if (argc == 1)
-        PrintUsage(argv[0]);
+  if (argc == 1)
+    PrintUsage(argv[0]);
 
-    Initialize(argc,argv);    
-    {
+  Initialize(argc, argv);
+  {
     ParmParse pp;
 
     if (pp.contains("help"))
-        PrintUsage(argv[0]);
+      PrintUsage(argv[0]);
 
     FArrayBox::setFormat(FABio::FAB_IEEE_32);
     //
@@ -54,136 +53,130 @@ main (int   argc,
     bool verbose = verbose_DEF;
     verbose = (pp.contains("verbose") ? true : false);
     if (verbose)
-        AmrData::SetVerbose(true);
+      AmrData::SetVerbose(true);
 
-    pp.get("infile",infile);
+    pp.get("infile", infile);
 
-    std::vector<std::string> pieces = Tokenize(infile,std::string("/"));
-    std::string outfile = pieces[pieces.size()-1] + std::string("_section");
-    pp.query("outfile",outfile);
+    std::vector<std::string> pieces = Tokenize(infile, std::string("/"));
+    std::string outfile = pieces[pieces.size() - 1] + std::string("_section");
+    pp.query("outfile", outfile);
 
     // Read in pltfile and get amrData ref
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(infile, fileType);
     if (!dataServices.AmrDataOk())
-        DataServices::Dispatch(DataServices::ExitRequest, NULL);
+      DataServices::Dispatch(DataServices::ExitRequest, NULL);
     AmrData& amrData = dataServices.AmrDataRef();
 
     Vector<int> comps;
-    if (int nc = pp.countval("comps"))
-    {
-        comps.resize(nc);
-        pp.getarr("comps",comps,0,nc);
-    }
-    else
-    {
-        int sComp = 0;
-        pp.query("sComp",sComp);
-        int nComp = amrData.NComp();
-        pp.query("nComp",nComp);
-        AMREX_ASSERT(sComp+nComp <= amrData.NComp());
-        comps.resize(nComp);
-        for (int i=0; i<nComp; ++i)
-            comps[i] = sComp + i;
+    if (int nc = pp.countval("comps")) {
+      comps.resize(nc);
+      pp.getarr("comps", comps, 0, nc);
+    } else {
+      int sComp = 0;
+      pp.query("sComp", sComp);
+      int nComp = amrData.NComp();
+      pp.query("nComp", nComp);
+      AMREX_ASSERT(sComp + nComp <= amrData.NComp());
+      comps.resize(nComp);
+      for (int i = 0; i < nComp; ++i)
+        comps[i] = sComp + i;
     }
 
-    Vector< Vector<int> > compsNEW = contigLists(comps);
-    int finestLevel = amrData.FinestLevel(); pp.query("finestLevel",finestLevel);
-    AMREX_ALWAYS_ASSERT(finestLevel >= 0 && finestLevel<=amrData.FinestLevel());
+    Vector<Vector<int>> compsNEW = contigLists(comps);
+    int finestLevel = amrData.FinestLevel();
+    pp.query("finestLevel", finestLevel);
+    AMREX_ALWAYS_ASSERT(
+      finestLevel >= 0 && finestLevel <= amrData.FinestLevel());
     Box subbox = amrData.ProbDomain()[finestLevel];
     Vector<int> inBox;
 
-    if (int nx=pp.countval("box"))
-    {
-        pp.getarr("box",inBox,0,nx);
-        int d=AMREX_SPACEDIM;
-        AMREX_ASSERT(inBox.size()==2*d);
-        subbox=Box(IntVect(AMREX_D_DECL(inBox[0],inBox[1],inBox[2])),
-                   IntVect(AMREX_D_DECL(inBox[d],inBox[d+1],inBox[d+2])),
-                   IndexType::TheCellType());
+    if (int nx = pp.countval("box")) {
+      pp.getarr("box", inBox, 0, nx);
+      int d = AMREX_SPACEDIM;
+      AMREX_ASSERT(inBox.size() == 2 * d);
+      subbox = Box(
+        IntVect(AMREX_D_DECL(inBox[0], inBox[1], inBox[2])),
+        IntVect(AMREX_D_DECL(inBox[d], inBox[d + 1], inBox[d + 2])),
+        IndexType::TheCellType());
     }
 
-    Vector<Box> subboxes(finestLevel+1,subbox);
-    for (int iLevel = finestLevel-1; iLevel>=0; --iLevel)
-        subboxes[iLevel] = coarsen(subboxes[iLevel+1],amrData.RefRatio()[iLevel]);
-    for (int iLevel = 1; iLevel<=finestLevel; ++iLevel)
-        subboxes[iLevel] = refine(subboxes[iLevel-1],amrData.RefRatio()[iLevel-1]);
+    Vector<Box> subboxes(finestLevel + 1, subbox);
+    for (int iLevel = finestLevel - 1; iLevel >= 0; --iLevel)
+      subboxes[iLevel] =
+        coarsen(subboxes[iLevel + 1], amrData.RefRatio()[iLevel]);
+    for (int iLevel = 1; iLevel <= finestLevel; ++iLevel)
+      subboxes[iLevel] =
+        refine(subboxes[iLevel - 1], amrData.RefRatio()[iLevel - 1]);
 
-    Vector<MultiFab*> data_sub(finestLevel+1);
+    Vector<MultiFab*> data_sub(finestLevel + 1);
     Vector<std::string> names(comps.size());
     Vector<std::string> subNames;
     Vector<int> fillComps;
-   
+
     Vector<Real> plo(AMREX_SPACEDIM), phi(AMREX_SPACEDIM);
-    Vector<Box> psize(finestLevel+1);
+    Vector<Box> psize(finestLevel + 1);
     const IntVect ilo = subbox.smallEnd();
     const IntVect ihi = subbox.bigEnd();
 
-   for (int i =0 ; i< AMREX_SPACEDIM; i++) {
-       
-       plo[i] = amrData.ProbLo()[i]+(ilo[i])*amrData.DxLevel()[finestLevel][i];
-       phi[i] = amrData.ProbLo()[i]+(ihi[i]+1)*amrData.DxLevel()[finestLevel][i];
-       
-     }
-        
+    for (int i = 0; i < AMREX_SPACEDIM; i++) {
+
+      plo[i] =
+        amrData.ProbLo()[i] + (ilo[i]) * amrData.DxLevel()[finestLevel][i];
+      phi[i] =
+        amrData.ProbLo()[i] + (ihi[i] + 1) * amrData.DxLevel()[finestLevel][i];
+    }
+
     int actual_lev = -1;
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-    {
-        // Build the BoxArray for the result
-        BoxArray ba_sub = intersect(amrData.boxArray(iLevel),subboxes[iLevel]);
+    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel) {
+      // Build the BoxArray for the result
+      BoxArray ba_sub = intersect(amrData.boxArray(iLevel), subboxes[iLevel]);
 
-        if (ba_sub.size() > 0)
-        {
-            actual_lev = iLevel;
-            DistributionMapping dmap_sub(ba_sub);
-            data_sub[iLevel] = new MultiFab(ba_sub,dmap_sub,comps.size(),0);
+      if (ba_sub.size() > 0) {
+        actual_lev = iLevel;
+        DistributionMapping dmap_sub(ba_sub);
+        data_sub[iLevel] = new MultiFab(ba_sub, dmap_sub, comps.size(), 0);
 
-            for (int i=0; i<comps.size(); ++i)
-            {
-                data_sub[iLevel]->ParallelCopy(amrData.GetGrids(iLevel,comps[i],subboxes[iLevel]),0,i,1);
-                amrData.FlushGrids(comps[i]);                
-                names[i] = amrData.PlotVarNames()[comps[i]];
-                
-                if (ParallelDescriptor::IOProcessor()) 
-                    cout << "Filling " << names[i] << " on level " << iLevel << endl;
-                
-            }
+        for (int i = 0; i < comps.size(); ++i) {
+          data_sub[iLevel]->ParallelCopy(
+            amrData.GetGrids(iLevel, comps[i], subboxes[iLevel]), 0, i, 1);
+          amrData.FlushGrids(comps[i]);
+          names[i] = amrData.PlotVarNames()[comps[i]];
+
+          if (ParallelDescriptor::IOProcessor())
+            cout << "Filling " << names[i] << " on level " << iLevel << endl;
         }
+      }
     }
 
     // Write out the subregion pltfile
-    WritePlotFile(data_sub,subboxes,amrData,outfile,verbose,names);
-    }
-    Finalize();
-    return 0;
+    WritePlotFile(data_sub, subboxes, amrData, outfile, verbose, names);
+  }
+  Finalize();
+  return 0;
 }
 
-static Vector< Vector<int> > contigLists(const Vector<int> orig)
+static Vector<Vector<int>>
+contigLists(const Vector<int> orig)
 {
-    AMREX_ASSERT(orig.size() > 0);
-    Vector< Vector<int> > res(1);
-    int mySet = 0;
-    res[mySet].resize(1);
-    int myCnt = 0;
-    res[mySet][myCnt] = orig[0];
+  AMREX_ASSERT(orig.size() > 0);
+  Vector<Vector<int>> res(1);
+  int mySet = 0;
+  res[mySet].resize(1);
+  int myCnt = 0;
+  res[mySet][myCnt] = orig[0];
 
-    for (int i=1; i<orig.size(); ++i)
-    {
-        if (res[mySet][myCnt]+1 == orig[i])
-        {
-            res[mySet].resize(++myCnt + 1);
-            res[mySet][myCnt] = orig[i];
-        }
-        else
-        {
-            myCnt = 0;
-            res.resize(++mySet+1);
-            res[mySet].resize(1);
-            res[mySet][myCnt] = orig[i];
-        }
+  for (int i = 1; i < orig.size(); ++i) {
+    if (res[mySet][myCnt] + 1 == orig[i]) {
+      res[mySet].resize(++myCnt + 1);
+      res[mySet][myCnt] = orig[i];
+    } else {
+      myCnt = 0;
+      res.resize(++mySet + 1);
+      res[mySet].resize(1);
+      res[mySet][myCnt] = orig[i];
     }
-    return res;
+  }
+  return res;
 }
-
-

--- a/Src/surfDATtoMEF.cpp
+++ b/Src/surfDATtoMEF.cpp
@@ -4,355 +4,342 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_Utility.H>
-using std::string;
+using std::cerr;
 using std::cout;
 using std::endl;
-using std::cerr;
 using std::map;
+using std::string;
 using std::vector;
 using namespace amrex;
 
 #define SIZET int
 
-static 
-bool isNumberLine(const std::string& line)
+static bool
+isNumberLine(const std::string& line)
 {
-    int i=0;
-    while (i<line.size() && isspace(line[i]))
-        i++;
-    if (i==line.size()-1)
-        return false;
-    else if (line[i]=='-' || line[i]=='.')
-        i++;
+  int i = 0;
+  while (i < line.size() && isspace(line[i]))
+    i++;
+  if (i == line.size() - 1)
+    return false;
+  else if (line[i] == '-' || line[i] == '.')
+    i++;
 
-    if (i==line.size()-1)
-        return false;
+  if (i == line.size() - 1)
+    return false;
 
-    return isdigit(line[i]) != 0;
+  return isdigit(line[i]) != 0;
 }
 
 Vector<string>
 GetVarNames(std::istream& is, string& currentLine)
 {
-    std::getline(is,currentLine);
-    vector<string> tokens;
-    string buf;
-    bool foundZone = false;
-    while (!foundZone)
-    {
-        std::getline(is,buf);
-        tokens = Tokenize(buf,"= ,");
-        if (tokens[0]=="ZONE")
-            foundZone = true;
-        else
-            currentLine += string(" ") + buf;
-    }
-    tokens = Tokenize(currentLine," =");
+  std::getline(is, currentLine);
+  vector<string> tokens;
+  string buf;
+  bool foundZone = false;
+  while (!foundZone) {
+    std::getline(is, buf);
+    tokens = Tokenize(buf, "= ,");
+    if (tokens[0] == "ZONE")
+      foundZone = true;
+    else
+      currentLine += string(" ") + buf;
+  }
+  tokens = Tokenize(currentLine, " =");
 
-    Vector<std::string> names;
-    for (int i=0; i<tokens.size(); ++i)
-    {
-        if (tokens[i] == "VARIABLES")
-        {
-            int nComp = tokens.size()-i-1;
-            names.resize(nComp);
-            for (int j=0; j<nComp; ++j)
-            {
-                names[j] = tokens[i+1+j];
-            }
-        }
+  Vector<std::string> names;
+  for (int i = 0; i < tokens.size(); ++i) {
+    if (tokens[i] == "VARIABLES") {
+      int nComp = tokens.size() - i - 1;
+      names.resize(nComp);
+      for (int j = 0; j < nComp; ++j) {
+        names[j] = tokens[i + 1 + j];
+      }
     }
-    currentLine = buf;
-    return names;
+  }
+  currentLine = buf;
+  return names;
 }
 
-map<std::string,std::string>
+map<std::string, std::string>
 GetZoneParams(std::istream& is, int nComp, string& currentLine)
 {
-    map<std::string,std::string> zoneParams; // The result
+  map<std::string, std::string> zoneParams; // The result
 
-    string txtLine = currentLine;
-    bool foundData = false;
-    while (!foundData)
-    {
-        std::getline(is,currentLine);
+  string txtLine = currentLine;
+  bool foundData = false;
+  while (!foundData) {
+    std::getline(is, currentLine);
 
-        if (!is)
-            return zoneParams;
+    if (!is)
+      return zoneParams;
 
-        if (isNumberLine(currentLine))
-            foundData = true;
-        else
-            txtLine = txtLine + string(" ") + currentLine;
-    }
-    
-    vector<string> tokens = Tokenize(txtLine,"\"");
-
-    if (tokens.size()>1)
-    {
-        for (int i=0; i<tokens.size(); i=i+2)
-        {
-            if (i+2<=tokens.size())
-            {
-                vector<std::string> subTokens=Tokenize(tokens[i],", ");
-
-                vector<std::string> tmp = Tokenize(subTokens[subTokens.size()-1],"=");
-                
-                string key = tmp[tmp.size()-1]; // key associated with this string parameter
-                
-                zoneParams[key] = "\"" + tokens[i+1] + "\"";
-            }
-        
-            vector<std::string> subTokens=Tokenize(tokens[i],", =");
-            int jst = (i==0 ? 1 : 0);
-            for (int j=jst; j<subTokens.size()-1; j=j+2)
-            {
-                string key = subTokens[j];
-
-                if (key=="DT")
-                {
-                    string tmpBuf;
-                    for (int jj=1; jj<nComp+1; ++jj)
-                        tmpBuf += subTokens[j+jj] + " ";
-                    int nSkip = nComp;
-                    if (subTokens[j+nComp+1] == ")")
-                    {
-                        nSkip++;
-                        tmpBuf += ")";
-                    }
-                    zoneParams[key] = tmpBuf;
-                    j = j+nComp;
-                }
-                else
-                    zoneParams[key] = subTokens[j+1];
-            }
-        }
-    }
+    if (isNumberLine(currentLine))
+      foundData = true;
     else
-    {
-        tokens = Tokenize(txtLine,", =");
-        for (int i=1; i<tokens.size()-1; i=i+2)  // Skip the ZONE word
-        {
-            string key = tokens[i];
-            if (key=="DT")
-            {
-                std::string dataTypeTokens=Tokenize(tokens[i+1],"()")[1];
-                i = i+nComp;
-            }
-            else
-                zoneParams[tokens[i]] = tokens[i+1];
-        }
+      txtLine = txtLine + string(" ") + currentLine;
+  }
+
+  vector<string> tokens = Tokenize(txtLine, "\"");
+
+  if (tokens.size() > 1) {
+    for (int i = 0; i < tokens.size(); i = i + 2) {
+      if (i + 2 <= tokens.size()) {
+        vector<std::string> subTokens = Tokenize(tokens[i], ", ");
+
+        vector<std::string> tmp =
+          Tokenize(subTokens[subTokens.size() - 1], "=");
+
+        string key =
+          tmp[tmp.size() - 1]; // key associated with this string parameter
+
+        zoneParams[key] = "\"" + tokens[i + 1] + "\"";
+      }
+
+      vector<std::string> subTokens = Tokenize(tokens[i], ", =");
+      int jst = (i == 0 ? 1 : 0);
+      for (int j = jst; j < subTokens.size() - 1; j = j + 2) {
+        string key = subTokens[j];
+
+        if (key == "DT") {
+          string tmpBuf;
+          for (int jj = 1; jj < nComp + 1; ++jj)
+            tmpBuf += subTokens[j + jj] + " ";
+          int nSkip = nComp;
+          if (subTokens[j + nComp + 1] == ")") {
+            nSkip++;
+            tmpBuf += ")";
+          }
+          zoneParams[key] = tmpBuf;
+          j = j + nComp;
+        } else
+          zoneParams[key] = subTokens[j + 1];
+      }
     }
-    return zoneParams;
+  } else {
+    tokens = Tokenize(txtLine, ", =");
+    for (int i = 1; i < tokens.size() - 1; i = i + 2) // Skip the ZONE word
+    {
+      string key = tokens[i];
+      if (key == "DT") {
+        std::string dataTypeTokens = Tokenize(tokens[i + 1], "()")[1];
+        i = i + nComp;
+      } else
+        zoneParams[tokens[i]] = tokens[i + 1];
+    }
+  }
+  return zoneParams;
 }
 
-static
-Real triangleArea(const Vector<Real>& p0,
-                  const Vector<Real>& p1,
-                  const Vector<Real>& p2)
+static Real
+triangleArea(
+  const Vector<Real>& p0, const Vector<Real>& p1, const Vector<Real>& p2)
 {
-    // Note: assumes (x,y,z) are first 3 components
-    return 0.5*sqrt(
-        pow(  ( p1[1] - p0[1])*(p2[2]-p0[2]) 
-              -(p1[2] - p0[2])*(p2[1]-p0[1]), 2)
-                                            
-        + pow(( p1[2] - p0[2])*(p2[0]-p0[0]) 
-              -(p1[0] - p0[0])*(p2[2]-p0[2]), 2)
-                                            
-        + pow(( p1[0] - p0[0])*(p2[1]-p0[1]) 
-              -(p1[1] - p0[1])*(p2[0]-p0[0]), 2));
+  // Note: assumes (x,y,z) are first 3 components
+  return 0.5 * sqrt(
+                 pow(
+                   (p1[1] - p0[1]) * (p2[2] - p0[2]) -
+                     (p1[2] - p0[2]) * (p2[1] - p0[1]),
+                   2)
+
+                 + pow(
+                     (p1[2] - p0[2]) * (p2[0] - p0[0]) -
+                       (p1[0] - p0[0]) * (p2[2] - p0[2]),
+                     2)
+
+                 + pow(
+                     (p1[0] - p0[0]) * (p2[1] - p0[1]) -
+                       (p1[1] - p0[1]) * (p2[0] - p0[0]),
+                     2));
 }
 
 class FABdata
 {
 public:
-    FABdata(SIZET i, SIZET n)
-        {fab.resize(Box(IntVect::TheZeroVector(),
-                        IntVect(AMREX_D_DECL(i-1,0,0))),n);}
-    Real& operator[](SIZET i) {return fab.dataPtr()[i];}
-    FArrayBox fab;
-    SIZET boxSize;
+  FABdata(SIZET i, SIZET n)
+  {
+    fab.resize(
+      Box(IntVect::TheZeroVector(), IntVect(AMREX_D_DECL(i - 1, 0, 0))), n);
+  }
+  Real& operator[](SIZET i) { return fab.dataPtr()[i]; }
+  FArrayBox fab;
+  SIZET boxSize;
 };
 
-void
-writeBin(const Vector<string>&         names,
-         const Vector<Vector<Real> >&  nodeVec,
-         const Vector<Vector<SIZET> >& eltVec,
-         const std::string&            outfile,
-         const std::string&            label);
+void writeBin(
+  const Vector<string>& names,
+  const Vector<Vector<Real>>& nodeVec,
+  const Vector<Vector<SIZET>>& eltVec,
+  const std::string& outfile,
+  const std::string& label);
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    Initialize(argc,argv);
+  Initialize(argc, argv);
 
-    ParmParse pp;
+  ParmParse pp;
 
-    std::string infile; pp.get("infile",infile);
+  std::string infile;
+  pp.get("infile", infile);
 
-    // Build outfile name (may modify below if more than one dataset)
-    vector<string> infileTokens = Tokenize(infile,".");
-    string outfile;
-    outfile = infileTokens[0];
-    for (int i=1; i<infileTokens.size()-1; ++i)
-        outfile += string(".") + infileTokens[i];
-    outfile += ".mef";
-    pp.query("outfile",outfile);
+  // Build outfile name (may modify below if more than one dataset)
+  vector<string> infileTokens = Tokenize(infile, ".");
+  string outfile;
+  outfile = infileTokens[0];
+  for (int i = 1; i < infileTokens.size() - 1; ++i)
+    outfile += string(".") + infileTokens[i];
+  outfile += ".mef";
+  pp.query("outfile", outfile);
 
-    std::ifstream ifs;
-    ifs.open(infile.c_str());
-    string buf;
+  std::ifstream ifs;
+  ifs.open(infile.c_str());
+  string buf;
 
-    //Read first zone info
-    Vector<string> names = GetVarNames(ifs,buf);
-    int nComp = names.size();
+  // Read first zone info
+  Vector<string> names = GetVarNames(ifs, buf);
+  int nComp = names.size();
 
-    map<std::string,std::string> zoneParams = GetZoneParams(ifs,nComp,buf);
+  map<std::string, std::string> zoneParams = GetZoneParams(ifs, nComp, buf);
 
-    Real areaEps = 1.e-12; pp.query("areaEps",areaEps);
+  Real areaEps = 1.e-12;
+  pp.query("areaEps", areaEps);
 
-    int zoneID = 0;
-    while (zoneParams.size() > 0)
-    {
-        // Find N and E in zone parameters
-        SIZET N,E;
-        string eltType("undefined");
-        string label("LabelHere");
-        
-        for (std::map<std::string,std::string>::const_iterator it=zoneParams.begin(); it!=zoneParams.end(); ++it)
-        {
-            if (it->first == "N")
-                N = atoi(it->second.c_str());
-            
-            if (it->first == "E")
-                E = atoi(it->second.c_str());
-            
-            if (it->first == "ET")
-                eltType = it->second.c_str();
+  int zoneID = 0;
+  while (zoneParams.size() > 0) {
+    // Find N and E in zone parameters
+    SIZET N, E;
+    string eltType("undefined");
+    string label("LabelHere");
 
-            if (it->first == "T")
-                label = it->second.c_str();
-        }
+    for (std::map<std::string, std::string>::const_iterator it =
+           zoneParams.begin();
+         it != zoneParams.end(); ++it) {
+      if (it->first == "N")
+        N = atoi(it->second.c_str());
 
-        if (ParallelDescriptor::IOProcessor())
-            cerr << "From " << infile << ": " << N << " nodes and " << E << " elements with "
-                 << nComp << " unknowns per node.  Dataset labelled: " << label << endl;
-        
-        Vector<Vector<Real> > nodeVec(N);
-        vector<string> tokens;
-        for (SIZET j=0; j<N; ++j)
-        {
-            Vector<Real>& v = nodeVec[j];
-            v.resize(nComp);
-            tokens = Tokenize(buf,", ");
-            AMREX_ASSERT(tokens.size()==nComp);
-            for (int k=0; k<nComp; ++k)
-            {
-                v[k] = atof(tokens[k].c_str());
-            }
-            std::getline(ifs,buf);
-        }
-        
-        int nodesPerElt = -1;
-        if (eltType == "TRIANGLE")
-            nodesPerElt = 3;
-        
-        Vector<Vector<SIZET> > eltVec(E);
-        for (SIZET j=0; j<E; ++j)
-        {
-            Vector<SIZET>& e = eltVec[j];
-            tokens = Tokenize(buf,", ");
-            AMREX_ASSERT(tokens.size()==nodesPerElt);
-            e.resize(nodesPerElt);
-            for (int k=0; k<nodesPerElt; ++k)
-                e[k] = atoi(tokens[k].c_str());
-            std::getline(ifs,buf);
-        }
+      if (it->first == "E")
+        E = atoi(it->second.c_str());
 
-        if (ParallelDescriptor::IOProcessor())
-            cerr << "...finished reading data" << endl;
+      if (it->first == "ET")
+        eltType = it->second.c_str();
 
-        Real area = 0;
-        map<Vector<int>,Real > bins;
-        for (int i=0; i<E; ++i)
-        {
-            const Vector<SIZET>& elt = eltVec[i];
-            const Vector<Real>& A = nodeVec[elt[0]-1];
-            const Vector<Real>& B = nodeVec[elt[1]-1];
-            const Vector<Real>& C = nodeVec[elt[2]-1];
-                        
-            area += triangleArea(A,B,C);
-        }
-
-        std::cout << "zoneID, area = " << zoneID << ", " << area << std::endl;
-
-        string binout = outfile;
-        if (zoneID>0)
-        {
-            char buf1[72];
-            sprintf(buf1, "%d", zoneID); 
-            binout = infileTokens[0];
-            for (int i=1; i<infileTokens.size()-1; ++i)
-                outfile += string(".") + infileTokens[i];
-            binout += string("_") + string(buf1) + ".mef";
-        }
-
-        writeBin(names,nodeVec,eltVec,binout,label);
-
-        zoneID++;
-        zoneParams = GetZoneParams(ifs,nComp,buf);
-
+      if (it->first == "T")
+        label = it->second.c_str();
     }
 
-    Finalize();
-    return 0;
+    if (ParallelDescriptor::IOProcessor())
+      cerr << "From " << infile << ": " << N << " nodes and " << E
+           << " elements with " << nComp
+           << " unknowns per node.  Dataset labelled: " << label << endl;
+
+    Vector<Vector<Real>> nodeVec(N);
+    vector<string> tokens;
+    for (SIZET j = 0; j < N; ++j) {
+      Vector<Real>& v = nodeVec[j];
+      v.resize(nComp);
+      tokens = Tokenize(buf, ", ");
+      AMREX_ASSERT(tokens.size() == nComp);
+      for (int k = 0; k < nComp; ++k) {
+        v[k] = atof(tokens[k].c_str());
+      }
+      std::getline(ifs, buf);
+    }
+
+    int nodesPerElt = -1;
+    if (eltType == "TRIANGLE")
+      nodesPerElt = 3;
+
+    Vector<Vector<SIZET>> eltVec(E);
+    for (SIZET j = 0; j < E; ++j) {
+      Vector<SIZET>& e = eltVec[j];
+      tokens = Tokenize(buf, ", ");
+      AMREX_ASSERT(tokens.size() == nodesPerElt);
+      e.resize(nodesPerElt);
+      for (int k = 0; k < nodesPerElt; ++k)
+        e[k] = atoi(tokens[k].c_str());
+      std::getline(ifs, buf);
+    }
+
+    if (ParallelDescriptor::IOProcessor())
+      cerr << "...finished reading data" << endl;
+
+    Real area = 0;
+    map<Vector<int>, Real> bins;
+    for (int i = 0; i < E; ++i) {
+      const Vector<SIZET>& elt = eltVec[i];
+      const Vector<Real>& A = nodeVec[elt[0] - 1];
+      const Vector<Real>& B = nodeVec[elt[1] - 1];
+      const Vector<Real>& C = nodeVec[elt[2] - 1];
+
+      area += triangleArea(A, B, C);
+    }
+
+    std::cout << "zoneID, area = " << zoneID << ", " << area << std::endl;
+
+    string binout = outfile;
+    if (zoneID > 0) {
+      char buf1[72];
+      sprintf(buf1, "%d", zoneID);
+      binout = infileTokens[0];
+      for (int i = 1; i < infileTokens.size() - 1; ++i)
+        outfile += string(".") + infileTokens[i];
+      binout += string("_") + string(buf1) + ".mef";
+    }
+
+    writeBin(names, nodeVec, eltVec, binout, label);
+
+    zoneID++;
+    zoneParams = GetZoneParams(ifs, nComp, buf);
+  }
+
+  Finalize();
+  return 0;
 }
 
 void
-writeBin(const Vector<string>&         names,
-         const Vector<Vector<Real> >&  nodeVec,
-         const Vector<Vector<SIZET> >& eltVec,
-         const std::string&            outfile,
-         const std::string&            label)
+writeBin(
+  const Vector<string>& names,
+  const Vector<Vector<Real>>& nodeVec,
+  const Vector<Vector<SIZET>>& eltVec,
+  const std::string& outfile,
+  const std::string& label)
 {
-    std::string vars;
-    for (int j=0; j<names.size(); ++j)
-        vars += " " + names[j];
+  std::string vars;
+  for (int j = 0; j < names.size(); ++j)
+    vars += " " + names[j];
 
-    FABdata tmpData(nodeVec.size(),nodeVec[0].size());
-    SIZET cnt = 0;
-    for (SIZET i=0; i<nodeVec.size(); ++i)
-    {
-        const Vector<Real>& vec = nodeVec[i];
-        for (int n=0; n<vec.size(); ++n)
-            tmpData[cnt++] = vec[n];
-    }
+  FABdata tmpData(nodeVec.size(), nodeVec[0].size());
+  SIZET cnt = 0;
+  for (SIZET i = 0; i < nodeVec.size(); ++i) {
+    const Vector<Real>& vec = nodeVec[i];
+    for (int n = 0; n < vec.size(); ++n)
+      tmpData[cnt++] = vec[n];
+  }
 
+  SIZET nElts = eltVec.size();
+  cnt = 0;
+  int nodesPerElt = eltVec[0].size();
+  Vector<SIZET> connData(nodesPerElt * nElts);
+  for (SIZET i = 0; i < nElts; ++i) {
+    const Vector<SIZET>& elt = eltVec[i];
+    AMREX_ASSERT(elt.size() == nodesPerElt);
+    for (int j = 0; j < elt.size(); ++j)
+      connData[cnt++] = elt[j];
+  }
 
-    SIZET nElts = eltVec.size();
-    cnt = 0;
-    int nodesPerElt = eltVec[0].size();
-    Vector<SIZET> connData(nodesPerElt*nElts);
-    for (SIZET i=0; i<nElts; ++i)
-    {
-        const Vector<SIZET>& elt = eltVec[i];
-        AMREX_ASSERT(elt.size()==nodesPerElt);
-        for (int j=0; j<elt.size(); ++j)
-            connData[cnt++] = elt[j];
-    }
-
-    std::ofstream ofs;
-    std::ostream* os =
-        (outfile=="-" ? (std::ostream*)(&std::cout) : (std::ostream*)(&ofs) );
-    if (outfile!="-")
-        ofs.open(outfile.c_str(),std::ios::out|std::ios::trunc|std::ios::binary);
-    (*os) << label << endl;
-    (*os) << vars << endl;
-    (*os) << nElts << " " << nodesPerElt << endl;
-    tmpData.fab.writeOn(*os);
-    (*os).write((char*)connData.dataPtr(),sizeof(SIZET)*connData.size());
-    if (outfile!="-")
-        ofs.close();
+  std::ofstream ofs;
+  std::ostream* os =
+    (outfile == "-" ? (std::ostream*)(&std::cout) : (std::ostream*)(&ofs));
+  if (outfile != "-")
+    ofs.open(
+      outfile.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
+  (*os) << label << endl;
+  (*os) << vars << endl;
+  (*os) << nElts << " " << nodesPerElt << endl;
+  tmpData.fab.writeOn(*os);
+  (*os).write((char*)connData.dataPtr(), sizeof(SIZET) * connData.size());
+  if (outfile != "-")
+    ofs.close();
 }
-

--- a/Src/surfMEFtoDAT.cpp
+++ b/Src/surfMEFtoDAT.cpp
@@ -6,15 +6,13 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
-    std::cerr << "usage:\n";
-    std::cerr << argv[0] << " infile=<name> [options] \n\tOptions:\n";
-    std::cerr << "\t     outfile=<name>\n";
-    exit(1);
+  std::cerr << "usage:\n";
+  std::cerr << argv[0] << " infile=<name> [options] \n\tOptions:\n";
+  std::cerr << "\t     outfile=<name>\n";
+  exit(1);
 }
 
 static std::string parseTitle(std::istream& is);
@@ -22,37 +20,36 @@ static std::vector<std::string> parseVarNames(std::istream& is);
 static std::string rootName(const std::string in);
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    amrex::Initialize(argc,argv);
-    {
+  amrex::Initialize(argc, argv);
+  {
     if (argc < 2)
-        print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-        print_usage(argc,argv);
+      print_usage(argc, argv);
 
-    bool verbose = false; pp.query("verbose",verbose);
+    bool verbose = false;
+    pp.query("verbose", verbose);
 
-    std::string infile; pp.get("infile",infile);
+    std::string infile;
+    pp.get("infile", infile);
 
     std::ifstream ifs;
-    std::istream* is = (infile=="-" ? (std::istream*)(&std::cin) : (std::istream*)(&ifs) );
-    if (infile!="-")
-    {
-        if (verbose)
-            std::cerr << "Opening " << infile << std::endl;
-        ifs.open(infile.c_str(),std::ios::in|std::ios::binary);
-        if (ifs.fail())
-            std::cerr << "Unable to open file : " << infile << std::endl;
-    }
-    else
-    {
-        if (verbose)
-            std::cerr << "Reading from stream" << std::endl;
+    std::istream* is =
+      (infile == "-" ? (std::istream*)(&std::cin) : (std::istream*)(&ifs));
+    if (infile != "-") {
+      if (verbose)
+        std::cerr << "Opening " << infile << std::endl;
+      ifs.open(infile.c_str(), std::ios::in | std::ios::binary);
+      if (ifs.fail())
+        std::cerr << "Unable to open file : " << infile << std::endl;
+    } else {
+      if (verbose)
+        std::cerr << "Reading from stream" << std::endl;
     }
     const std::string title = parseTitle(*is);
     const std::vector<std::string> names = parseVarNames(*is);
@@ -67,78 +64,76 @@ main (int   argc,
     nodeFab.readFrom((*is));
     Real* nodeData = nodeFab.dataPtr();
     int nPts = nodeFab.box().numPts();
-    
-    Vector<int> connData(nElts*MYLEN,0);
-    (*is).read((char*)connData.dataPtr(),sizeof(int)*connData.size());
+
+    Vector<int> connData(nElts * MYLEN, 0);
+    (*is).read((char*)connData.dataPtr(), sizeof(int) * connData.size());
 
     // Build outfile name
-    std::vector<std::string> infileTokens = amrex::Tokenize(infile,".");
+    std::vector<std::string> infileTokens = amrex::Tokenize(infile, ".");
     std::string outfile;
     outfile = infileTokens[0];
-    for (int i=1; i<infileTokens.size()-1; ++i)
-        outfile += std::string(".") + infileTokens[i];
+    for (int i = 1; i < infileTokens.size() - 1; ++i)
+      outfile += std::string(".") + infileTokens[i];
     outfile += ".dat";
-    pp.query("outfile",outfile);
+    pp.query("outfile", outfile);
 
     std::string vars("VARIABLES =");
-    for (int j=0; j<names.size(); ++j)
-        vars += " " + names[j];
+    for (int j = 0; j < names.size(); ++j)
+      vars += " " + names[j];
 
     // Write ASCII output file
-    std::ofstream os(outfile.c_str(),std::ios::out);
+    std::ofstream os(outfile.c_str(), std::ios::out);
     os << vars << std::endl;
     os << "ZONE T=\"" << title << "\" N=" << nPts << " E=" << nElts
        << " F=FEPOINT ET=";
-    os << (MYLEN==2 ? "LINESEG" : "TRIANGLE") << std::endl;
-    for (int i=0; i<nPts; ++i)
-    {
-        int offset = i*nComp;
-        for (int k=0; k<nComp; ++k)
-            os << nodeData[offset+k] << " ";
-        os << std::endl;
+    os << (MYLEN == 2 ? "LINESEG" : "TRIANGLE") << std::endl;
+    for (int i = 0; i < nPts; ++i) {
+      int offset = i * nComp;
+      for (int k = 0; k < nComp; ++k)
+        os << nodeData[offset + k] << " ";
+      os << std::endl;
     }
-    for (int i=0; i<nElts; ++i)
-    {
-        int offset = i*MYLEN;
-        for (int k=0; k<MYLEN; ++k)
-            os << connData[offset+k] << " ";
-        os << std::endl;
+    for (int i = 0; i < nElts; ++i) {
+      int offset = i * MYLEN;
+      for (int k = 0; k < MYLEN; ++k)
+        os << connData[offset + k] << " ";
+      os << std::endl;
     }
     os.close();
-    
-    }
-    amrex::Finalize();
-    return 0;
+  }
+  amrex::Finalize();
+  return 0;
 }
 
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return amrex::Tokenize(line,std::string(" "));
+  std::string line;
+  std::getline(is, line);
+  return amrex::Tokenize(line, std::string(" "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return line;
+  std::string line;
+  std::getline(is, line);
+  return line;
 }
 
-static std::string rootName(const std::string inStr)
+static std::string
+rootName(const std::string inStr)
 {
 #ifdef WIN32
-    const std::string dirSep("\\");
+  const std::string dirSep("\\");
 #else
-    const std::string dirSep("/");
+  const std::string dirSep("/");
 #endif
-    std::vector<std::string> res = amrex::Tokenize(inStr,dirSep);
-    res = amrex::Tokenize(res[res.size()-1],std::string("."));
-    std::string out = res[0];
-    for (int i=1; i<res.size()-1; ++i)
-        out = out + std::string(".") + res[i];
-    return out;
-    //return (res.size()>1 ? res[res.size()-2] : res[res.size()-1]);
+  std::vector<std::string> res = amrex::Tokenize(inStr, dirSep);
+  res = amrex::Tokenize(res[res.size() - 1], std::string("."));
+  std::string out = res[0];
+  for (int i = 1; i < res.size() - 1; ++i)
+    out = out + std::string(".") + res[i];
+  return out;
+  // return (res.size()>1 ? res[res.size()-2] : res[res.size()-1]);
 }
-

--- a/Src/template.cpp
+++ b/Src/template.cpp
@@ -9,10 +9,8 @@
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
@@ -22,50 +20,50 @@ print_usage (int,
 std::string
 getFileRoot(const std::string& infile)
 {
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-  Initialize(argc,argv);
+  Initialize(argc, argv);
   {
     if (argc < 2)
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     ParmParse pp;
 
     if (pp.contains("help"))
-      print_usage(argc,argv);
+      print_usage(argc, argv);
 
     if (pp.contains("verbose"))
       AmrData::SetVerbose(true);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
       // ^^^ this calls ParallelDescriptor::EndParallel() and exit()
     }
     AmrData& amrData = dataServices.AmrDataRef();
 
     int finestLevel = amrData.FinestLevel();
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
-    Vector<int> is_per(AMREX_SPACEDIM,1);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
+    Vector<int> is_per(AMREX_SPACEDIM, 1);
+    pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     Print() << "Periodicity assumed for this case: ";
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        Print() << is_per[idim] << " ";
+      Print() << is_per[idim] << " ";
     }
 
-    RealBox rb(&(amrData.ProbLo()[0]),&(amrData.ProbHi()[0]));
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
 
     Vector<MultiFab> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
@@ -75,52 +73,51 @@ main (int   argc,
 
     Vector<std::string> inNames = amrData.PlotVarNames();
     Vector<std::string> outNames = amrData.PlotVarNames();
-    
+
     Vector<int> destFillComps(nComp);
-    for (int i=0; i<nComp; ++i) destFillComps[i] = i;
+    for (int i = 0; i < nComp; ++i)
+      destFillComps[i] = i;
 
     for (int lev = 0; lev < Nlev; ++lev) {
-      
+
       const BoxArray ba = amrData.boxArray(lev);
       const DistributionMapping dm(ba);
 
-      outdata[lev] = MultiFab(ba,dm,nComp,nGrow);
-      MultiFab indata(ba,dm,nComp,nGrow);
+      outdata[lev] = MultiFab(ba, dm, nComp, nGrow);
+      MultiFab indata(ba, dm, nComp, nGrow);
 
       int coord = 0;
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb, coord, &(is_per[0]));      
-      
+      geoms[lev] =
+        Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
+
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata,lev,inNames,destFillComps);
+      amrData.FillVar(indata, lev, inNames, destFillComps);
       Print() << "Data has been read for level " << lev << std::endl;
-      
+
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-      for (MFIter mfi(indata,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-	{
-	  const Box& bx = mfi.tilebox();
-	  auto const& out_a = outdata[lev].array(mfi);
-	  auto const& in_a = indata.array(mfi);
-	  amrex::ParallelFor(bx, [=]
-			     AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-				 {
-				   // Do something funky
-				   for (int n = 0; n < nComp; n++) {
-				     out_a(i,j,k,n) = in_a(i,j,k,n); 
-				   }
-				 });
-	}
-
+      for (MFIter mfi(indata, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.tilebox();
+        auto const& out_a = outdata[lev].array(mfi);
+        auto const& in_a = indata.array(mfi);
+        amrex::ParallelFor(
+          bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            // Do something funky
+            for (int n = 0; n < nComp; n++) {
+              out_a(i, j, k, n) = in_a(i, j, k, n);
+            }
+          });
+      }
     }
-    
+
     std::string outfile(getFileRoot(plotFileName) + "_temp");
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfile(outfile, Nlev, GetVecOfConstPtrs(outdata), outNames,
-                                   geoms, 0.0, isteps, refRatios);
-
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfile(
+      outfile, Nlev, GetVecOfConstPtrs(outdata), outNames, geoms, 0.0, isteps,
+      refRatios);
   }
   Finalize();
   return 0;

--- a/Src/trimMEFgen.cpp
+++ b/Src/trimMEFgen.cpp
@@ -11,610 +11,587 @@
 
 using namespace amrex;
 
-using std::vector;
-using std::map;
-using std::string;
 using std::cerr;
-using std::endl;
 using std::cout;
+using std::endl;
+using std::map;
 using std::ofstream;
+using std::string;
+using std::vector;
 
-void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Vector<int>&       faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label);
+void read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Vector<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label);
 
-void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Vector<int>&    faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label);
+void write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Vector<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label);
 
-static
-std::vector<std::string> parseVarNames(std::istream& is)
+static std::vector<std::string>
+parseVarNames(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return Tokenize(line,std::string(", "));
+  std::string line;
+  std::getline(is, line);
+  return Tokenize(line, std::string(", "));
 }
 
-static std::string parseTitle(std::istream& is)
+static std::string
+parseTitle(std::istream& is)
 {
-    std::string line;
-    std::getline(is,line);
-    return line;
+  std::string line;
+  std::getline(is, line);
+  return line;
 }
 
 Real
-surface_area(const FArrayBox&   nodes,
-             const Vector<int>& faceData,
-             int                nodesPerElt)
+surface_area(
+  const FArrayBox& nodes, const Vector<int>& faceData, int nodesPerElt)
 {
-    Vector<const Real*> dat(AMREX_SPACEDIM);
-    for (int i=0; i<dat.size(); ++i)
-        dat[i] = nodes.dataPtr(i);
+  Vector<const Real*> dat(AMREX_SPACEDIM);
+  for (int i = 0; i < dat.size(); ++i)
+    dat[i] = nodes.dataPtr(i);
 
-    AMREX_ASSERT(nodesPerElt==3); // not general enough for anything else
-    int nElts = faceData.size() / nodesPerElt;
-    Real Area = 0;
-    Vector<Real> p0(AMREX_SPACEDIM), p1(AMREX_SPACEDIM), p2(AMREX_SPACEDIM);
-    for (int k=0; k<nElts; ++k)
-    {
-        // set points of 
-        for (int i=0; i<3; ++i)
-        {
-            p0[i] = dat[i][faceData[k*nodesPerElt + 0 ] - 1];
-            p1[i] = dat[i][faceData[k*nodesPerElt + 1 ] - 1];
-            p2[i] = dat[i][faceData[k*nodesPerElt + 2 ] - 1];
-        }
-
-        Area += 0.5*sqrt(
-            pow(( p1[1] - p0[1])*(p2[2]-p0[2]) 
-                -(p1[2] - p0[2])*(p2[1]-p0[1]), 2)
-            
-            + pow(( p1[2] - p0[2])*(p2[0]-p0[0]) 
-                  -(p1[0] - p0[0])*(p2[2]-p0[2]), 2)
-            
-            + pow(( p1[0] - p0[0])*(p2[1]-p0[1]) 
-                  -(p1[1] - p0[1])*(p2[0]-p0[0]), 2) );
+  AMREX_ASSERT(nodesPerElt == 3); // not general enough for anything else
+  int nElts = faceData.size() / nodesPerElt;
+  Real Area = 0;
+  Vector<Real> p0(AMREX_SPACEDIM), p1(AMREX_SPACEDIM), p2(AMREX_SPACEDIM);
+  for (int k = 0; k < nElts; ++k) {
+    // set points of
+    for (int i = 0; i < 3; ++i) {
+      p0[i] = dat[i][faceData[k * nodesPerElt + 0] - 1];
+      p1[i] = dat[i][faceData[k * nodesPerElt + 1] - 1];
+      p2[i] = dat[i][faceData[k * nodesPerElt + 2] - 1];
     }
-    return Area;
+
+    Area +=
+      0.5 *
+      sqrt(
+        pow(
+          (p1[1] - p0[1]) * (p2[2] - p0[2]) - (p1[2] - p0[2]) * (p2[1] - p0[1]),
+          2)
+
+        +
+        pow(
+          (p1[2] - p0[2]) * (p2[0] - p0[0]) - (p1[0] - p0[0]) * (p2[2] - p0[2]),
+          2)
+
+        +
+        pow(
+          (p1[0] - p0[0]) * (p2[1] - p0[1]) - (p1[1] - p0[1]) * (p2[0] - p0[0]),
+          2));
+  }
+  return Area;
 }
 
 void
-trim_surface(const Vector<int>&    comps,
-             const Vector<string>& signs,
-             const Vector<Real>&   vals,
-             FArrayBox&            nodes,
-             Vector<int>&          faceData,
-             int                   nodesPerElt)
+trim_surface(
+  const Vector<int>& comps,
+  const Vector<string>& signs,
+  const Vector<Real>& vals,
+  FArrayBox& nodes,
+  Vector<int>& faceData,
+  int nodesPerElt)
 {
-    const Box& nbox = nodes.box();
-    const int nc = comps.size();
-    Vector<Real*> dat(nc);
-    for (int i=0; i<nc; ++i)
-        dat[i] = nodes.dataPtr(comps[i]);
+  const Box& nbox = nodes.box();
+  const int nc = comps.size();
+  Vector<Real*> dat(nc);
+  for (int i = 0; i < nc; ++i)
+    dat[i] = nodes.dataPtr(comps[i]);
 
-    int cnt = 0;
-    int cnt_new = 0;
-    vector<int> nodeIdx;
-    for (IntVect iv=nbox.smallEnd(); iv<=nbox.bigEnd(); nbox.next(iv), cnt++)
-    {
-        bool remove_this_node = false;
-        for (int i=0; i<nc; ++i)
-        {
-            const Real data = dat[i][cnt];
-            if (signs[i]=="lt")
-            {
-                remove_this_node |= (data < vals[i]);
-            }
-            else if (signs[i]=="le")
-            {
-                remove_this_node |= (data <= vals[i]);
-            }
-            else if (signs[i]=="gt")
-            {
-                remove_this_node |= (data > vals[i]);
-            }
-            else if (signs[i]=="ge")
-            {
-                remove_this_node |= (data >= vals[i]);
-            }
-            else if (signs[i]=="eq")
-            {
-                remove_this_node |= (data == vals[i]);
-            }
-            else
-            {
-                cout << "i,signs[i] " << i << "," << signs[i] << endl;
-                amrex::Abort("Bad signs data. Use one of [lt,le,gt,ge,eq]");
-            }
-        }
-        
-        nodeIdx.push_back( remove_this_node ? -1 : cnt_new++ );
+  int cnt = 0;
+  int cnt_new = 0;
+  vector<int> nodeIdx;
+  for (IntVect iv = nbox.smallEnd(); iv <= nbox.bigEnd();
+       nbox.next(iv), cnt++) {
+    bool remove_this_node = false;
+    for (int i = 0; i < nc; ++i) {
+      const Real data = dat[i][cnt];
+      if (signs[i] == "lt") {
+        remove_this_node |= (data < vals[i]);
+      } else if (signs[i] == "le") {
+        remove_this_node |= (data <= vals[i]);
+      } else if (signs[i] == "gt") {
+        remove_this_node |= (data > vals[i]);
+      } else if (signs[i] == "ge") {
+        remove_this_node |= (data >= vals[i]);
+      } else if (signs[i] == "eq") {
+        remove_this_node |= (data == vals[i]);
+      } else {
+        cout << "i,signs[i] " << i << "," << signs[i] << endl;
+        amrex::Abort("Bad signs data. Use one of [lt,le,gt,ge,eq]");
+      }
     }
-    int nNodesNEW = cnt_new;
 
+    nodeIdx.push_back(remove_this_node ? -1 : cnt_new++);
+  }
+  int nNodesNEW = cnt_new;
+
+  // Build new nodes structure with bad points removed
+  Box newBox(IntVect::TheZeroVector(), (nNodesNEW - 1) * amrex::BASISV(0));
+  int nNodesOLD = nbox.numPts();
+  int nComp = nodes.nComp();
+  FArrayBox newNodes(newBox, nComp);
+  Vector<Real*> odp(nComp);
+  Vector<Real*> ndp(nComp);
+  for (int j = 0; j < nComp; ++j) {
+    odp[j] = nodes.dataPtr(j);
+    ndp[j] = newNodes.dataPtr(j);
+  }
+  cnt_new = 0;
+  for (int i = 0; i < nNodesOLD; ++i) {
+    int newNode = nodeIdx[i];
+    if (newNode >= 0)
+      for (int j = 0; j < nComp; ++j)
+        ndp[j][newNode] = odp[j][i];
+  }
+  nodes.resize(newBox, nComp);
+  nodes.copy(newNodes);
+  newNodes.clear(); // Make some space...not really necessary, but what the heck
+
+  const int nElts = faceData.size() / nodesPerElt;
+  AMREX_ASSERT(nElts * nodesPerElt == faceData.size()); // Idiot check
+
+  // Remove elements that refer to removed nodes
+  vector<int> newFaceData;
+  cnt_new = 0;
+  for (int i = 0; i < nElts; ++i) {
+    int offset = nodesPerElt * i;
+    bool eltGood = true;
+    for (int j = 0; j < nodesPerElt; ++j)
+      eltGood &=
+        (nodeIdx[faceData[offset + j] - 1] >=
+         0); // Remember that faceData is 1-based
+
+    if (eltGood) {
+      int new_offset = nodesPerElt * cnt_new;
+      for (int j = 0; j < nodesPerElt; ++j)
+        newFaceData.push_back(
+          nodeIdx[faceData[offset + j] - 1] +
+          1); // Make sure new faceData is 1-based
+      cnt_new++;
+    }
+  }
+
+  faceData.resize(cnt_new * nodesPerElt);
+  for (int i = 0; i < faceData.size(); ++i)
+    faceData[i] = newFaceData[i];
+}
+
+void
+trim_surface_RXY(
+  const string& sign,
+  Real radius,
+  FArrayBox& nodes,
+  Vector<int>& faceData,
+  int nodesPerElt)
+{
+  const Box& nbox = nodes.box();
+  const Real* xdat = nodes.dataPtr(0);
+  const Real* ydat = nodes.dataPtr(1);
+
+  int cnt = 0;
+  int cnt_new = 0;
+  vector<int> nodeIdx;
+  for (IntVect iv = nbox.smallEnd(); iv <= nbox.bigEnd();
+       nbox.next(iv), cnt++) {
+    Real x = xdat[cnt];
+    Real y = ydat[cnt];
+    Real r = std::sqrt(x * x + y * y);
+    bool remove_this_node = false;
+
+    if (sign == "lt") {
+      remove_this_node = (r < radius);
+    } else if (sign == "le") {
+      remove_this_node |= (r <= radius);
+    } else if (sign == "gt") {
+      remove_this_node |= (r > radius);
+    } else if (sign == "ge") {
+      remove_this_node |= (r >= radius);
+    } else if (sign == "eq") {
+      remove_this_node |= (r == radius);
+    } else {
+      cout << "sign_RXY: " << sign << endl;
+      amrex::Abort("Bad sign data.  Use one of [lt,le,gt,ge,eq]");
+    }
+
+    nodeIdx.push_back(remove_this_node ? -1 : cnt_new++);
+  }
+  int nNodesNEW = cnt_new;
+
+  // Build new nodes structure with bad points removed
+  Box newBox(IntVect::TheZeroVector(), (nNodesNEW - 1) * amrex::BASISV(0));
+  int nNodesOLD = nbox.numPts();
+  int nComp = nodes.nComp();
+  FArrayBox newNodes(newBox, nComp);
+  Vector<Real*> odp(nComp);
+  Vector<Real*> ndp(nComp);
+  for (int j = 0; j < nComp; ++j) {
+    odp[j] = nodes.dataPtr(j);
+    ndp[j] = newNodes.dataPtr(j);
+  }
+  cnt_new = 0;
+  for (int i = 0; i < nNodesOLD; ++i) {
+    int newNode = nodeIdx[i];
+    if (newNode >= 0)
+      for (int j = 0; j < nComp; ++j)
+        ndp[j][newNode] = odp[j][i];
+  }
+  nodes.resize(newBox, nComp);
+  nodes.copy(newNodes);
+  newNodes.clear(); // Make some space...not really necessary, but what the heck
+
+  const int nElts = faceData.size() / nodesPerElt;
+  AMREX_ASSERT(nElts * nodesPerElt == faceData.size()); // Idiot check
+
+  // Remove elements that refer to removed nodes
+  vector<int> newFaceData;
+  cnt_new = 0;
+  for (int i = 0; i < nElts; ++i) {
+    int offset = nodesPerElt * i;
+    bool eltGood = true;
+    for (int j = 0; j < nodesPerElt; ++j)
+      eltGood &=
+        (nodeIdx[faceData[offset + j] - 1] >=
+         0); // Remember that faceData is 1-based
+
+    if (eltGood) {
+      int new_offset = nodesPerElt * cnt_new;
+      for (int j = 0; j < nodesPerElt; ++j)
+        newFaceData.push_back(
+          nodeIdx[faceData[offset + j] - 1] +
+          1); // Make sure new faceData is 1-based
+      cnt_new++;
+    }
+  }
+
+  faceData.resize(cnt_new * nodesPerElt);
+  for (int i = 0; i < faceData.size(); ++i)
+    faceData[i] = newFaceData[i];
+}
+
+void
+remove_unused_nodes(FArrayBox& nodes, Vector<int>& faceData, int nodesPerElt)
+{
+  const Box& nbox = nodes.box();
+  int nNodesOLD = nbox.numPts();
+
+  std::vector<bool> removeNode(nNodesOLD, true);
+  for (int i = 0; i < faceData.size(); ++i) {
+    int node = faceData[i]; // These are 1-based node numbers
+    AMREX_ASSERT(node <= nNodesOLD && node > 0);
+    removeNode[node - 1] = false; // Indexing here is zero-based
+  }
+
+  Vector<int> nodeIdx(nNodesOLD);
+  int nNodesNEW = 0;
+  for (int i = 0; i < nNodesOLD; ++i) {
+    nodeIdx[i] = (removeNode[i] ? -1 : nNodesNEW++); // zero-based
+  }
+
+  if (nNodesNEW != nNodesOLD) {
     // Build new nodes structure with bad points removed
-    Box newBox(IntVect::TheZeroVector(),(nNodesNEW-1)*amrex::BASISV(0));
-    int nNodesOLD = nbox.numPts();
+    Box newBox(IntVect::TheZeroVector(), (nNodesNEW - 1) * amrex::BASISV(0));
     int nComp = nodes.nComp();
-    FArrayBox newNodes(newBox,nComp);
+    FArrayBox newNodes(newBox, nComp);
     Vector<Real*> odp(nComp);
     Vector<Real*> ndp(nComp);
-    for (int j=0; j<nComp; ++j)
-    {
-        odp[j] = nodes.dataPtr(j);
-        ndp[j] = newNodes.dataPtr(j);
+    for (int j = 0; j < nComp; ++j) {
+      odp[j] = nodes.dataPtr(j);
+      ndp[j] = newNodes.dataPtr(j);
     }
-    cnt_new = 0;
-    for (int i=0; i<nNodesOLD; ++i)
-    {
-        int newNode = nodeIdx[i];
-        if (newNode>=0)
-            for (int j=0; j<nComp; ++j)
-                ndp[j][newNode] = odp[j][i];
+    int cnt_new = 0;
+    for (int i = 0; i < nNodesOLD; ++i) {
+      int newNode = nodeIdx[i];
+      if (newNode >= 0)
+        for (int j = 0; j < nComp; ++j)
+          ndp[j][newNode] = odp[j][i];
     }
-    nodes.resize(newBox,nComp);
+    nodes.resize(newBox, nComp);
     nodes.copy(newNodes);
-    newNodes.clear(); // Make some space...not really necessary, but what the heck
+    newNodes
+      .clear(); // Make some space...not really necessary, but what the heck
 
     const int nElts = faceData.size() / nodesPerElt;
     AMREX_ASSERT(nElts * nodesPerElt == faceData.size()); // Idiot check
 
-    // Remove elements that refer to removed nodes
+    // Redefine elements with new numbering
     vector<int> newFaceData;
     cnt_new = 0;
-    for (int i=0; i<nElts; ++i)
-    {
-        int offset = nodesPerElt * i;
-        bool eltGood = true;
-        for (int j=0; j<nodesPerElt; ++j)
-            eltGood &= (nodeIdx[ faceData[offset+j] - 1 ] >= 0); // Remember that faceData is 1-based
+    for (int i = 0; i < nElts; ++i) {
+      int offset = nodesPerElt * i;
+      int new_offset = nodesPerElt * cnt_new;
+      for (int j = 0; j < nodesPerElt; ++j) {
+        if (
+          nodeIdx[faceData[offset + j] - 1] < 0 ||
+          nodeIdx[faceData[offset + j] - 1] >= nNodesOLD)
+          std::cout << "messed up" << std::endl;
 
-        if (eltGood)
-        {
-            int new_offset = nodesPerElt * cnt_new;
-            for (int j=0; j<nodesPerElt; ++j)
-                newFaceData.push_back(nodeIdx[ faceData[offset+j] - 1 ] + 1); // Make sure new faceData is 1-based
-            cnt_new++;
-        }
+        newFaceData.push_back(
+          nodeIdx[faceData[offset + j] - 1] +
+          1); // Make sure new faceData is 1-based
+      }
+      cnt_new++;
     }
 
-    faceData.resize(cnt_new*nodesPerElt);
-    for (int i=0; i<faceData.size(); ++i)
-        faceData[i] = newFaceData[i];
+    faceData.resize(cnt_new * nodesPerElt);
+    for (int i = 0; i < faceData.size(); ++i)
+      faceData[i] = newFaceData[i];
+
+    if (ParallelDescriptor::IOProcessor())
+      std::cout << "Removed " << nNodesOLD - nNodesNEW << " unusued nodes"
+                << std::endl;
+  }
 }
 
 void
-trim_surface_RXY(const string& sign,
-                 Real          radius,
-                 FArrayBox&    nodes,
-                 Vector<int>&  faceData,
-                 int           nodesPerElt)
+triangle_area(
+  const Real* x,
+  const Real* y,
+  const Real* z,
+  const Vector<int>& faceData,
+  int nElts,
+  int nNodes,
+  Real* area)
 {
-    const Box& nbox = nodes.box();
-    const Real* xdat = nodes.dataPtr(0);
-    const Real* ydat = nodes.dataPtr(1);
+  Real R1[3], R2[3], R3[3];
+  const Real* loc[3];
+  loc[0] = x;
+  loc[1] = y;
+  loc[2] = z;
 
-    int cnt = 0;
-    int cnt_new = 0;
-    vector<int> nodeIdx;
-    for (IntVect iv=nbox.smallEnd(); iv<=nbox.bigEnd(); nbox.next(iv), cnt++)
-    {
-        Real x = xdat[cnt];
-        Real y = ydat[cnt];
-        Real r = std::sqrt(x*x + y*y);
-        bool remove_this_node = false;
-
-        if (sign=="lt")
-        {
-            remove_this_node = (r < radius);
-        }
-        else if (sign=="le")
-        {
-            remove_this_node |= (r <= radius);
-        }
-        else if (sign=="gt")
-        {
-            remove_this_node |= (r > radius);
-        }
-        else if (sign=="ge")
-        {
-            remove_this_node |= (r >= radius);
-        }
-        else if (sign=="eq")
-        {
-            remove_this_node |= (r == radius);
-        }
-        else
-        {
-            cout << "sign_RXY: " << sign << endl;
-            amrex::Abort("Bad sign data.  Use one of [lt,le,gt,ge,eq]");
-        }
-        
-        nodeIdx.push_back( remove_this_node ? -1 : cnt_new++ );
+  for (int i = 0; i < nElts; ++i) {
+    int offset = i * 3;
+    int pa = faceData[offset + 0] - 1;
+    int pb = faceData[offset + 1] - 1;
+    int pc = faceData[offset + 2] - 1;
+    for (int j = 0; j < 3; ++j) {
+      R1[j] = loc[j][pb] - loc[j][pa];
+      R2[j] = loc[j][pc] - loc[j][pa];
     }
-    int nNodesNEW = cnt_new;
+    R3[0] = R1[1] * R2[2] - R2[1] * R1[2];
+    R3[1] = R1[2] * R2[0] - R2[2] * R1[0];
+    R3[2] = R1[0] * R2[1] - R2[0] * R1[1];
 
-    // Build new nodes structure with bad points removed
-    Box newBox(IntVect::TheZeroVector(),(nNodesNEW-1)*amrex::BASISV(0));
-    int nNodesOLD = nbox.numPts();
-    int nComp = nodes.nComp();
-    FArrayBox newNodes(newBox,nComp);
-    Vector<Real*> odp(nComp);
-    Vector<Real*> ndp(nComp);
-    for (int j=0; j<nComp; ++j)
-    {
-        odp[j] = nodes.dataPtr(j);
-        ndp[j] = newNodes.dataPtr(j);
-    }
-    cnt_new = 0;
-    for (int i=0; i<nNodesOLD; ++i)
-    {
-        int newNode = nodeIdx[i];
-        if (newNode>=0)
-            for (int j=0; j<nComp; ++j)
-                ndp[j][newNode] = odp[j][i];
-    }
-    nodes.resize(newBox,nComp);
-    nodes.copy(newNodes);
-    newNodes.clear(); // Make some space...not really necessary, but what the heck
-
-    const int nElts = faceData.size() / nodesPerElt;
-    AMREX_ASSERT(nElts * nodesPerElt == faceData.size()); // Idiot check
-
-    // Remove elements that refer to removed nodes
-    vector<int> newFaceData;
-    cnt_new = 0;
-    for (int i=0; i<nElts; ++i)
-    {
-        int offset = nodesPerElt * i;
-        bool eltGood = true;
-        for (int j=0; j<nodesPerElt; ++j)
-            eltGood &= (nodeIdx[ faceData[offset+j] - 1 ] >= 0); // Remember that faceData is 1-based
-
-        if (eltGood)
-        {
-            int new_offset = nodesPerElt * cnt_new;
-            for (int j=0; j<nodesPerElt; ++j)
-                newFaceData.push_back(nodeIdx[ faceData[offset+j] - 1 ] + 1); // Make sure new faceData is 1-based
-            cnt_new++;
-        }
-    }
-
-    faceData.resize(cnt_new*nodesPerElt);
-    for (int i=0; i<faceData.size(); ++i)
-        faceData[i] = newFaceData[i];
-}
-
-void
-remove_unused_nodes(FArrayBox&   nodes,
-                    Vector<int>& faceData,
-                    int          nodesPerElt)
-{
-    const Box& nbox = nodes.box();
-    int nNodesOLD = nbox.numPts();
-
-    std::vector<bool> removeNode(nNodesOLD,true);
-    for (int i=0; i<faceData.size(); ++i)
-    {
-        int node = faceData[i]; // These are 1-based node numbers
-        AMREX_ASSERT(node<=nNodesOLD && node>0);
-        removeNode[node-1] = false; // Indexing here is zero-based
-    }
-
-    Vector<int> nodeIdx(nNodesOLD);
-    int nNodesNEW = 0;
-    for (int i=0; i<nNodesOLD; ++i)
-    {
-        nodeIdx[i] = ( removeNode[i] ? -1 : nNodesNEW++ ); // zero-based
-    }
-
-    if (nNodesNEW != nNodesOLD)
-    {
-        // Build new nodes structure with bad points removed
-        Box newBox(IntVect::TheZeroVector(),(nNodesNEW-1)*amrex::BASISV(0));
-        int nComp = nodes.nComp();
-        FArrayBox newNodes(newBox,nComp);
-        Vector<Real*> odp(nComp);
-        Vector<Real*> ndp(nComp);
-        for (int j=0; j<nComp; ++j)
-        {
-            odp[j] = nodes.dataPtr(j);
-            ndp[j] = newNodes.dataPtr(j);
-        }
-        int cnt_new = 0;
-        for (int i=0; i<nNodesOLD; ++i)
-        {
-            int newNode = nodeIdx[i];
-            if (newNode>=0)
-                for (int j=0; j<nComp; ++j)
-                    ndp[j][newNode] = odp[j][i];
-        }
-        nodes.resize(newBox,nComp);
-        nodes.copy(newNodes);
-        newNodes.clear(); // Make some space...not really necessary, but what the heck
-        
-        const int nElts = faceData.size() / nodesPerElt;
-        AMREX_ASSERT(nElts * nodesPerElt == faceData.size()); // Idiot check
-        
-        // Redefine elements with new numbering
-        vector<int> newFaceData;
-        cnt_new = 0;
-        for (int i=0; i<nElts; ++i)
-        {
-            int offset = nodesPerElt * i;
-            int new_offset = nodesPerElt * cnt_new;
-            for (int j=0; j<nodesPerElt; ++j)
-            {
-                if (nodeIdx[ faceData[offset+j] - 1] < 0  || nodeIdx[ faceData[offset+j] - 1] >= nNodesOLD)
-                    std::cout << "messed up" << std::endl;
-                
-                newFaceData.push_back(nodeIdx[ faceData[offset+j] - 1 ] + 1); // Make sure new faceData is 1-based
-                
-            }
-            cnt_new++;
-        }
-        
-        faceData.resize(cnt_new*nodesPerElt);
-        for (int i=0; i<faceData.size(); ++i)
-            faceData[i] = newFaceData[i];
-
-        if (ParallelDescriptor::IOProcessor())
-            std::cout << "Removed " << nNodesOLD - nNodesNEW << " unusued nodes" << std::endl;
-    }
-}
-
-void
-triangle_area(const Real*        x,
-              const Real*        y,
-              const Real*        z,
-              const Vector<int>& faceData,
-              int                nElts,
-              int                nNodes,
-              Real*              area)
-{
-    Real R1[3], R2[3], R3[3];
-    const Real* loc[3];
-    loc[0] = x;
-    loc[1] = y;
-    loc[2] = z;
-
-    for (int i=0; i<nElts; ++i)
-    {
-        int offset=i*3;
-        int pa = faceData[offset+0] - 1;
-        int pb = faceData[offset+1] - 1;
-        int pc = faceData[offset+2] - 1;
-        for (int j=0; j<3; ++j)
-        {
-            R1[j] = loc[j][pb] - loc[j][pa];
-            R2[j] = loc[j][pc] - loc[j][pa];
-        }
-        R3[0] = R1[1]*R2[2] - R2[1]*R1[2];
-        R3[1] = R1[2]*R2[0] - R2[2]*R1[0];
-        R3[2] = R1[0]*R2[1] - R2[0]*R1[1];
-
-        Real res=0;
-        for (int j=0; j<3; ++j)
-            res += R3[j]*R3[j];
-        area[i] = 0.5*std::sqrt(res);
-    }
+    Real res = 0;
+    for (int j = 0; j < 3; ++j)
+      res += R3[j] * R3[j];
+    area[i] = 0.5 * std::sqrt(res);
+  }
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    amrex::Initialize(argc,argv);
+  amrex::Initialize(argc, argv);
 
-    ParmParse pp;
+  ParmParse pp;
 
-    int nElts;
-    string infile; pp.get("infile",infile);
-    string outfile; pp.get("outfile",outfile);
-    
-    FArrayBox nodes;
-    Vector<int> faceData;
-    vector<string> names;
-    string label;
-    read_iso(infile,nodes,faceData,nElts,names,label);
-    int nodesPerElt = faceData.size() / nElts;
-    AMREX_ASSERT(nodesPerElt*nElts == faceData.size());
+  int nElts;
+  string infile;
+  pp.get("infile", infile);
+  string outfile;
+  pp.get("outfile", outfile);
 
-    cout << "Surface area before: " << surface_area(nodes,faceData,nodesPerElt) << '\n';
+  FArrayBox nodes;
+  Vector<int> faceData;
+  vector<string> names;
+  string label;
+  read_iso(infile, nodes, faceData, nElts, names, label);
+  int nodesPerElt = faceData.size() / nElts;
+  AMREX_ASSERT(nodesPerElt * nElts == faceData.size());
 
-    Vector<int> comps;
-    int nc = pp.countval("comps");
-    if (nc>0)
-    {
-        comps.resize(nc);
-        pp.getarr("comps",comps,0,nc);
+  cout << "Surface area before: " << surface_area(nodes, faceData, nodesPerElt)
+       << '\n';
 
-        Vector<string> signs(nc);
-        int ns = pp.countval("signs");
-        AMREX_ASSERT(ns==nc);
-        pp.getarr("signs",signs,0,nc);
-        
-        Vector<Real> vals(nc);
-        int nv = pp.countval("vals");
-        AMREX_ASSERT(nv==nc);
-        pp.getarr("vals",vals,0,nc);
-        
-        trim_surface(comps,signs,vals,nodes,faceData,nodesPerElt);
-    }
+  Vector<int> comps;
+  int nc = pp.countval("comps");
+  if (nc > 0) {
+    comps.resize(nc);
+    pp.getarr("comps", comps, 0, nc);
 
-    Real RXY=-1; pp.query("RXY",RXY);
-    if ( RXY >= 0 )
-    {
-        string sign_RXY; pp.get("sign_RXY",sign_RXY);
-        trim_surface_RXY(sign_RXY,RXY,nodes,faceData,nodesPerElt);
-    }
-    cout << "Surface area after: " << surface_area(nodes,faceData,nodesPerElt) << '\n';
+    Vector<string> signs(nc);
+    int ns = pp.countval("signs");
+    AMREX_ASSERT(ns == nc);
+    pp.getarr("signs", signs, 0, nc);
 
-    nElts = faceData.size() / nodesPerElt;
-    AMREX_ASSERT(nElts*nodesPerElt == faceData.size());
+    Vector<Real> vals(nc);
+    int nv = pp.countval("vals");
+    AMREX_ASSERT(nv == nc);
+    pp.getarr("vals", vals, 0, nc);
 
-    Vector<int> remComps;
-    int nrc = pp.countval("remComps");
-    if (nrc>0)
-    {
-        remComps.resize(nrc);
-        pp.getarr("remComps",remComps,0,nrc);
+    trim_surface(comps, signs, vals, nodes, faceData, nodesPerElt);
+  }
 
-        int nCompsNew = names.size() - nrc;
-        FArrayBox newNodes(nodes.box(),nCompsNew);
-        int cnt = 0;
-        Vector<string> newNames(nCompsNew);
-        for (int i=0; i<names.size(); ++i)
-        {
-            bool keepThisComp = true;
-            for (int j=0; j<remComps.size(); ++j)
-            {
-                if (remComps[j] == i) {
-                    keepThisComp = false;
-                }
-            }
-            if (keepThisComp) {
-                newNames[cnt] = names[i];
-                newNodes.copy(nodes,i,cnt,1);
-                cnt++;
-                AMREX_ASSERT(cnt<nCompsNew);
-            }
+  Real RXY = -1;
+  pp.query("RXY", RXY);
+  if (RXY >= 0) {
+    string sign_RXY;
+    pp.get("sign_RXY", sign_RXY);
+    trim_surface_RXY(sign_RXY, RXY, nodes, faceData, nodesPerElt);
+  }
+  cout << "Surface area after: " << surface_area(nodes, faceData, nodesPerElt)
+       << '\n';
+
+  nElts = faceData.size() / nodesPerElt;
+  AMREX_ASSERT(nElts * nodesPerElt == faceData.size());
+
+  Vector<int> remComps;
+  int nrc = pp.countval("remComps");
+  if (nrc > 0) {
+    remComps.resize(nrc);
+    pp.getarr("remComps", remComps, 0, nrc);
+
+    int nCompsNew = names.size() - nrc;
+    FArrayBox newNodes(nodes.box(), nCompsNew);
+    int cnt = 0;
+    Vector<string> newNames(nCompsNew);
+    for (int i = 0; i < names.size(); ++i) {
+      bool keepThisComp = true;
+      for (int j = 0; j < remComps.size(); ++j) {
+        if (remComps[j] == i) {
+          keepThisComp = false;
         }
-
-        nodes.clear();
-        names.clear();
-        names = newNames;
-        nodes.resize(newNodes.box(), newNodes.nComp());
-        nodes.copy(newNodes);
+      }
+      if (keepThisComp) {
+        newNames[cnt] = names[i];
+        newNodes.copy(nodes, i, cnt, 1);
+        cnt++;
+        AMREX_ASSERT(cnt < nCompsNew);
+      }
     }
 
-    bool do_area_stats = false; pp.query("do_area_stats",do_area_stats);
-    if (do_area_stats)
-    {
-        Vector<Real> area(nElts);
+    nodes.clear();
+    names.clear();
+    names = newNames;
+    nodes.resize(newNodes.box(), newNodes.nComp());
+    nodes.copy(newNodes);
+  }
 
-        int idX=0;
-        int idY=1;
-        int idZ=2;
+  bool do_area_stats = false;
+  pp.query("do_area_stats", do_area_stats);
+  if (do_area_stats) {
+    Vector<Real> area(nElts);
 
-        int nNodes = nodes.box().numPts();
-        triangle_area(nodes.dataPtr(idX),nodes.dataPtr(idY),nodes.dataPtr(idZ),faceData,nElts,nNodes,area.dataPtr());
+    int idX = 0;
+    int idY = 1;
+    int idZ = 2;
 
-        // Find min, max
-        Real area_min = area[0];
-        Real area_max = area[0];
-        for (int i=0; i<area.size(); ++i)
-        {
-            area_min = std::min(area_min,area[i]);
-            area_max = std::max(area_max,area[i]);
-        }
-
-        cout << "  Triangle area min, max: " << area_min << " , " << area_max << '\n';
-        
-    }
-
-    remove_unused_nodes(nodes,faceData,nodesPerElt);
-
-    write_iso(outfile,nodes,faceData,nElts,names,label);
-
-    amrex::Finalize();
-    return 0;
-}
-
-void
-write_iso(const std::string&    outfile,
-          const FArrayBox&      nodes,
-          const Vector<int>&     faceData,
-          int                   nElts,
-          const vector<string>& names,
-          const string&         label)
-{
-    // Rotate data to vary quickest on component
-    int nCompSurf = nodes.nComp();
     int nNodes = nodes.box().numPts();
+    triangle_area(
+      nodes.dataPtr(idX), nodes.dataPtr(idY), nodes.dataPtr(idZ), faceData,
+      nElts, nNodes, area.dataPtr());
 
-    FArrayBox tnodes(nodes.box(),nCompSurf);
-    const Real** np = new const Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            ndat[j] = np[j][i];
-        }
-        ndat += nCompSurf;
+    // Find min, max
+    Real area_min = area[0];
+    Real area_max = area[0];
+    for (int i = 0; i < area.size(); ++i) {
+      area_min = std::min(area_min, area[i]);
+      area_max = std::max(area_max, area[i]);
     }
-    delete [] np;
 
-    std::ofstream ofs;
-    ofs.open(outfile.c_str(),std::ios::out|std::ios::trunc|std::ios::binary);
-    ofs << label << endl;
-    for (int i=0; i<nCompSurf; ++i)
-    {
-        ofs << names[i];
-        if (i < nCompSurf-1)
-            ofs << " ";
-        else
-            ofs << std::endl;
-    }
-    int nodesPerElt = faceData.size() / nElts;
-    ofs << nElts << " " << nodesPerElt << endl;
-    tnodes.writeOn(ofs);
-    ofs.write((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
-    ofs.close();
+    cout << "  Triangle area min, max: " << area_min << " , " << area_max
+         << '\n';
+  }
+
+  remove_unused_nodes(nodes, faceData, nodesPerElt);
+
+  write_iso(outfile, nodes, faceData, nElts, names, label);
+
+  amrex::Finalize();
+  return 0;
 }
 
 void
-read_iso(const std::string& infile,
-         FArrayBox&         nodes,
-         Vector<int>&       faceData,
-         int&               nElts,
-         vector<string>&    names,
-         string&            label)
+write_iso(
+  const std::string& outfile,
+  const FArrayBox& nodes,
+  const Vector<int>& faceData,
+  int nElts,
+  const vector<string>& names,
+  const string& label)
 {
-    std::ifstream ifs;
-    ifs.open(infile.c_str(),std::ios::in|std::ios::binary);
-    label = parseTitle(ifs);
-    names = parseVarNames(ifs);
-    const int nCompSurf = names.size();
+  // Rotate data to vary quickest on component
+  int nCompSurf = nodes.nComp();
+  int nNodes = nodes.box().numPts();
 
-    int nodesPerElt;
-    ifs >> nElts;
-    ifs >> nodesPerElt;
-
-    FArrayBox tnodes;
-    tnodes.readFrom(ifs);
-    const int nNodes = tnodes.box().numPts();
-
-    // "rotate" the data so that the components are 'in the right spot for fab data'
-    nodes.resize(tnodes.box(),nCompSurf);
-    Real** np = new Real*[nCompSurf];
-    for (int j=0; j<nCompSurf; ++j)
-        np[j] = nodes.dataPtr(j);
-
-    Real* ndat = tnodes.dataPtr();
-    for (int i=0; i<nNodes; ++i)
-    {
-        for (int j=0; j<nCompSurf; ++j)
-        {
-            np[j][i] = ndat[j];
-        }
-        ndat += nCompSurf;
+  FArrayBox tnodes(nodes.box(), nCompSurf);
+  const Real** np = new const Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      ndat[j] = np[j][i];
     }
-    delete [] np;
-    tnodes.clear();
+    ndat += nCompSurf;
+  }
+  delete[] np;
 
-    faceData.resize(nElts*nodesPerElt,0);
-    ifs.read((char*)faceData.dataPtr(),sizeof(int)*faceData.size());
+  std::ofstream ofs;
+  ofs.open(outfile.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
+  ofs << label << endl;
+  for (int i = 0; i < nCompSurf; ++i) {
+    ofs << names[i];
+    if (i < nCompSurf - 1)
+      ofs << " ";
+    else
+      ofs << std::endl;
+  }
+  int nodesPerElt = faceData.size() / nElts;
+  ofs << nElts << " " << nodesPerElt << endl;
+  tnodes.writeOn(ofs);
+  ofs.write((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
+  ofs.close();
 }
 
+void
+read_iso(
+  const std::string& infile,
+  FArrayBox& nodes,
+  Vector<int>& faceData,
+  int& nElts,
+  vector<string>& names,
+  string& label)
+{
+  std::ifstream ifs;
+  ifs.open(infile.c_str(), std::ios::in | std::ios::binary);
+  label = parseTitle(ifs);
+  names = parseVarNames(ifs);
+  const int nCompSurf = names.size();
+
+  int nodesPerElt;
+  ifs >> nElts;
+  ifs >> nodesPerElt;
+
+  FArrayBox tnodes;
+  tnodes.readFrom(ifs);
+  const int nNodes = tnodes.box().numPts();
+
+  // "rotate" the data so that the components are 'in the right spot for fab
+  // data'
+  nodes.resize(tnodes.box(), nCompSurf);
+  Real** np = new Real*[nCompSurf];
+  for (int j = 0; j < nCompSurf; ++j)
+    np[j] = nodes.dataPtr(j);
+
+  Real* ndat = tnodes.dataPtr();
+  for (int i = 0; i < nNodes; ++i) {
+    for (int j = 0; j < nCompSurf; ++j) {
+      np[j][i] = ndat[j];
+    }
+    ndat += nCompSurf;
+  }
+  delete[] np;
+  tnodes.clear();
+
+  faceData.resize(nElts * nodesPerElt, 0);
+  ifs.read((char*)faceData.dataPtr(), sizeof(int) * faceData.size());
+}

--- a/Src/turbfile.cpp
+++ b/Src/turbfile.cpp
@@ -7,223 +7,214 @@
 #include <AMReX_PlotFileUtil.H>
 
 #if AMREX_SPACEDIM == 2
-extern "C"
-{
-    void FLIPROWSY(const Real* dat, ARLIM_P(lo),ARLIM_P(hi));
+extern "C" {
+void FLIPROWSY(const Real* dat, ARLIM_P(lo), ARLIM_P(hi));
 };
 #endif
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
+static void
+print_usage(int, char* argv[])
 {
-    std::cerr << "usage:\n";
-    std::cerr << argv[0] << " ifile=<pltfile> ofile=<turbname>\n";
-    exit(1);
+  std::cerr << "usage:\n";
+  std::cerr << argv[0] << " ifile=<pltfile> ofile=<turbname>\n";
+  exit(1);
 }
 
-static
-void
-Extend (FArrayBox& xfab,
-        FArrayBox& vfab,
-        const Box& dm)
+static void
+Extend(FArrayBox& xfab, FArrayBox& vfab, const Box& dm)
 {
-    Box tbx = vfab.box();
+  Box tbx = vfab.box();
 
-    tbx.setBig(0, dm.bigEnd(0) + 3);
+  tbx.setBig(0, dm.bigEnd(0) + 3);
 
-    const int ygrow = AMREX_SPACEDIM==3 ? 3 : 1;
+  const int ygrow = AMREX_SPACEDIM == 3 ? 3 : 1;
 
-    tbx.setBig(1, dm.bigEnd(1) + ygrow);
+  tbx.setBig(1, dm.bigEnd(1) + ygrow);
 
-    xfab.resize(tbx,1);
+  xfab.resize(tbx, 1);
 
-    xfab.copy(vfab);
-    vfab.shift(0, dm.length(0));
-    xfab.copy(vfab);
-    vfab.shift(1, dm.length(1));
-    xfab.copy(vfab);
-    vfab.shift(0, -dm.length(0));
-    xfab.copy(vfab);
+  xfab.copy(vfab);
+  vfab.shift(0, dm.length(0));
+  xfab.copy(vfab);
+  vfab.shift(1, dm.length(1));
+  xfab.copy(vfab);
+  vfab.shift(0, -dm.length(0));
+  xfab.copy(vfab);
 }
 
 int
-main (int   argc,
-      char* argv[])
+main(int argc, char* argv[])
 {
-    Initialize(argc,argv);
+  Initialize(argc, argv);
 
-    if (argc < 2)
-        print_usage(argc,argv);
+  if (argc < 2)
+    print_usage(argc, argv);
 
-    if(ParallelDescriptor::NProcs() > 1) {
-      Abort("Not suitable for parallel");
-    }
-    ParmParse pp;
+  if (ParallelDescriptor::NProcs() > 1) {
+    Abort("Not suitable for parallel");
+  }
+  ParmParse pp;
 
-    if (pp.contains("help"))
-        print_usage(argc,argv);
+  if (pp.contains("help"))
+    print_usage(argc, argv);
 
-    if (pp.contains("verbose"))
-        AmrData::SetVerbose(true);
+  if (pp.contains("verbose"))
+    AmrData::SetVerbose(true);
 
-    std::string ifile;
-    pp.get("ifile",ifile);
+  std::string ifile;
+  pp.get("ifile", ifile);
 
-    std::string ofile;
-    pp.get("ofile",ofile);
+  std::string ofile;
+  pp.get("ofile", ofile);
 
-    std::cout << "Reading " << ifile << " ... " << std::flush;
+  std::cout << "Reading " << ifile << " ... " << std::flush;
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
-    DataServices dataServices(ifile, fileType);
-    std::cout << "done" << std::endl;
+  DataServices::SetBatchMode();
+  Amrvis::FileType fileType(Amrvis::NEWPLT);
+  DataServices dataServices(ifile, fileType);
+  std::cout << "done" << std::endl;
 
-    if (!dataServices.AmrDataOk())
-        DataServices::Dispatch(DataServices::ExitRequest, NULL);
-    AmrData& amrData = dataServices.AmrDataRef();
+  if (!dataServices.AmrDataOk())
+    DataServices::Dispatch(DataServices::ExitRequest, NULL);
+  AmrData& amrData = dataServices.AmrDataRef();
 
-    std::string TurbDir = ofile;
+  std::string TurbDir = ofile;
 
-    if (ParallelDescriptor::IOProcessor())
-        if (!UtilCreateDirectory(TurbDir, 0755))
-            CreateDirectoryFailed(TurbDir);
+  if (ParallelDescriptor::IOProcessor())
+    if (!UtilCreateDirectory(TurbDir, 0755))
+      CreateDirectoryFailed(TurbDir);
 
-    std::string Hdr = TurbDir; Hdr += "/HDR";
-    std::string Dat = TurbDir; Dat += "/DAT";
+  std::string Hdr = TurbDir;
+  Hdr += "/HDR";
+  std::string Dat = TurbDir;
+  Dat += "/DAT";
 
-    std::ofstream ifsd, ifsh;
+  std::ofstream ifsd, ifsh;
 
-    ifsh.open(Hdr.c_str(), std::ios::out|std::ios::trunc);
-    if (!ifsh.good())
-        FileOpenFailed(Hdr);
+  ifsh.open(Hdr.c_str(), std::ios::out | std::ios::trunc);
+  if (!ifsh.good())
+    FileOpenFailed(Hdr);
 
-    ifsd.open(Dat.c_str(), std::ios::out|std::ios::trunc);
-    if (!ifsd.good())
-        FileOpenFailed(Dat);
+  ifsd.open(Dat.c_str(), std::ios::out | std::ios::trunc);
+  if (!ifsd.good())
+    FileOpenFailed(Dat);
 
-    int dir         = AMREX_SPACEDIM - 1; pp.query("dir",dir);
-    int dir_arr[3];
-    for (int d = 0; d < AMREX_SPACEDIM; d++) {
-      d == dir ? dir_arr[d] = 0 : dir_arr[d] = 1;      
-    }
-    
-    const int          finestLevel = amrData.FinestLevel();
-    const Box          dm          = amrData.ProbDomain()[finestLevel];
-    Box                xdm         = dm;
-    const Vector<Real> dx          = amrData.DxLevel()[finestLevel];
-    IntVect            sm          = dm.smallEnd();
-    IntVect            bg          = dm.bigEnd();
-    std::string        names[3]    = { "x_velocity", "y_velocity", "z_velocity" };
-    FArrayBox          xfab;
-    //
-    // Write the first part of the header.
-    // Note that this is solely for periodic style inflow files.
-    //
-#if AMREX_SPACEDIM==2
-    xdm.setBig(0, dm.bigEnd(0) + 3);
-    xdm.setBig(1, dm.bigEnd(1) + 1);
+  int dir = AMREX_SPACEDIM - 1;
+  pp.query("dir", dir);
+  int dir_arr[3];
+  for (int d = 0; d < AMREX_SPACEDIM; d++) {
+    d == dir ? dir_arr[d] = 0 : dir_arr[d] = 1;
+  }
 
-    ifsh << xdm.length(0) << ' '
-         << xdm.length(1) << ' '
-         << 1             << '\n';
+  const int finestLevel = amrData.FinestLevel();
+  const Box dm = amrData.ProbDomain()[finestLevel];
+  Box xdm = dm;
+  const Vector<Real> dx = amrData.DxLevel()[finestLevel];
+  IntVect sm = dm.smallEnd();
+  IntVect bg = dm.bigEnd();
+  std::string names[3] = {"x_velocity", "y_velocity", "z_velocity"};
+  FArrayBox xfab;
+  //
+  // Write the first part of the header.
+  // Note that this is solely for periodic style inflow files.
+  //
+#if AMREX_SPACEDIM == 2
+  xdm.setBig(0, dm.bigEnd(0) + 3);
+  xdm.setBig(1, dm.bigEnd(1) + 1);
 
-    ifsh << amrData.ProbSize()[0] + 2*dx[0] << ' '
-         << amrData.ProbSize()[1]           << ' '
-         << 0                               << '\n';
+  ifsh << xdm.length(0) << ' ' << xdm.length(1) << ' ' << 1 << '\n';
 
-    ifsh << 1 << ' ' << 1 << ' ' << 0 << '\n';
-#elif AMREX_SPACEDIM==3
-    for (int d = 0; d < AMREX_SPACEDIM; d++) {
-      xdm.setBig(d, dm.bigEnd(d) + 1 + 2*dir_arr[d]);
-    }
+  ifsh << amrData.ProbSize()[0] + 2 * dx[0] << ' ' << amrData.ProbSize()[1]
+       << ' ' << 0 << '\n';
 
-    ifsh << xdm.length(0) << ' '
-         << xdm.length(1) << ' '
-         << xdm.length(2) << '\n';
+  ifsh << 1 << ' ' << 1 << ' ' << 0 << '\n';
+#elif AMREX_SPACEDIM == 3
+  for (int d = 0; d < AMREX_SPACEDIM; d++) {
+    xdm.setBig(d, dm.bigEnd(d) + 1 + 2 * dir_arr[d]);
+  }
 
-    ifsh << amrData.ProbSize()[0] + 2*dir_arr[0]*dx[0] << ' '
-         << amrData.ProbSize()[1] + 2*dir_arr[1]*dx[1] << ' '
-         << amrData.ProbSize()[2] + 2*dir_arr[2]*dx[2] << '\n';
+  ifsh << xdm.length(0) << ' ' << xdm.length(1) << ' ' << xdm.length(2) << '\n';
 
-    ifsh << 1 << ' ' << 1 << ' ' << 1 << '\n';
+  ifsh << amrData.ProbSize()[0] + 2 * dir_arr[0] * dx[0] << ' '
+       << amrData.ProbSize()[1] + 2 * dir_arr[1] * dx[1] << ' '
+       << amrData.ProbSize()[2] + 2 * dir_arr[2] * dx[2] << '\n';
+
+  ifsh << 1 << ' ' << 1 << ' ' << 1 << '\n';
 #else
-    Abort("Only 2-D & 3-D supported");
+  Abort("Only 2-D & 3-D supported");
 #endif
 
-    for (int d = 0; d < AMREX_SPACEDIM; ++d)
-    {
-        std::cout << "Loading component " << d << " ... " << std::flush;
+  for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+    std::cout << "Loading component " << d << " ... " << std::flush;
 
-        BoxArray ba(1);
+    BoxArray ba(1);
 
-#if AMREX_SPACEDIM==3
-        //
-        // In 3-D we work on one cell wide Z-planes.
-        // We first do the lo AMREX_SPACEDIM plane.
-        // And then all the other planes in xhi -> xlo order.
-        //
-        // In 2-D we only write a single x-y plane of data per component.
-        //
-        bg[dir] = sm[dir];
+#if AMREX_SPACEDIM == 3
+    //
+    // In 3-D we work on one cell wide Z-planes.
+    // We first do the lo AMREX_SPACEDIM plane.
+    // And then all the other planes in xhi -> xlo order.
+    //
+    // In 2-D we only write a single x-y plane of data per component.
+    //
+    bg[dir] = sm[dir];
 #endif
-        Box bx(sm,bg);
-        ba.set(0,bx);
-        MultiFab TMP(ba,DistributionMapping(ba),1,0);
+    Box bx(sm, bg);
+    ba.set(0, bx);
+    MultiFab TMP(ba, DistributionMapping(ba), 1, 0);
 
-        amrData.FillVar(TMP, amrData.FinestLevel(), names[d], 0);
-        amrData.FlushGrids(amrData.StateNumber(names[d]));
+    amrData.FillVar(TMP, amrData.FinestLevel(), names[d], 0);
+    amrData.FlushGrids(amrData.StateNumber(names[d]));
 
-        Extend(xfab, TMP[0], dm);
-        //
-        // Write current position of data file to header file.
-        //
-        ifsh << ifsd.tellp() << std::endl;
-#if AMREX_SPACEDIM==2
-        //
-        // Write the FAB to the data file after flipping rows in Y direction.
-        //
-        FLIPROWSY(xfab.dataPtr(), ARLIM(xfab.loVect()), ARLIM(xfab.hiVect()));
-        xfab.writeOn(ifsd);
-#elif AMREX_SPACEDIM==3
+    Extend(xfab, TMP[0], dm);
+    //
+    // Write current position of data file to header file.
+    //
+    ifsh << ifsd.tellp() << std::endl;
+#if AMREX_SPACEDIM == 2
+    //
+    // Write the FAB to the data file after flipping rows in Y direction.
+    //
+    FLIPROWSY(xfab.dataPtr(), ARLIM(xfab.loVect()), ARLIM(xfab.hiVect()));
+    xfab.writeOn(ifsd);
+#elif AMREX_SPACEDIM == 3
 
-        xfab.writeOn(ifsd);
+    xfab.writeOn(ifsd);
 
-        std::cout << "xfab min,max: " << xfab.min() << ' ' << xfab.max() << ' ' << bx << '\n';
-        //
-        // Now do all the planes in dirhi -> dirlo order.
-        //
-        for (int i = dm.bigEnd(dir); i >= dm.smallEnd(dir); i--)
-        {
-            sm[dir] = i;
-            bg[dir] = i;
-            Box bx(sm,bg);
-            ba.set(0,bx);
-            MultiFab TMP(ba,DistributionMapping(ba),1,0);
+    std::cout << "xfab min,max: " << xfab.min() << ' ' << xfab.max() << ' '
+              << bx << '\n';
+    //
+    // Now do all the planes in dirhi -> dirlo order.
+    //
+    for (int i = dm.bigEnd(dir); i >= dm.smallEnd(dir); i--) {
+      sm[dir] = i;
+      bg[dir] = i;
+      Box bx(sm, bg);
+      ba.set(0, bx);
+      MultiFab TMP(ba, DistributionMapping(ba), 1, 0);
 
-            amrData.FillVar(TMP, amrData.FinestLevel(), names[d], 0);
-            amrData.FlushGrids(amrData.StateNumber(names[d]));
+      amrData.FillVar(TMP, amrData.FinestLevel(), names[d], 0);
+      amrData.FlushGrids(amrData.StateNumber(names[d]));
 
-            Extend(xfab, TMP[0], dm);
-	    
-            //
-            // Write current position of data file to header file.
-            //
-            ifsh << ifsd.tellp() << std::endl;
-            //
-            // Write the FAB to the data file.
-            //
-            xfab.writeOn(ifsd);
+      Extend(xfab, TMP[0], dm);
 
-            std::cout << "xfab i,min,max: " << i<< ' ' << xfab.min() << ' ' << xfab.max() << ' ' << bx << '\n';
-        }
-#endif
-        std::cout << "done" << std::endl;
+      //
+      // Write current position of data file to header file.
+      //
+      ifsh << ifsd.tellp() << std::endl;
+      //
+      // Write the FAB to the data file.
+      //
+      xfab.writeOn(ifsd);
+
+      std::cout << "xfab i,min,max: " << i << ' ' << xfab.min() << ' '
+                << xfab.max() << ' ' << bx << '\n';
     }
+#endif
+    std::cout << "done" << std::endl;
+  }
 
-    Finalize();
+  Finalize();
 }


### PR DESCRIPTION
## Description

Formatting-only baseline for `sn_tlh_optimal_estimator`, so subsequent feature diffs stay clean and reviewable (and to align this branch's style with `development` ahead of any future merge).

### Changes

- Add the `.clang-format` configuration (copied from `development`; this branch previously had none).
- Run `clang-format` (v18) over all `Src` C++ sources and headers via the canonical command:
  ```
  find Src \( -name "*.cpp" -o -name "*.H" -o -name "*.h" \) -exec clang-format -i {} +
  ```

**No logic is changed** — this is purely whitespace/style. 59 source/header files reformatted, plus the new `.clang-format`. The result is idempotent under a second `clang-format` run.

### Note

This is intended to merge **before** the follow-up PR that ports the `progVar` / `computeMixtureFraction` tools, whose diff then shows only the real code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZaUVgkKjp7dapmSChiNN5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZaUVgkKjp7dapmSChiNN5)_