### PR TITLE
Add auxiliary variables and n_files options across tools

### DIFF
--- a/Docs/source/analysis/arithmetics.rst
+++ b/Docs/source/analysis/arithmetics.rst
@@ -57,6 +57,13 @@ Parameters
    Coordinate system identifier passed to the output ``Geometry``.
    ``0`` = Cartesian (default).  Other values follow the AMReX convention.
 
+``n_files``
+   Maximum number of binary files used to write the output plotfile data
+   (AMReX ``VisMF::SetNOutFiles``). Lower this to reduce the number of files
+   created for large parallel post-processing runs. AMReX clamps the value to
+   the number of MPI ranks, so a serial run always writes a single data file.
+   Default: the AMReX default.
+
 Output
 ------
 A new AMReX plotfile containing:

--- a/Docs/source/analysis/avgPlotfiles.rst
+++ b/Docs/source/analysis/avgPlotfiles.rst
@@ -19,6 +19,7 @@ Example Input File ``avgPlotfiles.inp``::
     #------------------- IO CONTROL -----------------------------------------------------------
     infiles = plt00000 plt00001 plt00002      # pltfiles to average
     outfile = plt_averaged                   # Name of output file
+    n_files = 64                             # DEF: AMReX default, cap on the number of plotfile data files (VisMF), clamped to the MPI rank count
 
     #------------------- Operation control ----------------------------------------------------
     variables = temp HeatRelease             # DEF: all possible, list of variable names to average

--- a/Docs/source/analysis/ciao2plt.rst
+++ b/Docs/source/analysis/ciao2plt.rst
@@ -51,6 +51,7 @@ Tool Options
    #------------------- IO CONTROL -----------------------------------------------------------
    infile  = SJ_H2_000000.h5                  # Input CIAO HDF5 file (required)
    outfile = plt_SJ_H2_000000                 # DEF: plt_<stem>; output plotfile directory
+   n_files = 64                               # DEF: AMReX default; cap on the number of plotfile data files (VisMF), clamped to the MPI rank count
 
 ``infile`` is the only required argument. ``outfile`` defaults to ``plt_`` followed
 by the input filename stem (extension stripped, directory stripped), e.g.

--- a/Docs/source/analysis/combinePlts.rst
+++ b/Docs/source/analysis/combinePlts.rst
@@ -22,7 +22,8 @@ Example Input File ``combinePlts.inp``::
         #------------------- IO CONTROL -----------------------------------------------------------
         infiles = plt00000 plt00001 plt00002      # pltfiles to combine
         outfile = plt_combined			  # Name of output file
-        
+        n_files = 64                              # DEF: AMReX default, cap on the number of plotfile data files (VisMF), clamped to the MPI rank count
+
         #------------------- Operation control ----------------------------------------------------
         vars = temp HeatRelease       	          # DEF: all possible, list of variables to average COMP or NAME
         finestLevel = 4				  # DEF: -1, gets finest level by defaults, or max level user sets to consider for combine 

--- a/Docs/source/analysis/convert2hdf5.rst
+++ b/Docs/source/analysis/convert2hdf5.rst
@@ -75,6 +75,10 @@ Output
 ######
 The output file ``<infile>_hdf5`` is a multi-level AMReX HDF5 plotfile stored as a single dataset. It contains all variables from the input file across all converted AMR levels, and can be opened with any AMReX-compatible HDF5 reader. Run time is printed to stdout on completion.
 
+.. note::
+
+   HDF5 output is written as a single consolidated file, so the ``n_files`` option used by the plain-plotfile tools does not apply to ``convert2hdf5``.
+
 Dependencies
 ############
 This tool requires an HDF5-enabled AMReX build. ``USE_HDF5 = TRUE`` must be set in ``GNUmakefile`` and a compatible HDF5 installation must be available at ``HDF5_HOME``. ZFP compression additionally requires the ZFP and H5Z-ZFP libraries and ``USE_HDF5_ZFP = TRUE``.

--- a/Docs/source/analysis/curvature.rst
+++ b/Docs/source/analysis/curvature.rst
@@ -92,3 +92,10 @@ Parameters
 
 ``do_velnormal``
    Compute normal velocity.
+
+``n_files``
+   Maximum number of binary files used to write the output plotfile data
+   (AMReX ``VisMF::SetNOutFiles``). Lower this to reduce the number of files
+   created for large parallel post-processing runs. AMReX clamps the value to
+   the number of MPI ranks, so a serial run always writes a single data file.
+   Default: the AMReX default.

--- a/Docs/source/analysis/curvature.rst
+++ b/Docs/source/analysis/curvature.rst
@@ -58,7 +58,7 @@ Parameters
    Finest AMR level to be processed.
 
 ``Aux_Variables``
-   Variable IDs copied unchanged from input to output plotfile.
+   Names of variables copied unchanged from input to output plotfile.
 
 ``progressName``
    Name of the progress variable.

--- a/Docs/source/analysis/diffPlts.rst
+++ b/Docs/source/analysis/diffPlts.rst
@@ -22,6 +22,7 @@ Example Input File ``diffPlts.inp``::
         #------------------- IO CONTROL -----------------------------------------------------------
         infiles = plt00000 plt00000_new                       # Plt files to calculate diff. First file is the reference file (for relative difference)
         outfile = plt00000_diff                               # DEF: infiles[0]+"_diff"; Name of output plt file.
+        n_files = 64                                          # DEF: AMReX default; cap on the number of plotfile data files (VisMF), clamped to the MPI rank count
         finestLevel = 1                                       # DEF: joint finest level of both plt files.
         is_per = 0 0 0                                        # DEF: 0 0 0, Assumed periodicity
         

--- a/Docs/source/analysis/favreAvgPlotfiles.rst
+++ b/Docs/source/analysis/favreAvgPlotfiles.rst
@@ -39,6 +39,7 @@ Tool Options
    #------------------- IO CONTROL -----------------------------------------------------------
    infiles = plt29000 plt30000 plt31000     # List of AMReX plotfiles to average [REQUIRED]
    outfile = plt_averaged                   # DEF: plt_averaged; Output averaged plotfile name
+   n_files = 64                             # DEF: AMReX default; cap on the number of plotfile data files
 
 ``infiles`` specifies the list of input AMReX plotfiles to be averaged. All input
 files must have the same physical domain geometry. Multiple files are provided as
@@ -46,6 +47,11 @@ a space-separated list.
 
 ``outfile`` specifies the name of the output plotfile containing the averaged
 statistics. If not provided, the default is ``plt_averaged``.
+
+``n_files`` caps the number of binary files used to write the output plotfile data
+(AMReX ``VisMF::SetNOutFiles``). Lower it to reduce the number of files created for
+large parallel post-processing runs. AMReX clamps the value to the number of MPI
+ranks, so a serial run always writes a single data file. Default: the AMReX default.
 
 ::
 

--- a/Docs/source/analysis/filterPlt.rst
+++ b/Docs/source/analysis/filterPlt.rst
@@ -30,7 +30,8 @@ Example Input File ``filterPlt.inp``::
         #------------------- IO CONTROL -----------------------------------------------------------
         infiles = plt00000 plt00001 plt00002      # pltfiles to average
         outfile = plt_averaged			  # DEF: plt_averaged, Name of output file
-        
+        n_files = 64                              # DEF: AMReX default, cap on the number of plotfile data files (VisMF), clamped to the MPI rank count
+
         #------------------- Operation control ----------------------------------------------------
         variables = temp HeatRelease              # DEF: all possible, list of variable names to average
         max_filter_level = 4			  # DEF: 1000, max level to consider for filtering

--- a/Docs/source/analysis/flattenAMRFile.rst
+++ b/Docs/source/analysis/flattenAMRFile.rst
@@ -52,6 +52,13 @@ Parameters
 ``verbose``
    Enable additional runtime output.
 
+``n_files``
+   Maximum number of binary files used to write the output plotfile data
+   (AMReX ``VisMF::SetNOutFiles``). Lower this to reduce the number of files
+   created for large parallel post-processing runs. AMReX clamps the value to
+   the number of MPI ranks, so a serial run always writes a single data file.
+   Default: the AMReX default.
+
 
 Output
 ------

--- a/Docs/source/analysis/generateTestPlt.rst
+++ b/Docs/source/analysis/generateTestPlt.rst
@@ -102,8 +102,9 @@ Available criterion types
 
    #------------------- Output ----------------------------------------------------------
    plotfile_name = pltTestFile            # DEF: pltTestFile; Name of the output plot file
+   n_files = 64                           # DEF: AMReX default; cap on the number of plotfile data files
 
-The output is a standard AMReX multilevel plot file (one level when ``amr.max_level = 0``) readable by any tool in the PeleAnalysis suite or visualised with VisIt or ParaView.
+The output is a standard AMReX multilevel plot file (one level when ``amr.max_level = 0``) readable by any tool in the PeleAnalysis suite or visualised with VisIt or ParaView. ``n_files`` caps the number of binary files used for the plotfile data (AMReX ``VisMF::SetNOutFiles``); AMReX clamps it to the number of MPI ranks, so a serial run always writes a single data file.
 ::
 
    #------------------- Fields ----------------------------------------------------------

--- a/Docs/source/analysis/grad.rst
+++ b/Docs/source/analysis/grad.rst
@@ -21,7 +21,8 @@ Example Input File ``grad.inp``::
         #------------------- IO CONTROL -----------------------------------------------------------
         infile = plt00000                         # input pltfile to calcuate grad on
         outfile = plt_grad			  # DEF: <infile>_gt, Name of output file
-        
+        n_files = 64                              # DEF: AMReX default, cap on the number of plotfile data files (VisMF), clamped to the MPI rank count
+
         #------------------- Operation control ----------------------------------------------------
         gradVar = temp		      	          # variable to calculate gradient on
         finestLevel = 4				  # DEF: 1000, max level to consider for gradient 

--- a/Docs/source/analysis/isosurface.rst
+++ b/Docs/source/analysis/isosurface.rst
@@ -29,6 +29,7 @@ Tool Options
    infile = plt00000                          # Plot file for surface construction
    outfile_base = plt00000_surf               # DEF: infile+isoCompName+time+isoval; Base name for output files
    distance.outfile = plt00000_distance       # DEF: distance; Name of output distance file, see build_distance_function.
+   n_files = 64                               # DEF: AMReX default; cap on the number of data files for the distance plotfile (VisMF), clamped to the MPI rank count
    writeSurf = 1                              # [0, 1], DEF: 1; Flag to write surface file.
    surfFormat = MEF                           # [MEF, XDMF], DEF: MEF; MEF (Marcs Element Format) is used by other PeleAnalysis tools.
    surface_is_large = 0                       # [0, 1], DEF: 0; Option for memory-intense surfaces. If the surface is large, write data to disk/clear mem/read up into a single fab.

--- a/Docs/source/analysis/makePlotfile.rst
+++ b/Docs/source/analysis/makePlotfile.rst
@@ -77,6 +77,13 @@ Parameters
 ``verbose`` (or ``v``)
    Enable verbose output.
 
