### PR TITLE
Port refined progVar and add computeMixtureFraction

### DIFF
--- a/Src/ModelSpecificAnalysis/GNUmakefile
+++ b/Src/ModelSpecificAnalysis/GNUmakefile
@@ -30,6 +30,7 @@ TINY_PROFILE = FALSE
 #EBASE=plotYtoX
 #EBASE=testQPDtools
 #EBASE=plotTransportCoeff
+#EBASE=computeMixtureFraction
 EBASE=plotZCelem
 
 CEXE_sources += $(EBASE).cpp

--- a/Src/ModelSpecificAnalysis/computeMixtureFraction.cpp
+++ b/Src/ModelSpecificAnalysis/computeMixtureFraction.cpp
@@ -9,8 +9,6 @@
 #include <AMReX_PlotFileUtil.H>
 #include <PelePhysics.H>
 
-// #include <mechanism.H>
-
 using namespace amrex;
 
 static void
@@ -42,20 +40,19 @@ main(int argc, char* argv[])
       print_usage(argc, argv);
 
     if (pp.contains("verbose"))
-      AmrData::SetVerbose(false);
+      AmrData::SetVerbose(true);
 
     std::string plotFileName;
     pp.get("infile", plotFileName);
     std::string fuelName = "H2";
     pp.query("fuelName", fuelName);
-    // Real s = 8.0; pp.query("stoichRatio",s);
-    // Real Y_O_air = 0.233; pp.query("YO2Air",Y_O_air);
-    // Real S = s/Y_O_air;
-    // const Real Z_st = Y_O_air/(s+Y_O_air);
-    std::string productName = "H2O";
-    pp.query("productName", productName);
-    int clipProgress = 0;
-    pp.query("clipProgress", clipProgress);
+    // Oxidizer stream composition (mass fractions); defaults to air.
+    Real YO2ox = 0.233;
+    pp.query("YO2ox", YO2ox);
+    Real YN2ox = 0.767;
+    pp.query("YN2ox", YN2ox);
+    std::string outsuffix = "_ZC";
+    pp.query("outsuffix", outsuffix);
     Vector<int> is_per(AMREX_SPACEDIM, 1);
     pp.queryarr("is_per", is_per, 0, AMREX_SPACEDIM);
     DataServices::SetBatchMode();
@@ -74,13 +71,9 @@ main(int argc, char* argv[])
     pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
       spec_names);
     auto eos = pele::physics::PhysicsType::eos();
-    const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
-    const std::string spName = "Y(" + fuelName + ")";
-    // const std::string oxName= "Y(O2)";
-    const std::string prodName = "Y(" + productName + ")";
 
     constexpr int nCompIn = NUM_SPECIES;
-    constexpr int nCompOut = 3;
+    constexpr int nCompOut = 1;
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
@@ -90,46 +83,24 @@ main(int argc, char* argv[])
       inNames[i] = "Y(" + spec_names[i] + ")";
     }
     // out
-    constexpr int idZlocal = 0;  // Z out here
-    constexpr int idCFlocal = 1; // CF out here
-    constexpr int idCPlocal = 2; // CP out here
+    constexpr int idZlocal = 0; // Z out here
     outNames[idZlocal] = "Z";
-    outNames[idCFlocal] = "CF";
-    outNames[idCPlocal] = "CP";
 
     Vector<MultiFab> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
     RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
     constexpr int nGrow = 0;
-    Vector<Real> YFminmax = {1e100, -1e100};
-    Vector<Real> YPminmax = {1e100, -1e100};
-    Vector<Box> probDomain = amrData.ProbDomain();
 