+``n_files``
+   Maximum number of binary files used to write the output plotfile data
+   (AMReX ``VisMF::SetNOutFiles``). Lower this to reduce the number of files
+   created for large parallel post-processing runs. AMReX clamps the value to
+   the number of MPI ranks, so a serial run always writes a single data file.
+   Default: the AMReX default.
+
 Output
 ------
 

--- a/Docs/source/analysis/partStream.rst
+++ b/Docs/source/analysis/partStream.rst
@@ -194,5 +194,9 @@ Output formats
    streamfile = plt00000_stream               # DEF: outfile + "_stream"; Name of writeStreams output file/dir
    writeStreamBin                             # [0, 1], DEF: 0; Write streamlines as binary.
    streamBinfile = plt00000_streamBin         # DEF: outfile + "_streamBin"; Name of writeStreamBin output file/dir
-   
+
+.. note::
+
+   When ``writeParticles`` is enabled, the particle plotfile is written through the AMReX particle I/O layer, whose data-file count is controlled by the native ``particles.particles_nfiles`` option (read directly by AMReX) rather than the ``n_files`` option used by the grid-based tools.
+
 

--- a/Docs/source/analysis/progVar.rst
+++ b/Docs/source/analysis/progVar.rst
@@ -50,6 +50,7 @@ the following structure:
    burntVal      = 1.0
    outsuffix     = _prog
    outname       = progVar
+   Aux_Variables = density temp
 
 
 Parameters
@@ -89,6 +90,11 @@ Parameters
    progress variable, in which case the input plotfile does not need the
    ``I_R(<species>)`` fields. Default: ``1`` (source term written).
 
+``Aux_Variables``
+   Names of variables copied unchanged from the input plotfile to the output
+   plotfile. Useful for carrying through fields (e.g. ``density``, ``temp``)
+   that ``progVar`` does not otherwise write. Default: none.
+
 ``finestLevel``
    Finest AMR level up to which the progress variable is computed.
    Default: plotfile finest level.
@@ -107,6 +113,7 @@ A new AMReX plotfile named ``<infile>outsuffix`` containing:
 - ``<outname>`` — the normalized progress variable :math:`C`
 - ``I_R(<outname>)`` — the progress-variable source term (only when
   ``printSource=1``, the default)
+- any ``Aux_Variables`` requested, copied unchanged from the input
 
 The output inherits the domain geometry, coordinate system, and box
 structure from the input plotfile.

--- a/Docs/source/analysis/qCriterion.rst
+++ b/Docs/source/analysis/qCriterion.rst
@@ -60,6 +60,13 @@ Parameters
    Names of variables copied unchanged from input to output plotfile.
    Default: none.
 
+``n_files``
+   Maximum number of binary files used to write the output plotfile data
+   (AMReX ``VisMF::SetNOutFiles``). Lower this to reduce the number of files
+   created for large parallel post-processing runs. AMReX clamps the value to
+   the number of MPI ranks, so a serial run always writes a single data file.
+   Default: the AMReX default.
+
 
 Output
 ------

--- a/Docs/source/analysis/regridPlt.rst
+++ b/Docs/source/analysis/regridPlt.rst
@@ -21,6 +21,7 @@ Tool Options
    #------------------- IO CONTROL -----------------------------------------------------------
    infile  = plt00500                         # Input AMReX plot file
    outfile = plt00500_rg                      # Output regridded plot file
+   n_files = 64                               # DEF: AMReX default; cap on the number of plotfile data files (VisMF), clamped to the MPI rank count
 
 `infile` and `outfile` are both required. `outfile` receives no default and must always be specified explicitly. The output is a standard multi-level AMReX plot file preserving the geometry, refinement ratios, and simulation time of the input.
 ::

--- a/Docs/source/analysis/subPlt.rst
+++ b/Docs/source/analysis/subPlt.rst
@@ -53,3 +53,7 @@ There are two ways to select which variables to extract. The first is to provide
    verbose                                    # Enable verbose output during data loading
 
 The flag `verbose` enables additional output during execution, reporting which variables are being filled on each AMR level. This is useful for monitoring progress on large plot files or for debugging unexpected output.
+
+.. note::
+
+   ``subPlt`` writes its output through the legacy ``WritePlotFile`` writer, which always writes one data file per MPI rank. The ``n_files`` option available in most other tools therefore does not apply here.

--- a/Docs/source/basics/analysis_util.rst
+++ b/Docs/source/basics/analysis_util.rst
@@ -166,6 +166,8 @@ write_plotfile
 Writes a multi-level set of ``MultiFab`` objects to an AMReX plotfile.
 MPI-safe: adds ``Barrier`` calls before and after the collective write,
 and redistributes boxes when the domain has fewer boxes than MPI ranks.
+Honours the ``n_files`` ParmParse option via :ref:`set_plot_nfiles`, so
+tools using this helper support ``n_files`` automatically.
 
 **Inputs**
 
@@ -210,6 +212,40 @@ None (writes to disk).
    const std::string outfile = "plt_result";
    analysis_util::write_plotfile(outfile, data.mf, {"density", "velocity_x"},
                                  data.geoms, data.time, data.ref_ratios);
+
+
+----
+
+.. _set_plot_nfiles:
+
+set_plot_nfiles
+~~~~~~~~~~~~~~~~
+
+**What it does**
+
+Reads the ``n_files`` ParmParse option (if present) and applies it with
+``VisMF::SetNOutFiles`` so that subsequent plotfile writes use at most
+``n_files`` binary data files. Returns the number of output files now in
+effect. When ``n_files`` is not specified, the current AMReX default is left
+unchanged. AMReX clamps the value to the number of MPI ranks, so a serial run
+always writes a single data file.
+
+``write_plotfile`` calls this automatically; a tool that writes plotfiles
+through some other path can call it directly to honour ``n_files``.
+
+**Inputs**
+
+None (reads the global ParmParse table).
+
+**Output**
+
+The number of output files in effect after the call (``int``).
+
+**Example**
+
+::
+
+   analysis_util::set_plot_nfiles();   // apply n_files before a manual write
 
 
 ----

--- a/Docs/source/modelSpecific/computeMixtureFraction.rst
+++ b/Docs/source/modelSpecific/computeMixtureFraction.rst
@@ -43,9 +43,10 @@ the following structure:
 
 .. code-block:: none
 
-   infile      = plt000000
-   fuelName    = H2
-   finestLevel = 2
+   infile        = plt000000
+   fuelName      = H2
+   finestLevel   = 2
+   Aux_Variables = density temp
 
 
 Parameters
@@ -79,6 +80,11 @@ Parameters
    Periodicity flags in each spatial direction (0: non-periodic, 1: periodic).
    Default: ``1 1 1``.
 
+``Aux_Variables``
+   Names of variables copied unchanged from the input plotfile to the output
+   plotfile, for carrying through fields the tool does not otherwise write.
+   Default: none.
+
 
 Output
 ------
@@ -87,6 +93,7 @@ A new AMReX plotfile named ``<infile>outsuffix`` (by default
 ``<infile>_ZC``) containing:
 
 - ``Z`` — Bilger mixture fraction
+- any ``Aux_Variables`` requested, copied unchanged from the input
 
 The output inherits the domain geometry, coordinate system, and box
 structure from the input plotfile.

--- a/Docs/source/modelSpecific/computeMixtureFraction.rst
+++ b/Docs/source/modelSpecific/computeMixtureFraction.rst
@@ -85,6 +85,13 @@ Parameters
    plotfile, for carrying through fields the tool does not otherwise write.
    Default: none.
 
+``n_files``
+   Maximum number of binary files used to write the output plotfile data
+   (AMReX ``VisMF::SetNOutFiles``). Lower this to reduce the number of files
+   created for large parallel post-processing runs. AMReX clamps the value to
+   the number of MPI ranks, so a serial run always writes a single data file.
+   Default: the AMReX default.
+
 
 Output
 ------

--- a/Docs/source/modelSpecific/plotTYtoLe.rst
+++ b/Docs/source/modelSpecific/plotTYtoLe.rst
@@ -50,6 +50,12 @@ The flag `verbose` enables additional console output from the AMReX data service
    Aux_Variables = density                    # DEF: none; variables copied unchanged to output
 
 `Aux_Variables` lists variables that are copied unchanged from the input to the output plot file, in addition to the computed ``Le(<species>)`` fields. This is useful for carrying through fields (such as ``density`` or ``temp``) that the tool does not otherwise write. The variables must exist in the input plot file. Default: none.
+::
+
+   #------------------- Output control -------------------------------------------------------
+   n_files = 64                               # DEF: AMReX default; cap on the number of plotfile data files
+
+`n_files` caps the number of binary files used to write the output plot file data (AMReX ``VisMF::SetNOutFiles``). Lower it to reduce the number of files created for large parallel post-processing runs. AMReX clamps the value to the number of MPI ranks, so a serial run always writes a single data file. Default: the AMReX default.
 
 Output
 ######

--- a/Docs/source/modelSpecific/plotTYtoLe.rst
+++ b/Docs/source/modelSpecific/plotTYtoLe.rst
@@ -44,6 +44,12 @@ Tool Options
    verbose                                    # Enable verbose output during data loading
 
 The flag `verbose` enables additional console output from the AMReX data services layer during file reading, reporting grid and variable information as each level is loaded. This flag takes no value and is activated simply by its presence in the input file or on the command line.
+::
+
+   #------------------- Auxiliary variables --------------------------------------------------
+   Aux_Variables = density                    # DEF: none; variables copied unchanged to output
+
+`Aux_Variables` lists variables that are copied unchanged from the input to the output plot file, in addition to the computed ``Le(<species>)`` fields. This is useful for carrying through fields (such as ``density`` or ``temp``) that the tool does not otherwise write. The variables must exist in the input plot file. Default: none.
 
 Output
 ######
@@ -56,7 +62,7 @@ The output plot file ``<infile>_Le`` is a standard multi-level AMReX plot file a
    Le(O)
    ...
 
-The variables are ordered according to the species ordering defined in the compiled chemical mechanism (``mechanism.H``). The output inherits the domain geometry, coordinate system, and box structure from the input plot file.
+The variables are ordered according to the species ordering defined in the compiled chemical mechanism (``mechanism.H``), followed by any ``Aux_Variables`` requested. The output inherits the domain geometry, coordinate system, and box structure from the input plot file.
 
 Dependencies
 ############

--- a/Docs/source/modelSpecific/plotTransportCoeff.rst
+++ b/Docs/source/modelSpecific/plotTransportCoeff.rst
@@ -66,6 +66,12 @@ The flag `verbose` enables additional console output from the AMReX data service
    Aux_Variables = density                    # DEF: none; variables copied unchanged to output
 
 `Aux_Variables` lists variables that are copied unchanged from the input to the output plot file, appended after the computed transport coefficients. This is useful for carrying through fields (such as ``density`` or ``temp``) that the tool does not otherwise write. The variables must exist in the input plot file. Default: none.
+::
+
+   #------------------- Output control -------------------------------------------------------
+   n_files = 64                               # DEF: AMReX default; cap on the number of plotfile data files
+
+`n_files` caps the number of binary files used to write the output plot file data (AMReX ``VisMF::SetNOutFiles``). Lower it to reduce the number of files created for large parallel post-processing runs. AMReX clamps the value to the number of MPI ranks, so a serial run always writes a single data file. Default: the AMReX default.
 
 Output
 ######

--- a/Docs/source/modelSpecific/plotTransportCoeff.rst
+++ b/Docs/source/modelSpecific/plotTransportCoeff.rst
@@ -60,6 +60,12 @@ Tool Options
    verbose                                    # Enable verbose output during data loading
 
 The flag `verbose` enables additional console output from the AMReX data services layer during file reading. It takes no value and is activated simply by its presence in the input file or on the command line.
+::
+
+   #------------------- Auxiliary variables --------------------------------------------------
+   Aux_Variables = density                    # DEF: none; variables copied unchanged to output
+
+`Aux_Variables` lists variables that are copied unchanged from the input to the output plot file, appended after the computed transport coefficients. This is useful for carrying through fields (such as ``density`` or ``temp``) that the tool does not otherwise write. The variables must exist in the input plot file. Default: none.
 
 Output
 ######
@@ -78,6 +84,7 @@ The output plot file ``<infile>_D`` is a standard multi-level AMReX plot file an
    mu
    xi
    lambda
+   ...                    [any Aux_Variables, copied unchanged from the input]
 
 The output inherits the domain geometry, coordinate system, and box structure from the input plot file.
 

--- a/Docs/source/modelSpecific/plotXtoY.rst
+++ b/Docs/source/modelSpecific/plotXtoY.rst
@@ -30,6 +30,7 @@ The program is controlled via an input file with the following structure:
 
    infile = plt000000
    finestLevel = 2
+   Aux_Variables = density
 
 
 Parameters
@@ -43,6 +44,11 @@ Parameters
    Finest AMR level processed by the conversion.
    Default: finest level available in the plotfile.
 
+``Aux_Variables``
+   Names of variables copied unchanged from the input plotfile to the output
+   plotfile, for carrying through fields the tool does not otherwise write.
+   Default: none.
+
 
 Output
 ------
@@ -51,6 +57,7 @@ A new AMReX plotfile containing:
 
 - mass fractions ``Y(species)``
 - temperature ``Temp``
+- any ``Aux_Variables`` requested, copied unchanged from the input
 
 The output plotfile name is automatically generated as
 

--- a/Docs/source/modelSpecific/plotXtoY.rst
+++ b/Docs/source/modelSpecific/plotXtoY.rst
@@ -49,6 +49,13 @@ Parameters
    plotfile, for carrying through fields the tool does not otherwise write.
    Default: none.
 
+``n_files``
+   Maximum number of binary files used to write the output plotfile data
+   (AMReX ``VisMF::SetNOutFiles``). Lower this to reduce the number of files
+   created for large parallel post-processing runs. AMReX clamps the value to
+   the number of MPI ranks, so a serial run always writes a single data file.
+   Default: the AMReX default.
+
 
 Output
 ------

--- a/Docs/source/modelSpecific/plotYtoX.rst
+++ b/Docs/source/modelSpecific/plotYtoX.rst
@@ -30,6 +30,7 @@ The program is controlled via an input file with the following structure:
 
    infile = plt000000
    finestLevel = 2
+   Aux_Variables = density
 
 
 Parameters
@@ -43,6 +44,11 @@ Parameters
    Finest AMR level processed by the conversion.
    Default: finest level available in the plotfile.
 
+``Aux_Variables``
+   Names of variables copied unchanged from the input plotfile to the output
+   plotfile, for carrying through fields the tool does not otherwise write.
+   Default: none.
+
 
 Output
 ------
@@ -51,6 +57,7 @@ A new AMReX plotfile containing:
 
 - mole fractions ``X(species)``
 - temperature ``Temp``
+- any ``Aux_Variables`` requested, copied unchanged from the input
 
 The output plotfile name is automatically generated as
 

--- a/Docs/source/modelSpecific/plotYtoX.rst
+++ b/Docs/source/modelSpecific/plotYtoX.rst
@@ -49,6 +49,13 @@ Parameters
    plotfile, for carrying through fields the tool does not otherwise write.
    Default: none.
 
+``n_files``
+   Maximum number of binary files used to write the output plotfile data
+   (AMReX ``VisMF::SetNOutFiles``). Lower this to reduce the number of files
+   created for large parallel post-processing runs. AMReX clamps the value to
+   the number of MPI ranks, so a serial run always writes a single data file.
+   Default: the AMReX default.
+
 
 Output
 ------

--- a/Docs/source/modelSpecific/testTsolve.rst
+++ b/Docs/source/modelSpecific/testTsolve.rst
@@ -42,6 +42,12 @@ Tool Options
    verbose                                    # Enable verbose output during data loading
 
 `verbose` enables additional console output from the AMReX data services layer during file reading. It takes no value and is activated simply by its presence in the input file or on the command line.
+::
+
+   #------------------- Auxiliary variables --------------------------------------------------
+   Aux_Variables = density                    # DEF: none; variables copied unchanged to output
+
+`Aux_Variables` lists variables that are copied unchanged from the input to the output plot file, appended after ``temp`` and ``dtemp``. This is useful for carrying through fields (such as ``density``) that the tool does not otherwise write. The variables must exist in the input plot file. Default: none.
 
 Output
 ######

--- a/Docs/source/modelSpecific/testTsolve.rst
+++ b/Docs/source/modelSpecific/testTsolve.rst
@@ -66,3 +66,7 @@ The output plot file ``<infile>_T`` contains two components at every grid point 
 
 A spatially uniform ``dtemp`` of zero confirms full EOS self-consistency. Large or spatially structured residuals indicate regions where the stored temperature is not consistent with the stored species composition under the compiled EOS.
 
+.. note::
+
+   ``testTsolve`` writes its output through the legacy ``WritePlotFile`` writer, which always writes one data file per MPI rank. The ``n_files`` option available in most other tools therefore does not apply here.
+

--- a/Src/InputsSamples/arithmetics.inp
+++ b/Src/InputsSamples/arithmetics.inp
@@ -3,6 +3,8 @@
 #------------------- IO CONTROL -----------------------------------------------------------
 infile = plt57000                       # input pltfile
 outfile = plt57000_sum                  # DEF: <infile>_<operator>, output pltfile
+n_files = 64                            # DEF: AMReX default; max number of plotfile data
+                                        # files written (VisMF), clamped to the MPI rank count
 
 #------------------- Operation control ----------------------------------------------------
 operator = add                          # arithmetic operator: add, subtract, multiply, divide

--- a/Src/InputsSamples/avgPlotfiles.inp
+++ b/Src/InputsSamples/avgPlotfiles.inp
@@ -3,6 +3,8 @@
 #------------------- IO CONTROL -----------------------------------------------------------
 infiles = plt00000 plt00001 plt00002      # pltfiles to average
 outfile = plt_averaged			  # DEF: plt_averaged, Name of output file
+n_files = 64				  # DEF: AMReX default; max number of plotfile data
+                                          # files written (VisMF), clamped to the MPI rank count
 
 #------------------- Operation control ----------------------------------------------------
 variables = temp HeatRelease              # DEF: all possible, list of variable names to average

--- a/Src/InputsSamples/ciao2plt.inp
+++ b/Src/InputsSamples/ciao2plt.inp
@@ -6,6 +6,8 @@
 #------------------- IO CONTROL -----------------------------------------------------------
 infile  = SJ_H2_000000.h5                  # Input CIAO HDF5 file (required)
 outfile = plt_SJ_H2_000000                 # DEF: plt_<stem>; output plotfile directory
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 
 #------------------- Field selection -------------------------------------------------------
 vars = T RHO OH H2O                        # DEF: all fields; space-separated list of

--- a/Src/InputsSamples/combinePlts.inp
+++ b/Src/InputsSamples/combinePlts.inp
@@ -3,6 +3,8 @@
 #------------------- IO CONTROL -----------------------------------------------------------
 infiles = plt00000 plt00001 plt00002      # pltfiles to combine
 outfile = plt_combined			  # Name of output file
+n_files = 64				  # DEF: AMReX default; max number of plotfile data
+                                          # files written (VisMF), clamped to the MPI rank count
 
 #------------------- Operation control ----------------------------------------------------
 vars = temp HeatRelease       	          # DEF: all possible, list of variables to include in combine

--- a/Src/InputsSamples/curvature.inp
+++ b/Src/InputsSamples/curvature.inp
@@ -7,7 +7,7 @@ finestLevel = 0                            # DEF: finest level of plot file; Set
                                            # finest level to read.
 
 #------------------- Variables ------------------------------------------------------------
-Aux_Variables = 2 3 4                      # DEF: ""; Variable IDs to be taken from input 
+Aux_Variables = density temp               # DEF: ""; Variable names to be taken from input
                                            # file over to output file without change.
 progressName = Y_H2                        # Name of progress variable
 progMin = 0.0                              # Limit progress variable to progMin.

--- a/Src/InputsSamples/curvature.inp
+++ b/Src/InputsSamples/curvature.inp
@@ -3,6 +3,8 @@
 #------------------- IO CONTROL -----------------------------------------------------------
 infile = plt00000                          # Input file (plt file).
 outfile = plt00000_curvature               # DEF: "<infile>_K"; Output file (plt file).
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 finestLevel = 0                            # DEF: finest level of plot file; Sets the 
                                            # finest level to read.
 

--- a/Src/InputsSamples/diffPlts.inp
+++ b/Src/InputsSamples/diffPlts.inp
@@ -3,6 +3,8 @@
 #------------------- IO CONTROL -----------------------------------------------------------
 infiles = plt00000 plt00000_new                       # Plt files to calculate diff. First file is the reference file (for relative difference)
 outfile = plt00000_diff                               # DEF: infiles[0]+"_diff"; Name of output plt file.
+n_files = 64                                          # DEF: AMReX default; max number of plotfile data
+                                                      # files written (VisMF), clamped to the MPI rank count
 finestLevel = 1                                       # DEF: joint finest level of both plt files.
 is_per = 0 0 0                                        # DEF: 0 0 0, Assumed periodicity
 

--- a/Src/InputsSamples/favreAvgPlotfiles.inp
+++ b/Src/InputsSamples/favreAvgPlotfiles.inp
@@ -5,6 +5,8 @@
 #------------------- IO CONTROL -----------------------------------------------------------
 infiles = plt29000 plt30000 plt31000       # List of AMReX plotfiles to average [REQUIRED]
 outfile = plt_favre_averaged               # DEF: plt_averaged; Output averaged plotfile name
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 
 #------------------- VARIABLE SELECTION --------------------------------------------------
 variables = x_velocity y_velocity z_velocity density rhoh temp