-    const int YFcomp = amrData.StateNumber("Y(" + fuelName + ")") -
-                       amrData.StateNumber("Y(" + spec_names[0] + ")");
-    const int YPcomp = amrData.StateNumber("Y(" + productName + ")") -
-                       amrData.StateNumber("Y(" + spec_names[0] + ")");
-
-    for (int lev = 0; lev < Nlev; ++lev) {
-      Real min, max;
-      amrData.MinMax(probDomain[lev], "Y(" + fuelName + ")", lev, min, max);
-      if (YFminmax[0] > min) {
-        YFminmax[0] = min;
-      }
-      if (YFminmax[1] < max) {
-        YFminmax[1] = max;
-      }
-      amrData.MinMax(probDomain[lev], "Y(" + productName + ")", lev, min, max);
-      if (YPminmax[0] > min) {
-        YPminmax[0] = min;
-      }
-      if (YPminmax[1] < max) {
-        YPminmax[1] = max;
-      }
+    // Locate the fuel species in the mechanism ordering that is used to fill
+    // indata (destFillComps[i] = i, inNames[i] = Y(spec_names[i])).
+    int YFcomp = -1;
+    for (int i = 0; i < NUM_SPECIES; ++i) {
+      if (spec_names[i] == fuelName)
+        YFcomp = i;
     }
-    // TODO: add some verb and manual querying
-    pp.queryarr("YFminmax", YFminmax);
-    pp.queryarr("YPminmax", YPminmax);
+    if (YFcomp < 0)
+      amrex::Abort("Fuel species " + fuelName + " not found in mechanism");
+
     Real Zfu = -1.0;
     Real Zox = -1.0;
 
@@ -138,10 +109,10 @@ main(int argc, char* argv[])
       YF[i] = 0.0;
       YO[i] = 0.0;
       if (spec_names[i] == "O2") {
-        YO[i] = 0.233;
+        YO[i] = YO2ox;
       }
       if (spec_names[i] == "N2") {
-        YO[i] = 0.767;
+        YO[i] = YN2ox;
       }
       if (i == YFcomp) {
         YF[i] = 1.0;
@@ -179,32 +150,28 @@ main(int argc, char* argv[])
       Zfu += spec_Bilger_fact[i] * YF[i];
       Zox += spec_Bilger_fact[i] * YO[i];
     }
+    if (Zfu == Zox) {
+      amrex::Abort("Fuel and oxidizer Bilger values are equal; check fuelName "
+                   "and oxidizer composition (Zfu - Zox is zero)");
+    }
     const Real denom_inv = 1.0 / (Zfu - Zox);
-    // amrex::GpuArray<amrex::Real, NUM_SPECIES> fact_Bilger;
-    // for (int n = 0; n < NUM_SPECIES; ++n) {
-    //   fact_Bilger[n] = a_pelelm->spec_Bilger_fact[n];
-    // }
 
     for (int lev = 0; lev < Nlev; ++lev) {
       const BoxArray ba = amrData.boxArray(lev);
-      const Vector<Real>& delta = amrData.DxLevel()[lev];
       const DistributionMapping dm(ba);
       MultiFab indata(ba, dm, nCompIn, nGrow);
       outdata[lev].define(ba, dm, nCompOut, nGrow);
 
       Print() << "Reading data for level " << lev << std::endl;
-      amrData.FillVar(indata, lev, inNames, destFillComps); // Problem
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev], &rb, 0, &(is_per[0]));
+      amrData.FillVar(indata, lev, inNames, destFillComps);
+      geoms[lev] = Geometry(
+        amrData.ProbDomain()[lev], &rb, amrData.CoordSys(), &(is_per[0]));
       Print() << "Data has been read for level " << lev << std::endl;
       auto in_ma = indata.const_arrays();
       auto out_ma = outdata[lev].arrays();
       amrex::ParallelFor(
         outdata[lev],
         [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept {
-          out_ma[box_no](i, j, k, idCFlocal) =
-            1.0 - in_ma[box_no](i, j, k, YFcomp) / YFminmax[1];
-          out_ma[box_no](i, j, k, idCPlocal) =
-            in_ma[box_no](i, j, k, YPcomp) / YPminmax[1];
           Real Zloc = 0.0;
           for (int n = 0; n < NUM_SPECIES; ++n) {
             Zloc += in_ma[box_no](i, j, k, n) * spec_Bilger_fact[n];
@@ -214,9 +181,8 @@ main(int argc, char* argv[])
       Print() << "Derive finished for level " << lev << std::endl;
     }
 
-    std::string outfile(getFileRoot(plotFileName) + "_ZC");
+    std::string outfile(getFileRoot(plotFileName) + outsuffix);
     Print() << "Writing new data to " << outfile << std::endl;
-    const bool verb = false;
     Vector<int> isteps(Nlev, 0);
     Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
     amrex::WriteMultiLevelPlotfile(

--- a/Src/progVar.cpp
+++ b/Src/progVar.cpp
@@ -30,6 +30,8 @@ print_usage(int, char* argv[])
                "pltfile[DEF->_prog]\n";
   std::cerr << "\t     outname=string This is the name of the variable in the "
                "output [DEF->progVar]\n";
+  std::cerr << "\t     printSource=int Set to 0 to skip computing and writing "
+               "the source term I_R(<outname>) [DEF->1]\n";
   exit(1);
 }
 
@@ -69,10 +71,20 @@ main(int argc, char* argv[])
     Real burnt = 1;
     pp.get("burntVal", burnt);
 
+    if (burnt == unburnt) {
+      amrex::Abort(
+        "burntVal must differ from unburntVal (denominator is zero)");
+    }
+
     std::string outsuffix = "_prog";
     pp.get("outsuffix", outsuffix);
     std::string outname = "progVar";
     pp.get("outname", outname);
+
+    // By default the progress-variable source term I_R(<outname>) is written.
+    // Set printSource=0 to output only specSum and the progress variable.
+    int printSource = 1;
+    pp.query("printSource", printSource);
 
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
@@ -112,32 +124,37 @@ main(int argc, char* argv[])
       }
     }
 
-    // Get ids of production rates I_R(<species>) for each species
+    // Get ids of production rates I_R(<species>) for each species (only needed
+    // when the source term is requested)
     Vector<int> idIR(nSpec, -1);
-    for (int j = 0; j < nSpec; ++j) {
-      // Strip "Y(" prefix and ")" suffix if present, e.g. "Y(H2)" -> "H2"
-      std::string specBase = species[j];
-      if (
-        specBase.size() > 2 && specBase.substr(0, 2) == "Y(" &&
-        specBase.back() == ')') {
-        specBase = specBase.substr(2, specBase.size() - 3);
-      }
+    if (printSource) {
+      for (int j = 0; j < nSpec; ++j) {
+        // Strip "Y(" prefix and ")" suffix if present, e.g. "Y(H2)" -> "H2"
+        std::string specBase = species[j];
+        if (
+          specBase.size() > 2 && specBase.substr(0, 2) == "Y(" &&
+          specBase.back() == ')') {
+          specBase = specBase.substr(2, specBase.size() - 3);
+        }
 
-      std::string irName = "I_R(" + specBase + ")";
-      for (int i = 0; i < (int)inNames.size(); ++i) {
-        if (inNames[i] == irName)
-          idIR[j] = i;
-      }
-      if (idIR[j] < 0) {
-        amrex::Abort("Production rate " + irName + " not found in plotfile");
+        std::string irName = "I_R(" + specBase + ")";
+        for (int i = 0; i < (int)inNames.size(); ++i) {
+          if (inNames[i] == irName)
+            idIR[j] = i;
+        }
+        if (idIR[j] < 0) {
+          amrex::Abort("Production rate " + irName + " not found in plotfile");
+        }
       }
     }
 
     Vector<MultiFab> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
     int nGrow = 0;
-    // Output: specSum, progVar, I_R(progVar)
-    Vector<std::string> outNames = {"specSum", outname, "I_R(" + outname + ")"};
+    // Output: specSum, progVar, and optionally I_R(progVar)
+    Vector<std::string> outNames = {"specSum", outname};
+    if (printSource)
+      outNames.push_back("I_R(" + outname + ")");
 
     Vector<int> destFillComps(nCompIn);
     for (int i = 0; i < nCompIn; ++i)
@@ -151,7 +168,7 @@ main(int argc, char* argv[])
       outdata[lev] = MultiFab(ba, dm, outNames.size(), nGrow);
       MultiFab indata(ba, dm, nCompIn, nGrow);
 
-      int coord = 0;
+      int coord = amrData.CoordSys();
       geoms[lev] =
         Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
 
@@ -165,11 +182,15 @@ main(int argc, char* argv[])
         amrex::Gpu::hostToDevice, idY.begin(), idY.end(), d_idY.begin());
       int const* idY_d = d_idY.data();
 
-      // Copy production rate index arrays to device
-      amrex::Gpu::DeviceVector<int> d_idIR(idIR.size());
-      amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, idIR.begin(), idIR.end(), d_idIR.begin());
-      int const* idIR_d = d_idIR.data();
+      // Copy production rate index arrays to device (only when writing source)
+      amrex::Gpu::DeviceVector<int> d_idIR;
+      int const* idIR_d = nullptr;
+      if (printSource) {
+        d_idIR.resize(idIR.size());
+        amrex::Gpu::copy(
+          amrex::Gpu::hostToDevice, idIR.begin(), idIR.end(), d_idIR.begin());
+        idIR_d = d_idIR.data();
+      }
 
       Real denom = burnt - unburnt;
 
@@ -194,11 +215,13 @@ main(int argc, char* argv[])
 
             // Production rate of progress variable:
             // I_R(C) = Sum( I_R(species) ) / (burnt - unburnt)
-            Real irSum = 0.0_rt;
-            for (int s = 0; s < nSpec; ++s) {
-              irSum += in_a(i, j, k, idIR_d[s]);
+            if (printSource) {
+              Real irSum = 0.0_rt;
+              for (int s = 0; s < nSpec; ++s) {
+                irSum += in_a(i, j, k, idIR_d[s]);
+              }
+              out_a(i, j, k, 2) = irSum / denom;
             }
-            out_a(i, j, k, 2) = irSum / denom;
           });
       }
     }