--- a/Src/InputsSamples/filterPlt.inp
+++ b/Src/InputsSamples/filterPlt.inp
@@ -2,6 +2,8 @@
 
 #------------------- IO CONTROL -----------------------------------------------------------
 infile = plt00000		          # pltfile to filter
+n_files = 64				  # DEF: AMReX default; max number of plotfile data
+                                          # files written (VisMF), clamped to the MPI rank count
 
 #------------------- Operation control ----------------------------------------------------
 variables = temp HeatRelease              # DEF: all possible, list of variable names to filter

--- a/Src/InputsSamples/flattenAMRFile.inp
+++ b/Src/InputsSamples/flattenAMRFile.inp
@@ -6,3 +6,5 @@ outfile = plt00000_flatten                 # DEF: "<infile>_flatten"; Output fil
                                            # (plt file).
 output_level = 0                           # DEF: 0; AMR level of output file.
 output_max_grid_size = 64                  # DEF: 64; Max grid size of output file.
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count

--- a/Src/InputsSamples/generateTestPlt.inp
+++ b/Src/InputsSamples/generateTestPlt.inp
@@ -11,6 +11,8 @@ geometry.is_periodic = 0 0 0 # Periodic boundary flags per axis
 
 # Output
 plotfile_name = plt_test      # Directory name written by the tool
+n_files = 64                  # DEF: AMReX default; max number of plotfile data
+                              # files written (VisMF), clamped to the MPI rank count
 
 # --- Multilevel AMR (set amr.max_level = 0 or omit for single-level output) ---
 amr.max_level = 2            # Number of refinement levels above the base grid

--- a/Src/InputsSamples/grad.inp
+++ b/Src/InputsSamples/grad.inp
@@ -3,6 +3,8 @@
 #------------------- IO CONTROL -----------------------------------------------------------
 infile = plt00000                         # input pltfile to calcuate grad on
 outfile = plt_grad			  # DEF: <infile>_gt, Name of output file
+n_files = 64				  # DEF: AMReX default; max number of plotfile data
+                                          # files written (VisMF), clamped to the MPI rank count
 
 #------------------- Operation control ----------------------------------------------------
 gradVar = temp		      	          # variable to calculate gradient on

--- a/Src/InputsSamples/isosurface.inp
+++ b/Src/InputsSamples/isosurface.inp
@@ -4,6 +4,8 @@
 #------------------- IO CONTROL -----------------------------------------------------------
 infile = plt00000                          # Plot file for surface construction
 outfile_base = plt00000_surf               # DEF: infile+isoCompName+time+isoval; Base name for output files
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 distance.outfile = plt00000_distance       # DEF: distance; Name of output distance file, see build_distance_function.
 writeSurf = 1                              # [0, 1], DEF: 1; Flag to write surface file.
 surfFormat = MEF                           # [MEF, XDMF], DEF: MEF; MEF (Marcs Element Format) is used by other PeleAnalysis tools.

--- a/Src/InputsSamples/makePlotfile.inp
+++ b/Src/InputsSamples/makePlotfile.inp
@@ -4,6 +4,8 @@
 infile_head = plane                        # Head (prefix) of FAB-files.
 infile_tail = .zslice.0.Level_0.fab        # Tail (suffix) of FAB-files.
 outfile = output                           # Output plt-file name.
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 start = 0                                  # Start index for input file (%06d integer 
                                            # between infile_head and infile_tail).
 end = 10                                   # End index for input file (%06d integer 

--- a/Src/InputsSamples/progVar.inp
+++ b/Src/InputsSamples/progVar.inp
@@ -1,0 +1,18 @@
+# Example input file for progVar
+
+#------------------- IO CONTROL -----------------------------------------------------------
+infile = plt00000                          # Input pltfile to compute the progress variable on
+outsuffix = _prog                          # DEF: _prog; suffix appended to <infile> for output
+outname = progVar                          # DEF: progVar; name of the progress-variable field
+
+#------------------- Operation control ----------------------------------------------------
+speciesNames = Y(H2) Y(H2O)                # Species mass fractions summed into the progress variable
+unburntVal = 0.0                           # DEF: 0; sum of the species in the unburnt mixture
+burntVal = 1.0                             # DEF: 1; sum of the species in the burnt mixture
+printSource = 1                            # DEF: 1; set 0 to skip the I_R(<outname>) source term
+finestLevel = 1000                         # DEF: finest level in file; max level to process
+is_per = 1 1 1                             # DEF: 1 1 1; periodicity flags per dimension
+
+#------------------- Auxiliary variables --------------------------------------------------
+Aux_Variables = density temp               # DEF: ""; variable names copied unchanged from the
+                                           # input to the output pltfile

--- a/Src/InputsSamples/progVar.inp
+++ b/Src/InputsSamples/progVar.inp
@@ -4,6 +4,8 @@
 infile = plt00000                          # Input pltfile to compute the progress variable on
 outsuffix = _prog                          # DEF: _prog; suffix appended to <infile> for output
 outname = progVar                          # DEF: progVar; name of the progress-variable field
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 
 #------------------- Operation control ----------------------------------------------------
 speciesNames = Y(H2) Y(H2O)                # Species mass fractions summed into the progress variable

--- a/Src/InputsSamples/qCriterion.inp
+++ b/Src/InputsSamples/qCriterion.inp
@@ -9,6 +9,8 @@ is_per = 0 1 0                             # DEF: 0 0 0; Periodicity (0: non-per
 sym_dir = 0 0 0                            # DEF: 0 0 0; Summetry (0: non-symmetric, 1: 
                                            # symmetric).
 outfile = plt000000_qCriterion             # DEF: "<infile>_qCriterion"; outfile name.
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 
 #-------------------- Variables -----------------------------------------------------------
 Aux_Variables = Y_H2                       # DEF: "". Auxialiary variables to take from

--- a/Src/InputsSamples/regridPlt.inp
+++ b/Src/InputsSamples/regridPlt.inp
@@ -4,6 +4,8 @@
 #------------------- IO CONTROL -----------------------------------------------------------
 infile  = plt00500                         # Input AMReX plot file
 outfile = plt00500_rg                      # Output regridded plot file
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 
 #------------------- AMR Control ----------------------------------------------------------
 finestLevel = 2                            # DEF: all levels in file; Finest AMR level to regrid

--- a/Src/ModelSpecificAnalysis/InputsSamples/plotTYtoLe.inp
+++ b/Src/ModelSpecificAnalysis/InputsSamples/plotTYtoLe.inp
@@ -3,9 +3,14 @@
 
 #------------------- IO CONTROL -----------------------------------------------------------
 infile = plt00500    # Input AMReX plot file (must contain Y(...), temp, density)
+n_files = 64         # DEF: AMReX default; max number of plotfile data
+                     # files written (VisMF), clamped to the MPI rank count
 
 #------------------- AMR Control ----------------------------------------------------------
 finestLevel = 2      # DEF: finest level in file; Finest AMR level to process
+
+#------------------- Auxiliary variables --------------------------------------------------
+Aux_Variables = density  # DEF: ""; variable names copied unchanged to output
 
 #------------------- Additional Flags -----------------------------------------------------
 # verbose            # Uncomment to enable verbose AMReX data loading output

--- a/Src/ModelSpecificAnalysis/InputsSamples/plotTransportCoeff.inp
+++ b/Src/ModelSpecificAnalysis/InputsSamples/plotTransportCoeff.inp
@@ -3,9 +3,14 @@
 
 #------------------- IO CONTROL -----------------------------------------------------------
 infile = plt00500                          # Input AMReX plot file (must contain Y(...), temp, density)
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 
 #------------------- AMR Control ----------------------------------------------------------
 finestLevel = 2                            # DEF: finest level in file; Finest AMR level to process
+
+#------------------- Auxiliary variables --------------------------------------------------
+Aux_Variables = density                    # DEF: ""; variable names copied unchanged to output
 
 #------------------- Additional Flags -----------------------------------------------------
 # verbose                                  # Uncomment to enable verbose AMReX data loading output

--- a/Src/ModelSpecificAnalysis/InputsSamples/plotXtoY.inp
+++ b/Src/ModelSpecificAnalysis/InputsSamples/plotXtoY.inp
@@ -2,4 +2,9 @@
 
 #------------------- IO CONTROL -----------------------------------------------------------
 infile = plt000000                         # Plt-file name.
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 finestLevel = 2                            # DEF: plotfile finest level.
+
+#------------------- Auxiliary variables --------------------------------------------------
+Aux_Variables = density                    # DEF: ""; variable names copied unchanged to output

--- a/Src/ModelSpecificAnalysis/InputsSamples/plotYtoX.inp
+++ b/Src/ModelSpecificAnalysis/InputsSamples/plotYtoX.inp
@@ -2,4 +2,9 @@
 
 #------------------- IO CONTROL -----------------------------------------------------------
 infile = plt000000                         # Plt-file name.
+n_files = 64                               # DEF: AMReX default; max number of plotfile data
+                                           # files written (VisMF), clamped to the MPI rank count
 finestLevel = 2                            # DEF: plotfile finest level.
+
+#------------------- Auxiliary variables --------------------------------------------------
+Aux_Variables = density                    # DEF: ""; variable names copied unchanged to output

--- a/Src/ModelSpecificAnalysis/computeMixtureFraction.cpp
+++ b/Src/ModelSpecificAnalysis/computeMixtureFraction.cpp
@@ -72,8 +72,17 @@ main(int argc, char* argv[])
       spec_names);
     auto eos = pele::physics::PhysicsType::eos();
 
-    constexpr int nCompIn = NUM_SPECIES;
-    constexpr int nCompOut = 1;
+    // Auxiliary variables: names copied unchanged from input to output plotfile
+    int nAuxVar = pp.countval("Aux_Variables");
+    Vector<std::string> auxVar(nAuxVar);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      pp.get("Aux_Variables", auxVar[ivar], ivar);
+    }
+
+    const int idAuxLocal = NUM_SPECIES; // aux vars start here in input
+    const int idAuxOut = 1;             // aux vars start here in output
+    const int nCompIn = NUM_SPECIES + nAuxVar;
+    const int nCompOut = 1 + nAuxVar;
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
     Vector<int> destFillComps(nCompIn);
@@ -87,6 +96,17 @@ main(int argc, char* argv[])
     outNames[idZlocal] = "Z";
 
     Vector<MultiFab> outdata(Nlev);
+    // Auxiliary variables are read into the input MultiFab and appended,
+    // unchanged, to the output plotfile after the computed field
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      if (amrData.StateNumber(auxVar[ivar]) < 0) {
+        amrex::Abort("Unknown auxiliary variable name: " + auxVar[ivar]);
+      }
+      destFillComps[idAuxLocal + ivar] = idAuxLocal + ivar;
+      inNames[idAuxLocal + ivar] = auxVar[ivar];
+      outNames[idAuxOut + ivar] = auxVar[ivar];
+    }
+
     Vector<Geometry> geoms(Nlev);
     RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
     constexpr int nGrow = 0;
@@ -179,6 +199,13 @@ main(int argc, char* argv[])
           out_ma[box_no](i, j, k, idZlocal) = (Zloc - Zox) * denom_inv;
         });
       Print() << "Derive finished for level " << lev << std::endl;
+
+      // Copy auxiliary variables unchanged from the input to the output
+      for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+        MultiFab::Copy(
+          outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
+      }
+
     }
 
     std::string outfile(getFileRoot(plotFileName) + outsuffix);

--- a/Src/ModelSpecificAnalysis/computeMixtureFraction.cpp
+++ b/Src/ModelSpecificAnalysis/computeMixtureFraction.cpp
@@ -5,6 +5,7 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_DataServices.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
 #include <PelePhysics.H>
@@ -95,7 +96,6 @@ main(int argc, char* argv[])
     constexpr int idZlocal = 0; // Z out here
     outNames[idZlocal] = "Z";
 
-    Vector<MultiFab> outdata(Nlev);
     // Auxiliary variables are read into the input MultiFab and appended,
     // unchanged, to the output plotfile after the computed field
     for (int ivar = 0; ivar < nAuxVar; ++ivar) {
@@ -107,6 +107,7 @@ main(int argc, char* argv[])
       outNames[idAuxOut + ivar] = auxVar[ivar];
     }
 
+    Vector<MultiFab> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
     RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
     constexpr int nGrow = 0;
@@ -198,7 +199,6 @@ main(int argc, char* argv[])
           }
           out_ma[box_no](i, j, k, idZlocal) = (Zloc - Zox) * denom_inv;
         });
-      Print() << "Derive finished for level " << lev << std::endl;
 
       // Copy auxiliary variables unchanged from the input to the output
       for (int ivar = 0; ivar < nAuxVar; ++ivar) {
@@ -206,9 +206,16 @@ main(int argc, char* argv[])
           outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
       }
 
+      Print() << "Derive finished for level " << lev << std::endl;
     }
 
     std::string outfile(getFileRoot(plotFileName) + outsuffix);
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
+
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
     Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});

--- a/Src/ModelSpecificAnalysis/plotTYtoLe.cpp
+++ b/Src/ModelSpecificAnalysis/plotTYtoLe.cpp
@@ -109,7 +109,7 @@ main(int argc, char* argv[])
       Print() << "Cannot find required data in pltfile" << std::endl;
 
     const int idLeout = 0;
-    const int idAuxLocal = NUM_SPECIES + 2;   // aux vars start here in input
+    const int idAuxLocal = NUM_SPECIES + 2;     // aux vars start here in input
     const int idAuxOut = idLeout + NUM_SPECIES; // aux vars start here in output
     const int nCompIn = NUM_SPECIES + 2 + nAuxVar;
     const int nCompOut = idLeout + NUM_SPECIES + nAuxVar;

--- a/Src/ModelSpecificAnalysis/plotTYtoLe.cpp
+++ b/Src/ModelSpecificAnalysis/plotTYtoLe.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_DataServices.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_BCRec.H>
 #include <AMReX_Interpolater.H>
 
@@ -79,7 +80,6 @@ main(int argc, char* argv[])
     pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
-    int idYin = -1;
     // Auxiliary variables: names copied unchanged from input to output plotfile
     int nAuxVar = pp.countval("Aux_Variables");
     Vector<std::string> auxVar(nAuxVar);
@@ -87,6 +87,7 @@ main(int argc, char* argv[])
       pp.get("Aux_Variables", auxVar[ivar], ivar);
     }
 
+    int idYin = -1;
     int idTin = -1;
     int idRin = -1;
     Vector<std::string> spec_names;
@@ -129,7 +130,6 @@ main(int argc, char* argv[])
     inNames[idTlocal] = TName;
     inNames[idRlocal] = RName;
 
-    Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     // Auxiliary variables are read into the input MultiFab and appended,
     // unchanged, to the output plotfile after the computed fields
     for (int ivar = 0; ivar < nAuxVar; ++ivar) {
@@ -141,6 +141,7 @@ main(int argc, char* argv[])
       outNames[idAuxOut + ivar] = auxVar[ivar];
     }
 
+    Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     Vector<std::unique_ptr<MultiFab>> tempdata(Nlev);
     Vector<Geometry> geoms(Nlev);
     amrex::RealBox real_box(
@@ -208,16 +209,22 @@ main(int argc, char* argv[])
           });
       }
 
-      Print() << "Derive finished for level " << lev << std::endl;
       // Copy auxiliary variables unchanged from the input to the output
       for (int ivar = 0; ivar < nAuxVar; ++ivar) {
         MultiFab::Copy(
           *outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
       }
 
+      Print() << "Derive finished for level " << lev << std::endl;
     }
 
     std::string outfile(getFileRoot(plotFileName) + "_Le");
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
+
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
     Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});

--- a/Src/ModelSpecificAnalysis/plotTYtoLe.cpp
+++ b/Src/ModelSpecificAnalysis/plotTYtoLe.cpp
@@ -80,6 +80,13 @@ main(int argc, char* argv[])
     int Nlev = finestLevel + 1;
 
     int idYin = -1;
+    // Auxiliary variables: names copied unchanged from input to output plotfile
+    int nAuxVar = pp.countval("Aux_Variables");
+    Vector<std::string> auxVar(nAuxVar);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      pp.get("Aux_Variables", auxVar[ivar], ivar);
+    }
+
     int idTin = -1;
     int idRin = -1;
     Vector<std::string> spec_names;
@@ -100,9 +107,11 @@ main(int argc, char* argv[])
     if (idYin < 0 || idTin < 0 || idRin < 0)
       Print() << "Cannot find required data in pltfile" << std::endl;
 
-    const int nCompIn = NUM_SPECIES + 2;
     const int idLeout = 0;
-    const int nCompOut = idLeout + NUM_SPECIES;
+    const int idAuxLocal = NUM_SPECIES + 2;   // aux vars start here in input
+    const int idAuxOut = idLeout + NUM_SPECIES; // aux vars start here in output
+    const int nCompIn = NUM_SPECIES + 2 + nAuxVar;
+    const int nCompOut = idLeout + NUM_SPECIES + nAuxVar;
 
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
@@ -121,6 +130,17 @@ main(int argc, char* argv[])
     inNames[idRlocal] = RName;
 
     Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
+    // Auxiliary variables are read into the input MultiFab and appended,
+    // unchanged, to the output plotfile after the computed fields
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      if (amrData.StateNumber(auxVar[ivar]) < 0) {
+        amrex::Abort("Unknown auxiliary variable name: " + auxVar[ivar]);
+      }
+      destFillComps[idAuxLocal + ivar] = idAuxLocal + ivar;
+      inNames[idAuxLocal + ivar] = auxVar[ivar];
+      outNames[idAuxOut + ivar] = auxVar[ivar];
+    }
+
     Vector<std::unique_ptr<MultiFab>> tempdata(Nlev);
     Vector<Geometry> geoms(Nlev);
     amrex::RealBox real_box(
@@ -189,6 +209,12 @@ main(int argc, char* argv[])
       }
 
       Print() << "Derive finished for level " << lev << std::endl;
+      // Copy auxiliary variables unchanged from the input to the output
+      for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+        MultiFab::Copy(
+          *outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
+      }
+
     }
 
     std::string outfile(getFileRoot(plotFileName) + "_Le");

--- a/Src/ModelSpecificAnalysis/plotTransportCoeff.cpp
+++ b/Src/ModelSpecificAnalysis/plotTransportCoeff.cpp
@@ -80,6 +80,13 @@ main(int argc, char* argv[])
     int Nlev = finestLevel + 1;
 
     int idYin = -1;
+    // Auxiliary variables: names copied unchanged from input to output plotfile
+    int nAuxVar = pp.countval("Aux_Variables");
+    Vector<std::string> auxVar(nAuxVar);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      pp.get("Aux_Variables", auxVar[ivar], ivar);
+    }
+
     int idTin = -1;
     int idRin = -1;
     Vector<std::string> spec_names;
@@ -100,13 +107,15 @@ main(int argc, char* argv[])
     if (idYin < 0 || idTin < 0 || idRin < 0)
       Print() << "Cannot find required data in pltfile" << std::endl;
 
-    const int nCompIn = NUM_SPECIES + 2;
     const int idDout = 0;
     const int idChiout = idDout + NUM_SPECIES;
     const int idMuout = idChiout + NUM_SPECIES;
     const int idXiout = idMuout + 1;
     const int idLamout = idXiout + 1;
-    const int nCompOut = idLamout + 1;
+    const int idAuxLocal = NUM_SPECIES + 2; // aux vars start here in input
+    const int idAuxOut = idLamout + 1;      // aux vars start here in output
+    const int nCompIn = NUM_SPECIES + 2 + nAuxVar;
+    const int nCompOut = idLamout + 1 + nAuxVar;
 
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
@@ -129,6 +138,17 @@ main(int argc, char* argv[])
     outNames[idLamout] = "lambda";
 
     Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
+    // Auxiliary variables are read into the input MultiFab and appended,
+    // unchanged, to the output plotfile after the computed fields
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      if (amrData.StateNumber(auxVar[ivar]) < 0) {
+        amrex::Abort("Unknown auxiliary variable name: " + auxVar[ivar]);
+      }
+      destFillComps[idAuxLocal + ivar] = idAuxLocal + ivar;
+      inNames[idAuxLocal + ivar] = auxVar[ivar];
+      outNames[idAuxOut + ivar] = auxVar[ivar];
+    }
+
     Vector<Geometry> geoms(Nlev);
     amrex::RealBox real_box(
       {AMREX_D_DECL(
@@ -179,6 +199,13 @@ main(int argc, char* argv[])
         });
       }
       Print() << "Derive finished for level " << lev << std::endl;
+
+      // Copy auxiliary variables unchanged from the input to the output
+      for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+        MultiFab::Copy(
+          *outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
+      }
+
     }
 
     std::string outfile(getFileRoot(plotFileName) + "_D");

--- a/Src/ModelSpecificAnalysis/plotTransportCoeff.cpp
+++ b/Src/ModelSpecificAnalysis/plotTransportCoeff.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_DataServices.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_BCRec.H>
 #include <AMReX_Interpolater.H>
 
@@ -79,7 +80,6 @@ main(int argc, char* argv[])
     pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
-    int idYin = -1;
     // Auxiliary variables: names copied unchanged from input to output plotfile
     int nAuxVar = pp.countval("Aux_Variables");
     Vector<std::string> auxVar(nAuxVar);
@@ -87,6 +87,7 @@ main(int argc, char* argv[])
       pp.get("Aux_Variables", auxVar[ivar], ivar);
     }
 
+    int idYin = -1;
     int idTin = -1;
     int idRin = -1;
     Vector<std::string> spec_names;
@@ -137,7 +138,6 @@ main(int argc, char* argv[])
     outNames[idXiout] = "xi";
     outNames[idLamout] = "lambda";
 