### PR DESCRIPTION
## Description

Ports the finalized `progVar` / `computeMixtureFraction` tools (from the squash-merge of #67 on `development`) onto `sn_tlh_optimal_estimator`.

The clang-format baseline landed separately in #68 (already merged into `sn_tlh_optimal_estimator`), so this PR rebased directly onto the formatted branch and its diff is now purely the real code changes — no formatting noise.

### Changes

- **`progVar.cpp`** — add a `printSource` flag (default `1`) to opt out of computing/writing the source term `I_R(<outname>)`; when disabled the `I_R(<species>)` fields are not required. Includes the review fixes carried on development: abort when `burntVal == unburntVal`, and use `amrData.CoordSys()` instead of a hard-coded coordinate.
- **`plotZC.cpp` → `computeMixtureFraction.cpp`** — the tool now outputs only the Bilger mixture fraction `Z` (the redundant `CF`/`CP` progress variables and the clipping option are removed) and supports a configurable `outsuffix` (default `_ZC`).
- **`ModelSpecificAnalysis/GNUmakefile`** — register `#EBASE=computeMixtureFraction`.

`plotZCelem.cpp` is a separate element-fraction tool and is left untouched.

### Notes

- Documentation is intentionally omitted here: this branch uses the older flat `Docs/source` layout, and the tool docs already live on `development` in the `analysis/` + `modelSpecific/` structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZaUVgkKjp7dapmSChiNN5