-    Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     // Auxiliary variables are read into the input MultiFab and appended,
     // unchanged, to the output plotfile after the computed fields
     for (int ivar = 0; ivar < nAuxVar; ++ivar) {
@@ -149,6 +149,7 @@ main(int argc, char* argv[])
       outNames[idAuxOut + ivar] = auxVar[ivar];
     }
 
+    Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
     amrex::RealBox real_box(
       {AMREX_D_DECL(
@@ -198,7 +199,6 @@ main(int argc, char* argv[])
             tbx, Y_a, T_a, rho_a, D_a, chi_a, mu_a, xi_a, lam_a, ltransparm);
         });
       }
-      Print() << "Derive finished for level " << lev << std::endl;
 
       // Copy auxiliary variables unchanged from the input to the output
       for (int ivar = 0; ivar < nAuxVar; ++ivar) {
@@ -206,9 +206,16 @@ main(int argc, char* argv[])
           *outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
       }
 
+      Print() << "Derive finished for level " << lev << std::endl;
     }
 
     std::string outfile(getFileRoot(plotFileName) + "_D");
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
+
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
     Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});

--- a/Src/ModelSpecificAnalysis/plotXtoY.cpp
+++ b/Src/ModelSpecificAnalysis/plotXtoY.cpp
@@ -73,6 +73,13 @@ main(int argc, char* argv[])
     int Nlev = finestLevel + 1;
 
     int idXin = -1;
+    // Auxiliary variables: names copied unchanged from input to output plotfile
+    int nAuxVar = pp.countval("Aux_Variables");
+    Vector<std::string> auxVar(nAuxVar);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      pp.get("Aux_Variables", auxVar[ivar], ivar);
+    }
+
     int idTin = -1;
     Vector<std::string> spec_names;
     pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
@@ -92,8 +99,10 @@ main(int argc, char* argv[])
 
     const int idYout = 0;
     const int idTout = NUM_SPECIES;
-    const int nCompIn = NUM_SPECIES + 1;
-    const int nCompOut = idYout + NUM_SPECIES + 1;
+    const int idAuxLocal = NUM_SPECIES + 1; // aux vars start here in input
+    const int idAuxOut = idTout + 1;        // aux vars start here in output
+    const int nCompIn = NUM_SPECIES + 1 + nAuxVar;
+    const int nCompOut = idYout + NUM_SPECIES + 1 + nAuxVar;
 
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
@@ -110,6 +119,17 @@ main(int argc, char* argv[])
     outNames[idTout] = TName;
 
     Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
+    // Auxiliary variables are read into the input MultiFab and appended,
+    // unchanged, to the output plotfile after the computed fields
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      if (amrData.StateNumber(auxVar[ivar]) < 0) {
+        amrex::Abort("Unknown auxiliary variable name: " + auxVar[ivar]);
+      }
+      destFillComps[idAuxLocal + ivar] = idAuxLocal + ivar;
+      inNames[idAuxLocal + ivar] = auxVar[ivar];
+      outNames[idAuxOut + ivar] = auxVar[ivar];
+    }
+
     Vector<Geometry> geoms(Nlev);
     amrex::RealBox real_box(
       {AMREX_D_DECL(
@@ -156,6 +176,12 @@ main(int argc, char* argv[])
       }
 
       Print() << "Derive finished for level " << lev << std::endl;
+      // Copy auxiliary variables unchanged from the input to the output
+      for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+        MultiFab::Copy(
+          *outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
+      }
+
     }
 
     std::string outfile(getFileRoot(plotFileName) + "_Y");

--- a/Src/ModelSpecificAnalysis/plotXtoY.cpp
+++ b/Src/ModelSpecificAnalysis/plotXtoY.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_DataServices.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_BCRec.H>
 #include <AMReX_Interpolater.H>
 #include <AMReX_GpuLaunch.H>
@@ -72,7 +73,6 @@ main(int argc, char* argv[])
     pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
-    int idXin = -1;
     // Auxiliary variables: names copied unchanged from input to output plotfile
     int nAuxVar = pp.countval("Aux_Variables");
     Vector<std::string> auxVar(nAuxVar);
@@ -80,6 +80,7 @@ main(int argc, char* argv[])
       pp.get("Aux_Variables", auxVar[ivar], ivar);
     }
 
+    int idXin = -1;
     int idTin = -1;
     Vector<std::string> spec_names;
     pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
@@ -118,7 +119,6 @@ main(int argc, char* argv[])
     inNames[idTlocal] = TName;
     outNames[idTout] = TName;
 
-    Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     // Auxiliary variables are read into the input MultiFab and appended,
     // unchanged, to the output plotfile after the computed fields
     for (int ivar = 0; ivar < nAuxVar; ++ivar) {
@@ -130,6 +130,7 @@ main(int argc, char* argv[])
       outNames[idAuxOut + ivar] = auxVar[ivar];
     }
 
+    Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
     amrex::RealBox real_box(
       {AMREX_D_DECL(
@@ -175,16 +176,22 @@ main(int argc, char* argv[])
         });
       }
 
-      Print() << "Derive finished for level " << lev << std::endl;
       // Copy auxiliary variables unchanged from the input to the output
       for (int ivar = 0; ivar < nAuxVar; ++ivar) {
         MultiFab::Copy(
           *outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
       }
 
+      Print() << "Derive finished for level " << lev << std::endl;
     }
 
     std::string outfile(getFileRoot(plotFileName) + "_Y");
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
+
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
     Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});

--- a/Src/ModelSpecificAnalysis/plotYtoX.cpp
+++ b/Src/ModelSpecificAnalysis/plotYtoX.cpp
@@ -73,6 +73,13 @@ main(int argc, char* argv[])
     int Nlev = finestLevel + 1;
 
     int idYin = -1;
+    // Auxiliary variables: names copied unchanged from input to output plotfile
+    int nAuxVar = pp.countval("Aux_Variables");
+    Vector<std::string> auxVar(nAuxVar);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      pp.get("Aux_Variables", auxVar[ivar], ivar);
+    }
+
     int idTin = -1;
     Vector<std::string> spec_names;
     pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
@@ -92,8 +99,10 @@ main(int argc, char* argv[])
 
     const int idXout = 0;
     const int idTout = NUM_SPECIES;
-    const int nCompIn = NUM_SPECIES + 1;
-    const int nCompOut = idXout + NUM_SPECIES + 1;
+    const int idAuxLocal = NUM_SPECIES + 1; // aux vars start here in input
+    const int idAuxOut = idTout + 1;        // aux vars start here in output
+    const int nCompIn = NUM_SPECIES + 1 + nAuxVar;
+    const int nCompOut = idXout + NUM_SPECIES + 1 + nAuxVar;
 
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
@@ -110,6 +119,17 @@ main(int argc, char* argv[])
     outNames[idTout] = TName;
 
     Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
+    // Auxiliary variables are read into the input MultiFab and appended,
+    // unchanged, to the output plotfile after the computed fields
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      if (amrData.StateNumber(auxVar[ivar]) < 0) {
+        amrex::Abort("Unknown auxiliary variable name: " + auxVar[ivar]);
+      }
+      destFillComps[idAuxLocal + ivar] = idAuxLocal + ivar;
+      inNames[idAuxLocal + ivar] = auxVar[ivar];
+      outNames[idAuxOut + ivar] = auxVar[ivar];
+    }
+
     Vector<Geometry> geoms(Nlev);
     amrex::RealBox real_box(
       {AMREX_D_DECL(
@@ -156,6 +176,12 @@ main(int argc, char* argv[])
       }
 
       Print() << "Derive finished for level " << lev << std::endl;
+      // Copy auxiliary variables unchanged from the input to the output
+      for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+        MultiFab::Copy(
+          *outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
+      }
+
     }
 
     std::string outfile(getFileRoot(plotFileName) + "_X");

--- a/Src/ModelSpecificAnalysis/plotYtoX.cpp
+++ b/Src/ModelSpecificAnalysis/plotYtoX.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_DataServices.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_BCRec.H>
 #include <AMReX_Interpolater.H>
 #include <AMReX_GpuLaunch.H>
@@ -72,7 +73,6 @@ main(int argc, char* argv[])
     pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
-    int idYin = -1;
     // Auxiliary variables: names copied unchanged from input to output plotfile
     int nAuxVar = pp.countval("Aux_Variables");
     Vector<std::string> auxVar(nAuxVar);
@@ -80,6 +80,7 @@ main(int argc, char* argv[])
       pp.get("Aux_Variables", auxVar[ivar], ivar);
     }
 
+    int idYin = -1;
     int idTin = -1;
     Vector<std::string> spec_names;
     pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
@@ -118,7 +119,6 @@ main(int argc, char* argv[])
     inNames[idTlocal] = TName;
     outNames[idTout] = TName;
 
-    Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     // Auxiliary variables are read into the input MultiFab and appended,
     // unchanged, to the output plotfile after the computed fields
     for (int ivar = 0; ivar < nAuxVar; ++ivar) {
@@ -130,6 +130,7 @@ main(int argc, char* argv[])
       outNames[idAuxOut + ivar] = auxVar[ivar];
     }
 
+    Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     Vector<Geometry> geoms(Nlev);
     amrex::RealBox real_box(
       {AMREX_D_DECL(
@@ -175,16 +176,22 @@ main(int argc, char* argv[])
         });
       }
 
-      Print() << "Derive finished for level " << lev << std::endl;
       // Copy auxiliary variables unchanged from the input to the output
       for (int ivar = 0; ivar < nAuxVar; ++ivar) {
         MultiFab::Copy(
           *outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
       }
 
+      Print() << "Derive finished for level " << lev << std::endl;
     }
 
     std::string outfile(getFileRoot(plotFileName) + "_X");
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
+
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
     Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});

--- a/Src/ModelSpecificAnalysis/testTsolve.cpp
+++ b/Src/ModelSpecificAnalysis/testTsolve.cpp
@@ -188,8 +188,8 @@ main(int argc, char* argv[])
 
     std::string outfile(getFileRoot(plotFileName) + "_T");
 
-    // NOTE: testTsolve uses the legacy WritePlotFile writer (one file per rank),
-    // so the n_files option does not apply here.
+    // NOTE: testTsolve uses the legacy WritePlotFile writer (one file per
+    // rank), so the n_files option does not apply here.
     Print() << "Writing new data to " << outfile << std::endl;
     const bool verb = false;
     WritePlotFile(GetVecOfPtrs(outdata), amrData, outfile, verb, outNames);

--- a/Src/ModelSpecificAnalysis/testTsolve.cpp
+++ b/Src/ModelSpecificAnalysis/testTsolve.cpp
@@ -83,6 +83,13 @@ main(int argc, char* argv[])
     pp.query("finestLevel", finestLevel);
     int Nlev = finestLevel + 1;
 
+    // Auxiliary variables: names copied unchanged from input to output plotfile
+    int nAuxVar = pp.countval("Aux_Variables");
+    Vector<std::string> auxVar(nAuxVar);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      pp.get("Aux_Variables", auxVar[ivar], ivar);
+    }
+
     int idYin = -1;
     int idTin = -1;
     Vector<std::string> spec_names;
@@ -103,8 +110,10 @@ main(int argc, char* argv[])
 
     const int idTout = 0;
     const int iddTout = idTout + 1;
-    const int nCompOut = iddTout + 1;
-    const int nCompIn = NUM_SPECIES + 1;
+    const int idAuxLocal = NUM_SPECIES + 1; // aux vars start here in input
+    const int idAuxOut = iddTout + 1;       // aux vars start here in output
+    const int nCompOut = iddTout + 1 + nAuxVar;
+    const int nCompIn = NUM_SPECIES + 1 + nAuxVar;
 
     Vector<std::string> outNames(nCompOut);
     Vector<std::string> inNames(nCompIn);
@@ -119,6 +128,17 @@ main(int argc, char* argv[])
     inNames[idTlocal] = TName;
     outNames[idTout] = TName;
     outNames[iddTout] = "d" + TName;
+
+    // Auxiliary variables are read into the input MultiFab and appended,
+    // unchanged, to the output plotfile after the computed fields
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      if (amrData.StateNumber(auxVar[ivar]) < 0) {
+        amrex::Abort("Unknown auxiliary variable name: " + auxVar[ivar]);
+      }
+      destFillComps[idAuxLocal + ivar] = idAuxLocal + ivar;
+      inNames[idAuxLocal + ivar] = auxVar[ivar];
+      outNames[idAuxOut + ivar] = auxVar[ivar];
+    }
 
     Vector<std::unique_ptr<MultiFab>> outdata(Nlev);
     const int nGrow = 0;
@@ -155,6 +175,12 @@ main(int argc, char* argv[])
           Tout(i, j, k) = Tsolve;
           dTout(i, j, k) = Tsolve - Tin(i, j, k);
         });
+      }
+
+      // Copy auxiliary variables unchanged from the input to the output
+      for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+        MultiFab::Copy(
+          *outdata[lev], indata, idAuxLocal + ivar, idAuxOut + ivar, 1, nGrow);
       }
 
       Print() << "Derive finished for level " << lev << std::endl;

--- a/Src/ModelSpecificAnalysis/testTsolve.cpp
+++ b/Src/ModelSpecificAnalysis/testTsolve.cpp
@@ -187,6 +187,9 @@ main(int argc, char* argv[])
     }
 
     std::string outfile(getFileRoot(plotFileName) + "_T");
+
+    // NOTE: testTsolve uses the legacy WritePlotFile writer (one file per rank),
+    // so the n_files option does not apply here.
     Print() << "Writing new data to " << outfile << std::endl;
     const bool verb = false;
     WritePlotFile(GetVecOfPtrs(outdata), amrData, outfile, verb, outNames);

--- a/Src/arithmetics.cpp
+++ b/Src/arithmetics.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_DataServices.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_Reduce.H>
 #include <AMReX_ParallelDescriptor.H>
 
@@ -192,6 +193,11 @@ main(int argc, char* argv[])
           outdata[lev], outdata[lev], inVarB_id, outVar_id, 1, 0);
       }
     }
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
 
     Print() << "Writing new data to " << outfileName << std::endl;
     Vector<int> isteps(Nlev, 0);

--- a/Src/avgPlotfiles.cpp
+++ b/Src/avgPlotfiles.cpp
@@ -1,6 +1,7 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <PltFileManager.H>
 
 using namespace amrex;
@@ -214,6 +215,11 @@ main(int argc, char* argv[])
     }
 
     // Save the final plt file
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
+
     Print() << "Saving final plt file..." << std::endl;
     Vector<int> stepidx(nlevels, 0);
     WriteMultiLevelPlotfile(

--- a/Src/ciao2plt.cpp
+++ b/Src/ciao2plt.cpp
@@ -5,6 +5,7 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_Print.H>
 
 #include "H5Cpp.h"
@@ -364,6 +365,11 @@ main(int argc, char* argv[])
 
     MultiFab data(ba, DistributionMapping(ba), (int)vars.size(), 0);
     read_fields(file, mesh, vars, data);
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
 
     Print() << "Writing " << outfile << "...\n";
     WriteSingleLevelPlotfile(outfile, data, vars, geom, time, 0);

--- a/Src/combinePlts.cpp
+++ b/Src/combinePlts.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_DataServices.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 
 using namespace amrex;
 
@@ -166,6 +167,11 @@ main(int argc, char* argv[])
   }
 
   // write pltfile
+  // Cap the number of plotfile data files via the n_files option (AMReX)
+  int n_files = amrex::VisMF::GetNOutFiles();
+  pp.query("n_files", n_files);
+  amrex::VisMF::SetNOutFiles(n_files);
+
   Vector<int> isteps(Nlev, 0);
   Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
   amrex::WriteMultiLevelPlotfile(

--- a/Src/curvature.cpp
+++ b/Src/curvature.cpp
@@ -896,6 +896,12 @@ main(int argc, char* argv[])
       ostate[lev] = new MultiFab(ba, dmap[lev], nCompOut, 0);
       MultiFab::Copy(*ostate[lev], *state[lev], 0, 0, nCompOut, 0);
     }
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
+
     Print() << "Writing new data to " << outfile << "\n";
     Vector<int> isteps(Nlev, 0);
     Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});

--- a/Src/diffPlts.cpp
+++ b/Src/diffPlts.cpp
@@ -8,6 +8,7 @@
 #include <AMReX_DataServices.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_Utility.H>
 
 using namespace amrex;
@@ -198,6 +199,11 @@ main(int argc, char* argv[])
   }
 
   // write pltfile
+  // Cap the number of plotfile data files via the n_files option (AMReX)
+  int n_files = amrex::VisMF::GetNOutFiles();
+  pp.query("n_files", n_files);
+  amrex::VisMF::SetNOutFiles(n_files);
+
   Vector<int> isteps(Nlev, 0);
   Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
   amrex::WriteMultiLevelPlotfile(

--- a/Src/filterPlt.cpp
+++ b/Src/filterPlt.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_DataServices.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_FillPatchUtil.H>
 #include <Filter.H>
 #include <PltFileManager.H>
@@ -235,6 +236,11 @@ main(int argc, char** argv)
 
   amrex::Print() << "Saving filtered data..." << std::endl;
   std::string outfile(getFileRoot(infile) + "_filtered");
+
+  // Cap the number of plotfile data files via the n_files option (AMReX)
+  int n_files = amrex::VisMF::GetNOutFiles();
+  pp.query("n_files", n_files);
+  amrex::VisMF::SetNOutFiles(n_files);
 
   write_plotfile(
     outfile, Nlev, amrex::GetVecOfConstPtrs(outdata), variableNames,

--- a/Src/flattenAMRFile.cpp
+++ b/Src/flattenAMRFile.cpp
@@ -1,6 +1,7 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <PltFileManager.H>
 
 using namespace amrex;
@@ -97,6 +98,11 @@ main(int argc, char* argv[])
     if (verbose) {
       Print() << " Writting data \n";
     }
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
+
     WriteSingleLevelPlotfile(
       outfile, output, plt_vars, geom, pltData.getTime(), 0);
   }

--- a/Src/generateTestPlt.cpp
+++ b/Src/generateTestPlt.cpp
@@ -2,6 +2,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_TagBox.H>
 #include <AMReX_Cluster.H>
 #include <algorithm>
@@ -1003,6 +1004,11 @@ main(int argc, char* argv[])
     // Write multilevel plot file
     std::string plotfile_name = "pltTestFile";
     pp.query("plotfile_name", plotfile_name);
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
 
     Vector<int> isteps(Nlev, 0);
     Vector<IntVect> refRatios(Nlev - 1);

--- a/Src/grad.cpp
+++ b/Src/grad.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_DataServices.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_MLMG.H>
 #include <AMReX_MLPoisson.H>
 #include <AMReX_MLABecLaplacian.H>
@@ -252,6 +253,11 @@ main(int argc, char* argv[])
     nnames[idGr + AMREX_SPACEDIM] = "||grad" + gradVar + "||";
     std::string outfile(getFileRoot(infile) + "_gt");
     pp.query("outfile", outfile);
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
 
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);

--- a/Src/isosurface.cpp
+++ b/Src/isosurface.cpp
@@ -9,6 +9,7 @@
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_FillPatchUtil.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include "makelevelset3.h"
 
 using namespace amrex;
@@ -1739,6 +1740,11 @@ main(int argc, char* argv[])
           refRatio[lev] = IntVect(AMREX_D_DECL(ir, ir, ir));
         }
       }
+      // Cap the number of plotfile data files via the n_files option (AMReX)
+      int n_files = amrex::VisMF::GetNOutFiles();
+      pp.query("n_files", n_files);
+      amrex::VisMF::SetNOutFiles(n_files);
+
       WriteMultiLevelPlotfile(
         outfile, Nlev, ptrs, {"distance"}, geoms, time, levelSteps, refRatio);
       distance.clear();

--- a/Src/makePlotfile.cpp
+++ b/Src/makePlotfile.cpp
@@ -5,6 +5,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_DataServices.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 
 using namespace amrex;
 
@@ -279,6 +280,11 @@ main(int argc, char* argv[])
   if (verbose) {
     Print() << "*** writing plotfile " << std::endl;
   }
+  // Cap the number of plotfile data files via the n_files option (AMReX)
+  int n_files = amrex::VisMF::GetNOutFiles();
+  pp.query("n_files", n_files);
+  amrex::VisMF::SetNOutFiles(n_files);
+
   int levelSteps;
   WriteSingleLevelPlotfile(outfile, *mf, names, geoms, time, levelSteps);
   amrex::Finalize();

--- a/Src/progVar.cpp
+++ b/Src/progVar.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_DataServices.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 
 using namespace amrex;
 
@@ -86,7 +87,6 @@ main(int argc, char* argv[])
     int printSource = 1;
     pp.query("printSource", printSource);
 
-    DataServices::SetBatchMode();
     // Auxiliary variables: names of variables copied unchanged from the input
     // plotfile to the output plotfile (see Aux_Variables in the documentation).
     int nAuxVar = pp.countval("Aux_Variables");
@@ -95,6 +95,7 @@ main(int argc, char* argv[])
       pp.get("Aux_Variables", auxVar[ivar], ivar);
     }
 
+    DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
@@ -120,7 +121,6 @@ main(int argc, char* argv[])
     int nCompIn = amrData.NComp();
     Vector<std::string> inNames = amrData.PlotVarNames();
 
-    // Get ids of relevant species (mass fractions)
     // Resolve the component index of each auxiliary variable in the input file
     Vector<int> auxIdx(nAuxVar, -1);
     for (int ivar = 0; ivar < nAuxVar; ++ivar) {
@@ -130,6 +130,7 @@ main(int argc, char* argv[])
       }
     }
 
+    // Get ids of relevant species (mass fractions)
     Vector<int> idY(nSpec, -1);
     for (int j = 0; j < nSpec; ++j) {
       for (int i = 0; i < (int)inNames.size(); ++i) {
@@ -173,13 +174,13 @@ main(int argc, char* argv[])
     if (printSource)
       outNames.push_back("I_R(" + outname + ")");
 
-    Vector<int> destFillComps(nCompIn);
     // Auxiliary variables are appended, unchanged, after the computed fields
     const int nBaseOut = outNames.size();
     for (int ivar = 0; ivar < nAuxVar; ++ivar) {
       outNames.push_back(auxVar[ivar]);
     }
 
+    Vector<int> destFillComps(nCompIn);
     for (int i = 0; i < nCompIn; ++i)
       destFillComps[i] = i;
 
@@ -247,15 +248,21 @@ main(int argc, char* argv[])
             }
           });
       }
-    }
 
       // Copy auxiliary variables unchanged from the input to the output
       for (int ivar = 0; ivar < nAuxVar; ++ivar) {
         MultiFab::Copy(
           outdata[lev], indata, auxIdx[ivar], nBaseOut + ivar, 1, nGrow);
       }
+    }
 
     std::string outfile(getFileRoot(plotFileName) + outsuffix);
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
+
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
     Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});

--- a/Src/progVar.cpp
+++ b/Src/progVar.cpp
@@ -87,6 +87,14 @@ main(int argc, char* argv[])
     pp.query("printSource", printSource);
 
     DataServices::SetBatchMode();
+    // Auxiliary variables: names of variables copied unchanged from the input
+    // plotfile to the output plotfile (see Aux_Variables in the documentation).
+    int nAuxVar = pp.countval("Aux_Variables");
+    Vector<std::string> auxVar(nAuxVar);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      pp.get("Aux_Variables", auxVar[ivar], ivar);
+    }
+
     Amrvis::FileType fileType(Amrvis::NEWPLT);
 
     DataServices dataServices(plotFileName, fileType);
@@ -113,6 +121,15 @@ main(int argc, char* argv[])
     Vector<std::string> inNames = amrData.PlotVarNames();
 
     // Get ids of relevant species (mass fractions)
+    // Resolve the component index of each auxiliary variable in the input file
+    Vector<int> auxIdx(nAuxVar, -1);
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      auxIdx[ivar] = amrData.StateNumber(auxVar[ivar]);
+      if (auxIdx[ivar] < 0) {
+        amrex::Abort("Unknown auxiliary variable name: " + auxVar[ivar]);
+      }
+    }
+
     Vector<int> idY(nSpec, -1);
     for (int j = 0; j < nSpec; ++j) {
       for (int i = 0; i < (int)inNames.size(); ++i) {
@@ -157,6 +174,12 @@ main(int argc, char* argv[])
       outNames.push_back("I_R(" + outname + ")");
 
     Vector<int> destFillComps(nCompIn);
+    // Auxiliary variables are appended, unchanged, after the computed fields
+    const int nBaseOut = outNames.size();
+    for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+      outNames.push_back(auxVar[ivar]);
+    }
+
     for (int i = 0; i < nCompIn; ++i)
       destFillComps[i] = i;
 
@@ -225,6 +248,12 @@ main(int argc, char* argv[])
           });
       }
     }
+
+      // Copy auxiliary variables unchanged from the input to the output
+      for (int ivar = 0; ivar < nAuxVar; ++ivar) {
+        MultiFab::Copy(
+          outdata[lev], indata, auxIdx[ivar], nBaseOut + ivar, 1, nGrow);
+      }
 
     std::string outfile(getFileRoot(plotFileName) + outsuffix);
     Print() << "Writing new data to " << outfile << std::endl;

--- a/Src/qCriterion.cpp
+++ b/Src/qCriterion.cpp
@@ -5,6 +5,7 @@
 #include <AMReX_DataServices.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 #include <AMReX_MLMG.H>
 #include <AMReX_MLPoisson.H>
 #include <AMReX_MLABecLaplacian.H>
@@ -430,6 +431,11 @@ main(int argc, char* argv[])
 
     std::string outfile(getFileRoot(infile) + "_qCriterion");
     pp.query("outfile", outfile);
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
 
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);

--- a/Src/regridPlt.cpp
+++ b/Src/regridPlt.cpp
@@ -5,6 +5,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_DataServices.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 
 using namespace amrex;
 
@@ -148,6 +149,11 @@ main(int argc, char* argv[])
       }
       dat[lev] = fileData[lev];
     }
+
+    // Cap the number of plotfile data files via the n_files option (AMReX)
+    int n_files = amrex::VisMF::GetNOutFiles();
+    pp.query("n_files", n_files);
+    amrex::VisMF::SetNOutFiles(n_files);
 
     WriteMultiLevelPlotfile(
       outfile, Nlev, dat, names, geoms, amrData.Time(), levelSteps, refRatio);

--- a/Src/subPlt.cpp
+++ b/Src/subPlt.cpp
@@ -153,6 +153,8 @@ main(int argc, char* argv[])
     }
 
     // Write out the subregion pltfile
+    // NOTE: subPlt uses the legacy WritePlotFile writer (one file per rank), so
+    // the n_files option does not apply here.
     WritePlotFile(data_sub, subboxes, amrData, outfile, verbose, names);
   }
   Finalize();

--- a/Tools/Util/analysis_util.H
+++ b/Tools/Util/analysis_util.H
@@ -60,6 +60,13 @@ int find_var_index(
 
 // --- I/O tools ---
 
+// Read the `n_files` ParmParse option (if present) and apply it to AMReX so
+// that subsequent plotfile writes use at most `n_files` data files
+// (VisMF::SetNOutFiles). Useful to limit file counts for large post-processing
+// campaigns. Returns the number of output files now in effect. When `n_files`
+// is not specified, the current AMReX default is left unchanged.
+int set_plot_nfiles();
+
 struct PlotfileData
 {
   amrex::Vector<amrex::MultiFab> mf;

--- a/Tools/Util/analysis_util_io.cpp
+++ b/Tools/Util/analysis_util_io.cpp
@@ -2,13 +2,25 @@
 
 #include <AMReX_DataServices.H>
 #include <AMReX_ParallelDescriptor.H>
+#include <AMReX_ParmParse.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_VisMF.H>
 
 #include <cmath>
 
 using namespace amrex;
 
 namespace analysis_util {
+
+int
+set_plot_nfiles()
+{
+  int n_files = VisMF::GetNOutFiles();
+  ParmParse pp;
+  pp.query("n_files", n_files);
+  VisMF::SetNOutFiles(n_files);
+  return VisMF::GetNOutFiles();
+}
 
 // Returns a BoxArray with at least nprocs boxes by applying maxSize so that
 // WriteMultiLevelPlotfile and AmrData::FillVar do not deadlock in MPI mode
@@ -109,6 +121,9 @@ write_plotfile(
   // Synchronize all ranks before the collective write to avoid deadlock
   // when some ranks arrive later (e.g. after a preceding read_plotfile).
   ParallelDescriptor::Barrier();
+
+  // Honour the `n_files` ParmParse option to cap the number of output files.
+  set_plot_nfiles();
 
   const int n_lev = static_cast<int>(mf.size());
   Vector<int> isteps(n_lev, 0);


### PR DESCRIPTION
## Summary

Adds two cross-cutting features to the PeleAnalysis tools:

1. **Auxiliary variables (`Aux_Variables`)** — carry arbitrary variables from the input plotfile straight through to the output plotfile, unchanged. Extends the existing `Aux_Variables` mechanism (already in `qCriterion`, `grad`, `curvature`, `stream2plt`) to the other derived-output tools that previously dropped the input variables.
2. **`n_files` option** — cap the number of binary data files written for a plotfile (AMReX `VisMF::SetNOutFiles`), to limit file counts for large parallel post-processing campaigns.

### Auxiliary variables
`Aux_Variables = <names...>` lists variables read from the input plotfile and appended, unchanged, after each tool's computed fields; the tool aborts if a requested variable is missing. Added to `progVar` and the model-specific derived tools `plotXtoY`, `plotYtoX`, `plotTYtoLe`, `plotTransportCoeff`, `computeMixtureFraction`, `testTsolve`.

Not added where it is redundant (tools that already pass through all/selected input variables: `arithmetics`, `filterPlt`, `subPlt`, `regridPlt`, `flattenAMRFile`, the averaging/diff tools) or where there is no single-plotfile-in / plotfile-out.

Also fixes the `curvature` docs/sample, which incorrectly described `Aux_Variables` as variable *IDs* — the tool resolves them by *name*.

### n_files
`n_files = <N>` calls `VisMF::SetNOutFiles(N)` before the write. AMReX clamps the value to the number of MPI ranks, so a **serial run always writes a single data file**; the effect is observable only under MPI.

- Shared helper `analysis_util::set_plot_nfiles()` reads the option and is called from `analysis_util::write_plotfile` (covers `template`, `favreAvgPlotfiles`).
- All other cell-plotfile writers apply it inline: `arithmetics`, `avgPlotfiles`, `ciao2plt`, `combinePlts`, `curvature`, `diffPlts`, `filterPlt`, `flattenAMRFile`, `generateTestPlt`, `grad`, `isosurface` (distance plotfile), `makePlotfile`, `progVar`, `qCriterion`, `regridPlt`, `plotXtoY`, `plotYtoX`, `plotTYtoLe`, `plotTransportCoeff`, `computeMixtureFraction`.
- Documented (not silently faked) where the standard mechanism does not apply: `subPlt`/`testTsolve` (legacy one-file-per-rank writer), `partStream` (particle I/O uses `particles.particles_nfiles`), `convert2hdf5` (single HDF5 file).

### Verification
Built against AMReX + PelePhysics (DIM=3, gnu, serial) and exercised end-to-end with `generateTestPlt`:
- `generateTestPlt`, `grad`, `progVar`, `qCriterion`, `curvature`, `arithmetics`, `avgPlotfiles`, `combinePlts`, `diffPlts`, `filterPlt`, `flattenAMRFile`, `makePlotfile`, `regridPlt`, `subPlt`, `isosurface`, `template`, `favreAvgPlotfiles` all build cleanly; all six model-specific tools compile (full link needs a SUNDIALS build unavailable here).
- Ran `grad`, `qCriterion`, `progVar`, `template` with `Aux_Variables` and `n_files`; confirmed the output variable list and, via the plotfile FAB min/max, that aux data is copied through unchanged (constant `density=1.15` and a sine `temp` field carry through exactly).
- `clang-format` 18 clean on all changed `Src` files.

### Scope note
The `Aux_Variables` rollout (which tools) and `n_files` (all plotfile writers) follow the existing conventions; happy to broaden or narrow if preferred.

=========== Fill your description above and fill the checklist below ===========

The steps outlined in CONTRIBUTING.md were checked. This includes:

**General**
- [x] C++ and Python code formatted (clang-format 18, no Python changes)
- [x] Updated the documentation

**For new tools**
- [ ] Added an example input file with short descriptions for all input options — N/A (no new tools; added a `progVar.inp` sample and `Aux_Variables`/`n_files` lines to existing samples)
- [ ] Added a documentation page for the tool similar to existing pages — N/A (no new tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0141iEKsrnqLUxP8wVm3YWYS)_